### PR TITLE
Fix NT_VERIFY and ASSERT macros not being switched on and off consistently

### DIFF
--- a/Source/Common/pch_common.h
+++ b/Source/Common/pch_common.h
@@ -49,10 +49,6 @@
 #define UNREFERENCED_PARAMETER(args)
 #endif
 
-#ifndef max
-#define max(x,y) std::max(x,y)
-#endif
-
 #ifndef ARRAYSIZE
 #define ARRAYSIZE(x) sizeof(x) / sizeof(x[0])
 #endif
@@ -74,20 +70,13 @@ typedef std::chrono::steady_clock chrono_clock_t;
 
 #if !HC_UNITTEST_API
 #define ENABLE_LOGS 1
-#define ENABLE_ASSERTS 1
 #endif
 
 #ifndef DebugBreak
 #define DebugBreak()
 #endif
 
-#ifdef ENABLE_ASSERTS
 #define ASSERT(condition) assert(condition)
-#define NT_VERIFY(condition) ASSERT(condition)
-#else
-#define ASSERT(condition)
-#define NT_VERIFY(condition) condition
-#endif
 
 typedef int32_t function_context;
 #include <httpClient/httpClient.h>

--- a/Source/Task/AsyncQueue.cpp
+++ b/Source/Task/AsyncQueue.cpp
@@ -439,12 +439,14 @@ static void EnsureSharedInitialization()
     BOOL pending;
 
     // Only failure modes for InitOnce are usage errors.
-    NT_VERIFY(InitOnceBeginInitialize(&s_sharedInit, 0, &pending, nullptr));
+    BOOL res = InitOnceBeginInitialize(&s_sharedInit, 0, &pending, nullptr);
+    assert(res);
 
     if (pending)
     {
         InitializeListHead(&s_sharedList);
-        NT_VERIFY(InitOnceComplete(&s_sharedInit, 0, nullptr));
+        res = InitOnceComplete(&s_sharedInit, 0, nullptr);
+        assert(res);
     }
 }
 


### PR DESCRIPTION
Currently they are controlled by ENABLE_ASSERTS, but then delegate to the system assert macro which switches on a different setting leading to scenarios where we think asserts are being compiled but they are not.

Solved by removing ENABLE_ASSERTS and the NT_VERIFY macro completely