### PR TITLE
Fix the definition of E_NOT_SUFFICIENT_BUFFER to be a compile time constant even without c++17 support

### DIFF
--- a/Include/httpClient/pal.h
+++ b/Include/httpClient/pal.h
@@ -39,27 +39,23 @@
 #define _HRESULTYPEDEF_(_sc) ((HRESULT)_sc)
 
 // Windows defines these as an inline function so they cannot be
-// used in a switch statement.  On compilers >= 1900 (VS 2017) the
-// function is marked constexpr and we can keep them as-is.
-
-#if _MSC_VER < 1900
+// used in a switch statement. (It would work if we required c++17 support)
 #undef E_TIME_CRITICAL_THREAD
 #undef E_NOT_SUFFICIENT_BUFFER
-#endif
 
 #ifndef E_TIME_CRITICAL_THREAD
 #ifndef ERROR_TIME_CRITICAL_THREAD
 #define ERROR_TIME_CRITICAL_THREAD 0x1A0
 #endif
-#define E_TIME_CRITICAL_THREAD           __HRESULT_FROM_WIN32(ERROR_TIME_CRITICAL_THREAD)
+#define E_TIME_CRITICAL_THREAD           __HRESULT_FROM_WIN32(ERROR_TIME_CRITICAL_THREAD) // 0x800701A0
 #endif
 
 #ifndef E_NOT_SUPPORTED
-#define E_NOT_SUPPORTED                  __HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED)
+#define E_NOT_SUPPORTED                  __HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED) // 0x80070032
 #endif
 
 #ifndef E_NOT_SUFFICIENT_BUFFER
-#define E_NOT_SUFFICIENT_BUFFER          __HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER)
+#define E_NOT_SUFFICIENT_BUFFER          __HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER) // 0x8007007A
 #endif
 
 #else 

--- a/Source/Common/pch_common.h
+++ b/Source/Common/pch_common.h
@@ -46,7 +46,7 @@
 #endif
 
 #ifndef _WIN32
-#define UNREFERENCED_PARAMETER(args)
+#define UNREFERENCED_PARAMETER(args) (void)(args);
 #endif
 
 #ifndef ARRAYSIZE

--- a/Source/Common/utils.h
+++ b/Source/Common/utils.h
@@ -36,7 +36,7 @@ void FormatHelper(TBuffer& buffer, _In_z_ _Printf_format_string_ char const* for
     va_end(args2);
 
     ASSERT(written == required);
-    //UNREFERENCED_LOCAL(written);
+    UNREFERENCED_PARAMETER(written);
 
     buffer.resize(buffer.size() - 1); // drop null terminator
 }


### PR DESCRIPTION
Also silence some warnings