### PR TITLE
Fixing build if task.h is #included first

### DIFF
--- a/Include/httpClient/task.h
+++ b/Include/httpClient/task.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "types.h"
+
 #if defined(__cplusplus)
 extern "C" {
 #endif


### PR DESCRIPTION
This file needs to include types.h or it doesnt compile if #included before other libHttpClient headers