### PR TITLE
One more fix for iOS

### DIFF
--- a/Include/httpClient/pal.h
+++ b/Include/httpClient/pal.h
@@ -6,6 +6,7 @@
 #pragma warning(disable: 4702) // unreachable code
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #include <httpClient/config.h>


### PR DESCRIPTION
iOS has a problem with size_t and finding std::nullptr_t in the global namespace. stddef.h fixes both of these issues.