### PR TITLE
Merge with changes in Windows tree

### DIFF
--- a/Include/httpClient/async.h
+++ b/Include/httpClient/async.h
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #pragma once
 
-#include <httpClient/pal.h>
-
 /// <summary>
 /// An async_queue_handle_t contains async work.  When you make an async call, that call is placed
 /// on an async queue for execution.  An async queue has two sides:  a worker side and

--- a/Include/httpClient/asyncProvider.h
+++ b/Include/httpClient/asyncProvider.h
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #pragma once
 
-#include <httpClient/pal.h>
-
 typedef enum AsyncOp
 {
     /// <summary>

--- a/Include/httpClient/asyncQueue.h
+++ b/Include/httpClient/asyncQueue.h
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #pragma once
 
-#include <httpClient/pal.h>
-
 /// <summary>
 /// An async_queue_t contains async work. An async queue has two sides:  a worker side and
 /// a completion side.  Each side can have different rules for how queued calls

--- a/Source/Common/pch_common.h
+++ b/Source/Common/pch_common.h
@@ -91,6 +91,10 @@ typedef int32_t function_context;
 HC_DECLARE_TRACE_AREA(HTTPCLIENT);
 HC_DECLARE_TRACE_AREA(WEBSOCKET);
 
+// Define TRACE for AsyncLib
+#define ASYNC_LIB_TRACE(result, message)	        \
+    HC_TRACE_ERROR_HR(HTTPCLIENT, result, message); \
+
 #define CATCH_RETURN() CATCH_RETURN_IMPL(__FILE__, __LINE__)
 
 #define CATCH_RETURN_IMPL(file, line) \

--- a/Source/Task/AsyncLib.cpp
+++ b/Source/Task/AsyncLib.cpp
@@ -548,8 +548,22 @@ STDAPI GetAsyncResult(
         else if (token != state->token)
         {
             // Call/Result mismatch.  This AsyncBlock was initiated by state->function
-            ASSERT(false);
+            char buf[100];
+            if (state->function != nullptr)
+            {
+                sprintf_s(
+                    buf,
+                    "Call/Result mismatch.  This AsyncBlock was initiated by '%s'.\r\n",
+                    state->function);
+            }
+            else
+            {
+                sprintf_s(buf, "Call/Result mismatch\r\n");
+            }
+
             result = E_INVALIDARG;
+            ASYNC_LIB_TRACE(result, buf);
+            ASSERT(false);
         }
         else if (state->providerData.bufferSize == 0)
         {

--- a/Source/Task/AsyncQueue.cpp
+++ b/Source/Task/AsyncQueue.cpp
@@ -439,14 +439,12 @@ static void EnsureSharedInitialization()
     BOOL pending;
 
     // Only failure modes for InitOnce are usage errors.
-    BOOL res = InitOnceBeginInitialize(&s_sharedInit, 0, &pending, nullptr);
-    assert(res);
+    (void)InitOnceBeginInitialize(&s_sharedInit, 0, &pending, nullptr);
 
     if (pending)
     {
         InitializeListHead(&s_sharedList);
-        res = InitOnceComplete(&s_sharedInit, 0, nullptr);
-        assert(res);
+        (void)InitOnceComplete(&s_sharedInit, 0, nullptr);
     }
 }
 

--- a/Source/Task/Callback.h
+++ b/Source/Task/Callback.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "httpClient\asyncQueue.h"
+#include "AsyncQueue.h"
 
 template<class CallbackType, class CallbackDataType>
 struct DefaultThunk
@@ -320,6 +320,12 @@ private:
     SRWLOCK m_lock;
     uint32_t m_nextCookie = 1;
     LIST_ENTRY m_callbackHead;
+
+    // Disable copy ctor and assignment, as these cannot be implemented without 
+    // potentially throwing exceptions
+
+    Callback<CallbackType, CallbackDataType, CallbackThunk>(Callback<CallbackType, CallbackDataType, CallbackThunk>&);
+    Callback<CallbackType, CallbackDataType, CallbackThunk>& operator= (Callback<CallbackType, CallbackDataType, CallbackThunk>&);
 
     void Release(_In_ CallbackSharedData* sharedData)
     {

--- a/Source/Task/Callback.h
+++ b/Source/Task/Callback.h
@@ -43,6 +43,11 @@ public:
         Clear();
     }
 
+    // Disable copy ctor and assignment, as these cannot be implemented without 
+    // potentially throwing exceptions
+    Callback<CallbackType, CallbackDataType, CallbackThunk>(const Callback<CallbackType, CallbackDataType, CallbackThunk>&) = delete;
+    Callback<CallbackType, CallbackDataType, CallbackThunk>& operator= (const Callback<CallbackType, CallbackDataType, CallbackThunk>&) = delete;
+
     //
     // Adds a callback function to this callback.
     //
@@ -320,12 +325,6 @@ private:
     SRWLOCK m_lock;
     uint32_t m_nextCookie = 1;
     LIST_ENTRY m_callbackHead;
-
-    // Disable copy ctor and assignment, as these cannot be implemented without 
-    // potentially throwing exceptions
-
-    Callback<CallbackType, CallbackDataType, CallbackThunk>(Callback<CallbackType, CallbackDataType, CallbackThunk>&);
-    Callback<CallbackType, CallbackDataType, CallbackThunk>& operator= (Callback<CallbackType, CallbackDataType, CallbackThunk>&);
 
     void Release(_In_ CallbackSharedData* sharedData)
     {

--- a/Source/Task/Callback_STL.h
+++ b/Source/Task/Callback_STL.h
@@ -41,6 +41,11 @@ public:
     {
         Clear();
     }
+    
+    // Disable copy ctor and assignment, as these cannot be implemented without 
+    // potentially throwing exceptions
+    Callback<CallbackType, CallbackDataType, CallbackThunk>(const Callback<CallbackType, CallbackDataType, CallbackThunk>&) = delete;
+    Callback<CallbackType, CallbackDataType, CallbackThunk>& operator= (const Callback<CallbackType, CallbackDataType, CallbackThunk>&) = delete;    
 
     //
     // Adds a callback function to this callback.
@@ -319,12 +324,6 @@ private:
     std::shared_mutex m_lock;
     std::atomic<uint32_t> m_nextCookie = 1;
     LIST_ENTRY m_callbackHead;
-
-    // Disable copy ctor and assignment, as these cannot be implemented without 
-    // potentially throwing exceptions
-
-    Callback<CallbackType, CallbackDataType, CallbackThunk>(Callback<CallbackType, CallbackDataType, CallbackThunk>&);
-    Callback<CallbackType, CallbackDataType, CallbackThunk>& operator= (Callback<CallbackType, CallbackDataType, CallbackThunk>&);
 
     void Release(_In_ CallbackSharedData* sharedData)
     {

--- a/Source/Task/Callback_STL.h
+++ b/Source/Task/Callback_STL.h
@@ -320,6 +320,12 @@ private:
     std::atomic<uint32_t> m_nextCookie = 1;
     LIST_ENTRY m_callbackHead;
 
+    // Disable copy ctor and assignment, as these cannot be implemented without 
+    // potentially throwing exceptions
+
+    Callback<CallbackType, CallbackDataType, CallbackThunk>(Callback<CallbackType, CallbackDataType, CallbackThunk>&);
+    Callback<CallbackType, CallbackDataType, CallbackThunk>& operator= (Callback<CallbackType, CallbackDataType, CallbackThunk>&);
+
     void Release(_In_ CallbackSharedData* sharedData)
     {
         if (sharedData->Refs.fetch_sub(1) == 1)


### PR DESCRIPTION
This change synchronizes libHttpClient with matching code in Windows.  Same sources are now compiling in both trees.