### PR TITLE
Refactoring mem.h

### DIFF
--- a/Source/Common/pch_common.h
+++ b/Source/Common/pch_common.h
@@ -25,20 +25,18 @@
 #endif
 
 // STL includes
-#include <string>
-#include <regex>
-#include <chrono>
-#include <map>
-#include <queue>
-#include <vector>
-#include <memory>
-#include <stdint.h>
-#include <thread>
-#include <mutex>
 #include <atomic>
+#include <cassert>
+#include <chrono>
 #include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <string>
+#include <thread>
 #include <unordered_map>
-#include <assert.h>
+#include <vector>
 
 #if UWP_API
 #include <collection.h>
@@ -64,16 +62,8 @@
 
 #ifdef _WIN32
 typedef wchar_t char_t;
-typedef std::wstring string_t;
-typedef std::wstringstream stringstream_t;
-typedef std::wregex regex_t;
-typedef std::wsmatch smatch_t;
 #else
 typedef char char_t;
-typedef std::string string_t;
-typedef std::stringstream stringstream_t;
-typedef std::regex regex_t;
-typedef std::smatch smatch_t;
 #endif
 
 #if _MSC_VER <= 1800

--- a/Source/Common/singleton.h
+++ b/Source/Common/singleton.h
@@ -15,9 +15,9 @@ struct http_singleton
     std::mutex m_singletonLock;
 
     std::mutex m_asyncLock;
-    http_internal_queue(std::shared_ptr<HC_ASYNC_INFO>) m_asyncPendingQueue;
-    http_internal_vector(std::shared_ptr<HC_ASYNC_INFO>) m_asyncProcessingQueue;
-    http_internal_queue(std::shared_ptr<HC_ASYNC_INFO>) m_asyncCompleteQueue;
+    http_internal_queue<std::shared_ptr<HC_ASYNC_INFO>> m_asyncPendingQueue;
+    http_internal_vector<std::shared_ptr<HC_ASYNC_INFO>> m_asyncProcessingQueue;
+    http_internal_queue<std::shared_ptr<HC_ASYNC_INFO>> m_asyncCompleteQueue;
 
     std::unique_ptr<http_thread_pool> m_threadPool;
 
@@ -29,7 +29,7 @@ struct http_singleton
     void _Raise_logging_event(_In_ xbox_services_diagnostics_trace_level level, _In_ const std::string& category, _In_ const std::string& message);
 
     std::mutex m_loggingWriteLock;
-    std::unordered_map<function_context, std::function<void(xbox_services_diagnostics_trace_level, const std::string&, const std::string&)>> m_loggingHandlers;
+    http_internal_unordered_map<function_context, std::function<void(xbox_services_diagnostics_trace_level, const std::string&, const std::string&)>> m_loggingHandlers;
     function_context m_loggingHandlersCounter;
 
     HC_HTTP_CALL_PERFORM_FUNC m_performFunc;

--- a/Source/HTTP/httpcall.h
+++ b/Source/HTTP/httpcall.h
@@ -20,12 +20,12 @@ struct HC_CALL
     http_internal_string method;
     http_internal_string url;
     http_internal_string requestBodyString;
-    http_internal_map(http_internal_string, http_internal_string) requestHeaders;
+    http_internal_map<http_internal_string, http_internal_string> requestHeaders;
     bool retryAllowed;
     uint32_t timeoutInSeconds;
 
     http_internal_string responseString;
-    http_internal_map(http_internal_string, http_internal_string) responseHeaders;
+    http_internal_map<http_internal_string, http_internal_string> responseHeaders;
     uint32_t statusCode;
     uint32_t errorCode;
     http_internal_string errorMessage;


### PR DESCRIPTION
- Cut down http_stl_allocator to the C++11 minimal allocator interface
- Replaced the http_internal_* container macros with template aliases
- Replaced direct uses of stl containers with the http_interal_* version in a couple of places
- Slight cleanup of pch.h