### PR TITLE
Remove application properties from AndroidManifest

### DIFF
--- a/Build/libHttpClient.141.Android.Java/app/src/main/AndroidManifest.xml
+++ b/Build/libHttpClient.141.Android.Java/app/src/main/AndroidManifest.xml
@@ -1,17 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.libHttpClient"
+          package="com.xbox.httpclient"
           android:versionCode="1"
           android:versionName="1.0">
-  <application
-      android:allowBackup="false"
-      android:label="@string/app_name">
-    <activity android:name=".libHttpClient"
-              android:label="@string/app_name">
-      <intent-filter>
-        <action android:name="android.intent.action.MAIN" />
-        <category android:name="android.intent.category.LAUNCHER" />
-      </intent-filter>
-    </activity>
-  </application>
+  <application/>
 </manifest>

--- a/Build/libHttpClient.141.Android.Java/app/src/main/AndroidManifest.xml.template
+++ b/Build/libHttpClient.141.Android.Java/app/src/main/AndroidManifest.xml.template
@@ -1,17 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.libHttpClient"
+          package="com.xbox.httpclient"
           android:versionCode="1"
           android:versionName="1.0">
-  <application
-      android:allowBackup="false"
-      android:label="@string/app_name">
-    <activity android:name=".libHttpClient"
-              android:label="@string/app_name">
-      <intent-filter>
-        <action android:name="android.intent.action.MAIN" />
-        <category android:name="android.intent.category.LAUNCHER" />
-      </intent-filter>
-    </activity>
-  </application>
+  <application/>
 </manifest>


### PR DESCRIPTION
Currently when an app takes a dependency on the libHttpClient aar, the app tile will be duplicated in the app list with a tile that cannot launch due to a mis-configured ApplicationManifest file. This removes the incorrect default data that Visual Studio included in their template. I've verified that this gets rid of the extra tile with a test project.