### PR TITLE
Platform detection

### DIFF
--- a/Build/libHttpClient.140.UWP.C/libHttpClient.140.UWP.C.vcxproj
+++ b/Build/libHttpClient.140.UWP.C/libHttpClient.140.UWP.C.vcxproj
@@ -158,6 +158,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\async.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\asyncProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\asyncQueue.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\mock.h" />

--- a/Build/libHttpClient.140.UWP.C/libHttpClient.140.UWP.C.vcxproj.filters
+++ b/Build/libHttpClient.140.UWP.C/libHttpClient.140.UWP.C.vcxproj.filters
@@ -114,6 +114,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\asyncQueue.h">
       <Filter>C++ Public Includes</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h">
+      <Filter>C++ Public Includes</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h">
       <Filter>C++ Public Includes</Filter>
     </ClInclude>

--- a/Build/libHttpClient.140.Win32.C/libHttpClient.140.Win32.C.vcxproj
+++ b/Build/libHttpClient.140.Win32.C/libHttpClient.140.Win32.C.vcxproj
@@ -149,6 +149,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\async.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\asyncProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\asyncQueue.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\mock.h" />

--- a/Build/libHttpClient.140.Win32.C/libHttpClient.140.Win32.C.vcxproj.filters
+++ b/Build/libHttpClient.140.Win32.C/libHttpClient.140.Win32.C.vcxproj.filters
@@ -117,6 +117,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\asyncQueue.h">
       <Filter>C++ Public Includes</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h">
+      <Filter>C++ Public Includes</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h">
       <Filter>C++ Public Includes</Filter>
     </ClInclude>

--- a/Build/libHttpClient.140.XDK.C/libHttpClient.140.XDK.C.vcxproj
+++ b/Build/libHttpClient.140.XDK.C/libHttpClient.140.XDK.C.vcxproj
@@ -136,6 +136,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\async.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\asyncProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\asyncQueue.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\mock.h" />

--- a/Build/libHttpClient.140.XDK.C/libHttpClient.140.XDK.C.vcxproj.filters
+++ b/Build/libHttpClient.140.XDK.C/libHttpClient.140.XDK.C.vcxproj.filters
@@ -141,6 +141,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\asyncQueue.h">
       <Filter>C++ Public Includes</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h">
+      <Filter>C++ Public Includes</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h">
       <Filter>C++ Public Includes</Filter>
     </ClInclude>

--- a/Build/libHttpClient.141.UWP.C/libHttpClient.141.UWP.C.vcxproj
+++ b/Build/libHttpClient.141.UWP.C/libHttpClient.141.UWP.C.vcxproj
@@ -158,6 +158,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\async.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\asyncProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\asyncQueue.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\mock.h" />

--- a/Build/libHttpClient.141.UWP.C/libHttpClient.141.UWP.C.vcxproj.filters
+++ b/Build/libHttpClient.141.UWP.C/libHttpClient.141.UWP.C.vcxproj.filters
@@ -114,6 +114,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\asyncQueue.h">
       <Filter>C++ Public Includes</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h">
+      <Filter>C++ Public Includes</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h">
       <Filter>C++ Public Includes</Filter>
     </ClInclude>

--- a/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj
+++ b/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj
@@ -149,6 +149,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\async.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\asyncProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\asyncQueue.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\mock.h" />

--- a/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj.filters
+++ b/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj.filters
@@ -117,6 +117,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\asyncQueue.h">
       <Filter>C++ Public Includes</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h">
+      <Filter>C++ Public Includes</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h">
       <Filter>C++ Public Includes</Filter>
     </ClInclude>

--- a/Build/libHttpClient.141.XDK.C/libHttpClient.141.XDK.C.vcxproj
+++ b/Build/libHttpClient.141.XDK.C/libHttpClient.141.XDK.C.vcxproj
@@ -136,6 +136,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\async.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\asyncProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\asyncQueue.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\mock.h" />

--- a/Build/libHttpClient.141.XDK.C/libHttpClient.141.XDK.C.vcxproj.filters
+++ b/Build/libHttpClient.141.XDK.C/libHttpClient.141.XDK.C.vcxproj.filters
@@ -141,6 +141,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\asyncQueue.h">
       <Filter>C++ Public Includes</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h">
+      <Filter>C++ Public Includes</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h">
       <Filter>C++ Public Includes</Filter>
     </ClInclude>

--- a/Build/libHttpClient.UnitTest.140.TAEF/libHttpClient.UnitTest.140.TAEF.vcxproj
+++ b/Build/libHttpClient.UnitTest.140.TAEF/libHttpClient.UnitTest.140.TAEF.vcxproj
@@ -157,6 +157,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\async.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\asyncProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\asyncQueue.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\mock.h" />

--- a/Build/libHttpClient.UnitTest.140.TAEF/libHttpClient.UnitTest.140.TAEF.vcxproj.filters
+++ b/Build/libHttpClient.UnitTest.140.TAEF/libHttpClient.UnitTest.140.TAEF.vcxproj.filters
@@ -147,6 +147,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\asyncQueue.h">
       <Filter>C++ Public Includes</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h">
+      <Filter>C++ Public Includes</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h">
       <Filter>C++ Public Includes</Filter>
     </ClInclude>

--- a/Build/libHttpClient.UnitTest.140.TE/libHttpClient.UnitTest.140.TE.vcxproj
+++ b/Build/libHttpClient.UnitTest.140.TE/libHttpClient.UnitTest.140.TE.vcxproj
@@ -232,6 +232,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\async.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\asyncProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\asyncQueue.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\mock.h" />

--- a/Build/libHttpClient.UnitTest.140.TE/libHttpClient.UnitTest.140.TE.vcxproj.filters
+++ b/Build/libHttpClient.UnitTest.140.TE/libHttpClient.UnitTest.140.TE.vcxproj.filters
@@ -141,6 +141,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\asyncQueue.h">
       <Filter>C++ Public Includes</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h">
+      <Filter>C++ Public Includes</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h">
       <Filter>C++ Public Includes</Filter>
     </ClInclude>

--- a/Include/httpClient/async.h
+++ b/Include/httpClient/async.h
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #pragma once
 
+#include <httpClient/pal.h>
+
 /// <summary>
 /// An async_queue_handle_t contains async work.  When you make an async call, that call is placed
 /// on an async queue for execution.  An async queue has two sides:  a worker side and

--- a/Include/httpClient/asyncProvider.h
+++ b/Include/httpClient/asyncProvider.h
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #pragma once
 
+#include <httpClient/pal.h>
+
 typedef enum AsyncOp
 {
     /// <summary>

--- a/Include/httpClient/asyncQueue.h
+++ b/Include/httpClient/asyncQueue.h
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #pragma once
 
+#include <httpClient/pal.h>
+
 /// <summary>
 /// An async_queue_t contains async work. An async queue has two sides:  a worker side and
 /// a completion side.  Each side can have different rules for how queued calls

--- a/Include/httpClient/config.h
+++ b/Include/httpClient/config.h
@@ -1,0 +1,67 @@
+#pragma once
+
+// These macros define the "os"s that libHttpClient knows about
+#define HC_PLATFORM_UNKNOWN 0
+#define HC_PLATFORM_WIN32 1
+#define HC_PLATFORM_UWA 2
+#define HC_PLATFORM_XDK 3
+#define HC_PLATFORM_ANDROID 11
+#define HC_PLATFORM_IOS 21
+
+// These macros define the datamodels that libHttpClient knows about
+// (a datamodel defines the size of primitive types such as int and pointers)
+#define HC_DATAMODEL_UNKNOWN 0
+#define HC_DATAMODEL_ILP32 1 // int, long and pointer are 32 bits (32 bit platforms)
+#define HC_DATAMODEL_LLP64 2 // int and long are 32 bit; long long and pointer are 64 bits (64 bit windows)
+#define HC_DATAMODEL_LP64 3 // int is 32 bit; long and pointer are 64 bits (64 bit unix)
+// see http://www.unix.org/version2/whatsnew/lp64_wp.html for detailed descriptions
+
+#if defined(_WIN32)
+    #include <sdkddkver.h>
+    #include <winapifamily.h>
+
+    #if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
+        #define HC_PLATFORM HC_PLATFORM_WIN32
+    #elif WINAPI_FAMILY == WINAPI_FAMILY_PC_APP && _WIN32_WINNT >= _WIN32_WINNT_WIN10
+        #define HC_PLATFORM HC_PLATFORM_UWA
+    #elif WINAPI_FAMILY == WINAPI_FAMILY_TV_APP || WINAPI_FAMILY == WINAPI_FAMILY_TV_TITLE
+        #define HC_PLATFROM HC_PLATFORM_XDK
+    #endif
+
+    #if defined(_WIN64)
+        #define HC_DATAMODEL HC_DATAMODEL_LLP64
+    #else
+        #define HC_DATAMODEL HC_DATAMODEL_ILP32
+    #endif
+#elif defined(__ANDROID__)
+    #define HC_PLATFORM HC_PLATFORM_ANDROID
+
+    #if defined(__LP64__)
+        #define HC_DATAMODEL HC_DATAMODEL_LP64
+    #else
+        #define HC_DATAMODEL HC_DATAMODEL_ILP32
+    #endif
+#elif defined(__APPLE__)
+    #include <TargetConditionals.h>
+    #if TARGET_OS_IPHONE == 1
+        #define HC_PLATFORM HC_PLATFORM_IOS
+    #endif
+
+    #if defined(__LP64__)
+        #define HC_DATAMODEL HC_DATAMODEL_LP64
+    #else
+        #error HC does not support 32 bit builds for Apple platforms
+    #endif
+#endif
+
+// HC_PLATFORM defines the "os" that libHttpClient is being built for
+#if !defined(HC_PLATFORM)
+#error HC does not recognize this platform
+#define HC_PLATFORM HC_PLATFORM_UNKNOWN
+#endif
+
+// HC_PLATFORM defines the datamodel that libHttpClient is being built for
+#if !defined(HC_DATAMODEL)
+#error HC does not recognize the datamodel used on this platform
+#define HC_DATAMODEL HC_DATAMODEL_UNKNOWN
+#endif

--- a/Include/httpClient/pal.h
+++ b/Include/httpClient/pal.h
@@ -2,13 +2,15 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma once
-#pragma warning(disable: 4062)
-#pragma warning(disable: 4702)
+#pragma warning(disable: 4062) // enumerator 'identifier' in switch of enum 'enumeration' is not handled
+#pragma warning(disable: 4702) // unreachable code
 
 #include <stdbool.h>
 #include <stdint.h>
 
-#ifdef _WIN32
+#include <httpClient/config.h>
+
+#if HC_PLATFORM == HC_PLATFORM_WIN32 || HC_PLATFORM == HC_PLATFORM_UWA || HC_PLATFORM == HC_PLATFORM_XDK
 
     #ifndef WIN32_LEAN_AND_MEAN
     #define WIN32_LEAN_AND_MEAN
@@ -20,16 +22,12 @@
 
     #include <windows.h>
 
-    #ifndef _WIN32_WINNT_WIN10
-    #define _WIN32_WINNT_WIN10 0x0A00
-    #endif
-
     #ifndef HC_XDK_API
-    #define HC_XDK_API (WINAPI_FAMILY == WINAPI_FAMILY_TV_APP || WINAPI_FAMILY == WINAPI_FAMILY_TV_TITLE) 
+    #define HC_XDK_API (HC_PLATFORM == HC_PLATFORM_XDK)
     #endif
 
     #ifndef HC_UWP_API
-    #define HC_UWP_API (WINAPI_FAMILY == WINAPI_FAMILY_APP && _WIN32_WINNT >= _WIN32_WINNT_WIN10)
+    #define HC_UWP_API (HC_PLATFORM == HC_PLATFORM_UWA)
     #endif
 
     #if HC_UNITTEST_API
@@ -39,7 +37,7 @@
 
 #else 
 
-    // not _WIN32
+    // not WIN32
     typedef int32_t HRESULT;
 
     #define CALLBACK

--- a/Source/Common/utils.cpp
+++ b/Source/Common/utils.cpp
@@ -102,4 +102,22 @@ HRESULT UnknownExceptionToResult(_In_z_ char const* file, uint32_t line)
     return E_FAIL;
 }
 
+// Validate the datamodel detected by httpClient/config.h
+#if HC_DATAMODEL == HC_DATAMODEL_ILP32
+static_assert(sizeof(int) == 4, "int is not 32 bits");
+static_assert(sizeof(long) == 4, "long is not 32 bits");
+static_assert(sizeof(void*) == 4, "pointer is not 32 bits");
+#elif HC_DATAMODEL == HC_DATAMODEL_LLP64
+static_assert(sizeof(int) == 4, "int is not 32 bits");
+static_assert(sizeof(long) == 4, "long is not 32 bits");
+static_assert(sizeof(long long) == 8, "long long is not 64 bits");
+static_assert(sizeof(void*) == 8, "pointer is not 64 bits");
+#elif HC_DATAMODEL == HC_DATAMODEL_LP64
+static_assert(sizeof(int) == 4, "int is not 32 bits");
+static_assert(sizeof(long) == 8, "long is not 64 bits");
+static_assert(sizeof(void*) == 8, "pointer is not 64 bits");
+#else
+#error Invalid datamodel selected by httpClient/config.h
+#endif
+
 NAMESPACE_XBOX_HTTP_CLIENT_DETAIL_END

--- a/Utilities/CMake/CMakeLists.txt
+++ b/Utilities/CMake/CMakeLists.txt
@@ -79,6 +79,7 @@ include_directories(
 set(CMAKE_SUPPRESS_REGENERATION true)
 
 set(Public_Source_Files
+    ../../../include/httpClient/config.h
     ../../../include/httpClient/httpClient.h
     ../../../include/httpClient/httpProvider.h
     ../../../include/httpClient/mock.h
@@ -89,34 +90,34 @@ set(Public_Source_Files
     ../../../include/httpClient/pal.h
     )
 
-set(Task_Source_Files    
+set(Task_Source_Files
     ../../../Source/Task/AsyncQueue.cpp
     ../../../Source/Task/AsyncLib.cpp
     ../../../Source/Task/CriticalThread.cpp
     )
-    
-set(Global_Source_Files    
+
+set(Global_Source_Files
     ../../../Source/Global/mem.cpp
     ../../../Source/Global/mem.h
     ../../../Source/Global/global_publics.cpp
     ../../../Source/Global/global.cpp
-    ../../../Source/Global/global.h       
+    ../../../Source/Global/global.h
     )
 
 set(WebSocket_Source_Files
     ../../../Source/WebSocket/hcwebsocket.h
     ../../../Source/WebSocket/hcwebsocket.cpp
     )
-    
+
 set(WinRT_WebSocket_Source_Files
     ../../../Source/WebSocket/WinRT/winrt_websocket.cpp
     )
-    
+
 set(Win32_WebSocket_Source_Files
     ../../../Source/WebSocket/Win32/win32_websocket.cpp
     )
-    
-set(Mock_Source_Files        
+
+set(Mock_Source_Files
     ../../../Source/Mock/mock.cpp
     ../../../Source/Mock/mock.h
     ../../../Source/Mock/mock_publics.cpp
@@ -163,7 +164,7 @@ set(WinHttp_HTTP_Source_Files
     ../../../Source/HTTP/WinHttp/winhttp_http_task.cpp
     ../../../Source/HTTP/WinHttp/winhttp_http_task.h
     )
-        
+
 set(XMLHttp_HTTP_Source_Files
     ../../../Source/HTTP/XMLHttp/http_buffer.cpp
     ../../../Source/HTTP/XMLHttp/http_buffer.h
@@ -176,7 +177,7 @@ set(XMLHttp_HTTP_Source_Files
     ../../../Source/HTTP/XMLHttp/xmlhttp_http_task.cpp
     ../../../Source/HTTP/XMLHttp/xmlhttp_http_task.h
     )
-    
+
 set(Logger_Source_Files
     ../../../Source/Logger/trace.cpp
     ../../../Source/Logger/trace_internal.h
@@ -261,7 +262,7 @@ if( UWP )
         ${WinRT_WebSocket_Source_Files}
         )
 endif()
-    
+
 if( XDK )
     source_group("C++ Source\\HTTP\\XMLHttp" FILES ${XMLHttp_HTTP_Source_Files})
     source_group("C++ Source\\Common\\Win" FILES ${Common_Windows_Source_Files})


### PR DESCRIPTION
This change introduces a new completely standalone header httpClient/config.h that provides platform detection.

The header sets 2 macros: `HC_PLATFORM` and `HC_DATAMODEL`.
`HC_PLATFORM` defines the "os" that we are building on, while `HC_DATAMODEL` defines what size various primitives data types are (to detect 32bit vs 64bit for example).

These macros can then be used to do compiler switches (for example to determine how to implement the async library on different oses).

libHttpClient already defines the `HC_API_*` macros that are similar to the `HC_PLATFORM` macro, but the name is not very descriptive and they are not guaranteed to be always defined which makes them harder to use.