### PR TITLE
Add support for 4-byte wchar_t

### DIFF
--- a/Samples/CustomHttpImplWithCurl/PerformWithCurl.cpp
+++ b/Samples/CustomHttpImplWithCurl/PerformWithCurl.cpp
@@ -41,7 +41,7 @@ std::string to_utf8string(const std::wstring &value)
     return conversion.to_bytes(value);
 }
 
-std::wstring to_utf16string(const std::string &value)
+std::wstring to_wstring(const std::string &value)
 {
     std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> conversion;
     return conversion.from_bytes(value);
@@ -83,7 +83,7 @@ void HC_CALLING_CONV PerformCallWithCurl(
         char *ct;
         res = curl_easy_getinfo(curl, CURLINFO_CONTENT_TYPE, &ct);
         std::string responseStr = chunk.memory;
-        std::wstring wstr = to_utf16string(responseStr);
+        std::wstring wstr = to_wstring(responseStr);
         HCHttpCallResponseSetResponseString(call, wstr.c_str());
     }
     HCHttpCallResponseSetErrorCode(call, res);

--- a/Source/Common/utils.cpp
+++ b/Source/Common/utils.cpp
@@ -5,26 +5,64 @@
 
 NAMESPACE_XBOX_HTTP_CLIENT_BEGIN
 
+namespace details
+{
+    template <size_t charsize>
+    struct widestring
+    {
+    };
+
+    template <>
+    struct widestring<2>
+    {
+        static std::wstring to_wstring(const std::string& input)
+        {
+            std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> utfConverter;
+            return utfConverter.from_bytes(input);
+        }
+
+        static std::string to_utf8string(const std::wstring& input)
+        {
+            std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> utfConverter;
+            return utfConverter.to_bytes(input);
+        }
+    };
+
+    template <>
+    struct widestring<4>
+    {
+        static std::wstring to_wstring(const std::string& input)
+        {
+            std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> utfConverter;
+            return utfConverter.from_bytes(input);
+        }
+
+        static std::string to_utf8string(const std::wstring& input)
+        {
+            std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> utfConverter;
+            return utfConverter.to_bytes(input);
+        }
+    };
+}
+
 std::string to_utf8string(std::string value) 
-{ 
-    return value; 
+{
+    return value;
 }
 
 std::string to_utf8string(const std::wstring &value) 
-{ 
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> conversion;
-    return conversion.to_bytes(value);
+{
+    return details::widestring<sizeof(wchar_t)>::to_utf8string(value);
 }
 
-std::wstring to_utf16string(const std::string &value)
-{ 
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> conversion;
-    return conversion.from_bytes(value);
-} 
+std::wstring to_wstring(std::wstring value)
+{
+    return value;
+}
 
-std::wstring to_utf16string(std::wstring value) 
-{ 
-    return value; 
+std::wstring to_wstring(const std::string &value)
+{
+    return details::widestring<sizeof(wchar_t)>::to_wstring(value);
 }
 
 NAMESPACE_XBOX_HTTP_CLIENT_END

--- a/Source/Common/utils.h
+++ b/Source/Common/utils.h
@@ -9,8 +9,8 @@ std::string to_utf8string(std::string value);
 
 std::string to_utf8string(const std::wstring &value);
 
-std::wstring to_utf16string(const std::string &value);
+std::wstring to_wstring(const std::string &value);
 
-std::wstring to_utf16string(std::wstring value);
+std::wstring to_wstring(std::wstring value);
 
 NAMESPACE_XBOX_HTTP_CLIENT_END

--- a/Tests/UnitTests/Tests/GlobalTests.cpp
+++ b/Tests/UnitTests/Tests/GlobalTests.cpp
@@ -27,9 +27,9 @@ public:
         VERIFY_ARE_EQUAL_STR(_T("1.0.0.0"), ver);
 
 #pragma warning(disable: 4800)
-        std::wstring test1 = to_utf16string(L"test");
+        std::wstring test1 = to_wstring(L"test");
         VERIFY_ARE_EQUAL_STR(L"test", test1.c_str());
-        std::wstring test2 = to_utf16string("test");
+        std::wstring test2 = to_wstring("test");
         VERIFY_ARE_EQUAL_STR(L"test", test2.c_str());
         std::string test3 = to_utf8string(L"test");
         VERIFY_ARE_EQUAL_STR("test", test3.c_str());


### PR DESCRIPTION
Some of our target platforms use four bytes for wchar_t, whereas others
use two. This change adds a class that is templated on sizeof(wchar_t)
in order to pick the correct conversion based on the size; to/from UTF-16
for cases where wchar_t is two bytes, and to/from UCS-4/UTF-32 for cases
where wchar_t is four bytes.

Note: This change makes the name to_utf16string problematic, so it has
been renamed to to_widestring. This does not feel ideal, as it doesn't
line up with the to_utf8string name, but renaming that to to_string felt
odd. A previous project I worked on used to_utf8string and from_utf8string.
I like those names, but it would only make sense to use them if we removed
the overload that takes a std::wstring as its parameter.