### PR TITLE
Replace existing HTTP execute call with a non-blocking call

### DIFF
--- a/Build/libHttpClient.141.Android.Java/app/src/main/java/com/xbox/httpClient/HttpClientRequest.java
+++ b/Build/libHttpClient.141.Android.Java/app/src/main/java/com/xbox/httpClient/HttpClientRequest.java
@@ -42,8 +42,8 @@ public class HttpClientRequest {
 
     public void doRequestAsync(final long sourceCall) {
         OkHttpClient client = new OkHttpClient.Builder()
-        		.retryOnConnectionFailure(false) // Explicitly disable retries; retry logic will be managed by native code in libHttpClient
-        		.build();
+                .retryOnConnectionFailure(false) // Explicitly disable retries; retry logic will be managed by native code in libHttpClient
+                .build();
         client.newCall(this.requestBuilder.build()).enqueue(new Callback() {
             @Override
             public void onFailure(final Call call, IOException e) {

--- a/Build/libHttpClient.141.Android.Java/app/src/main/java/com/xbox/httpClient/HttpClientRequest.java
+++ b/Build/libHttpClient.141.Android.Java/app/src/main/java/com/xbox/httpClient/HttpClientRequest.java
@@ -4,6 +4,8 @@ import android.util.Log;
 
 import java.io.IOException;
 
+import okhttp3.Call;
+import okhttp3.Callback;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -38,14 +40,23 @@ public class HttpClientRequest {
         this.requestBuilder = requestBuilder.addHeader(name, value);
     }
 
-    public HttpClientResponse doRequest() {
-        OkHttpClient client = new OkHttpClient.Builder().build();
+    public void doRequestAsync(final long sourceCall) {
+        OkHttpClient client = new OkHttpClient.Builder()
+        		.retryOnConnectionFailure(false) // Explicitly disable retries; retry logic will be managed by native code in libHttpClient
+        		.build();
+        client.newCall(this.requestBuilder.build()).enqueue(new Callback() {
+            @Override
+            public void onFailure(final Call call, IOException e) {
+                Log.e("HttpRequestClient", "Failed to execute async request", e);
+                OnRequestCompleted(sourceCall, null);
+            }
 
-        try {
-            Response response = client.newCall(this.requestBuilder.build()).execute();
-            return new HttpClientResponse(response); 
-        } catch (IOException e) {
-            Log.e("HttpRequestClient", "Failed to execute request", e);
-            return null;
-        }
-    }}
+            @Override
+            public void onResponse(Call call, final Response response) throws IOException {
+                OnRequestCompleted(sourceCall, new HttpClientResponse(response));
+            }
+        });
+    }
+
+    private native void OnRequestCompleted(long call, HttpClientResponse response);
+}

--- a/Source/HTTP/Android/android_http_request.h
+++ b/Source/HTTP/Android/android_http_request.h
@@ -4,28 +4,27 @@
 
 class HttpRequest {
 public:
-    HttpRequest(JavaVM* javaVm, jclass httpRequestClass, jclass httpResponseClass);
+    HttpRequest(AsyncBlock* asyncBlock, JavaVM* javaVm, jclass httpRequestClass, jclass httpResponseClass);
     virtual ~HttpRequest();
 
     HRESULT Initialize();
+    AsyncBlock* GetAsyncBlock() { return m_asyncBlock; }
 
     // Request Functions
     HRESULT SetUrl(const char* url);
     HRESULT SetMethodAndBody(const char* method, const char* contentType, const uint8_t* body, uint32_t bodySize);
     HRESULT AddHeader(const char* headerName, const char* headerValue);
-    HRESULT ExecuteRequest();
+    HRESULT ExecuteAsync(hc_call_handle_t call);
 
-    // Response Functions
-    uint32_t GetResponseCode();
-    uint32_t GetResponseHeaderCount();
-    std::string GetHeaderNameAtIndex(uint32_t index);
-    std::string GetHeaderValueAtIndex(uint32_t index);
-    HRESULT ProcessResponseBody(hc_call_handle_t call);
+    HRESULT ProcessResponse(hc_call_handle_t call, jobject response);
+
 private:
     HRESULT GetJniEnv(JNIEnv**);
+    uint32_t GetResponseHeaderCount(jobject response);
+    HRESULT ProcessResponseBody(hc_call_handle_t call, jobject response);
 
     jobject m_httpRequestInstance;
-    jobject m_httpResponseInstance;
+    AsyncBlock* m_asyncBlock;
 
     JavaVM* m_javaVm;
     jclass m_httpRequestClass;


### PR DESCRIPTION
Currently the Java implementation is using a blocking call for executing the underlying HTTP request. This updates the call to use the asynchronous version and refactors the C++ side to handle setting the call context and retrieving it when the call has completed.