### PR TITLE
Spec review feedback

### DIFF
--- a/Include/httpClient/asyncProvider.h
+++ b/Include/httpClient/asyncProvider.h
@@ -88,14 +88,14 @@ typedef HRESULT CALLBACK AsyncProvider(_In_ AsyncOp op, _In_ const AsyncProvider
 /// </summary>
 /// <param name='asyncBlock'>A pointer to the AsyncBlock that holds data for the call.</param>
 /// <param name='context'>An optional context pointer that will be stored in the AsyncProviderData object passed back to the AsyncProvider callback.</param>
-/// <param name='token'>An optional arbitrary token that can be used to identify this call.</param>
-/// <param name='functionName'>An optional string that names the function providing the async call.  This is typically the __FUNCTION__ compiler macro.</param>
+/// <param name='identity'>An optional arbitrary pointer that can be used to identify this call.</param>
+/// <param name='identityName'>An optional string that names the async call.  This is typically the __FUNCTION__ compiler macro.</param>
 /// <param name='provider'>The function callback to invoke to implement the async call.</param>
 STDAPI BeginAsync(
     _Inout_ AsyncBlock* asyncBlock,
     _In_opt_ void* context,
-    _In_opt_ const void* token,
-    _In_opt_ const char* functionName,
+    _In_opt_ const void* identity,
+    _In_opt_ const char* identityName,
     _In_ AsyncProvider* provider);
 
 /// <summary>
@@ -130,13 +130,13 @@ STDAPI_(void) CompleteAsync(
 /// BeginAsync.
 /// </summary>
 /// <param name='asyncBlock'>A pointer to the AsyncBlock that was passed to BeginAsync.</param>
-/// <param name='token'>An optional token used to match this result call with a prior BeginAsync call. If a token was passed to BeginAsync, the same token must be passed here.</param>
+/// <param name='identity'>An optional pointer used to match this result call with a prior BeginAsync call. If an identity pointer was passed to BeginAsync, the same pointer must be passed here.</param>
 /// <param name='bufferSize'>The size of the provided buffer, in bytes.</param>
 /// <param name='buffer'>A pointer to the result buffer.</param>
 /// <param name='bufferUsed'>An optional pointer that contains the number of bytes written to the buffer.  This is defined as the requiredResultSize passed to CompleteAsync.</param>
 STDAPI GetAsyncResult(
     _Inout_ AsyncBlock* asyncBlock,
-    _In_opt_ const void* token,
+    _In_opt_ const void* identity,
     _In_ size_t bufferSize,
     _Out_writes_bytes_to_opt_(bufferSize, *bufferUsed) void* buffer,
     _Out_opt_ size_t* bufferUsed);

--- a/Include/httpClient/asyncQueue.h
+++ b/Include/httpClient/asyncQueue.h
@@ -3,6 +3,12 @@
 #pragma once
 
 /// <summary>
+/// A token returned when registering a callback to identify the registration. This token
+/// is later used to unregister the callback.
+/// </summary>
+typedef uint64_t registration_token_t;
+
+/// <summary>
 /// An async_queue_t contains async work. An async queue has two sides:  a worker side and
 /// a completion side.  Each side can have different rules for how queued calls
 /// are dispatched.
@@ -212,24 +218,24 @@ STDAPI_(void) RemoveAsyncQueueCallbacks(
     _In_ AsyncQueueRemovePredicate* removePredicate);
 
 /// <summary>
-/// Adds a callback that will be invoked whenever a callback
+/// Registers a callback that will be invoked whenever a callback
 /// is submitted to this queue.
 /// </summary>
-/// <param name='queue'>The queue to add the submit callback to.</param>
+/// <param name='queue'>The queue to register the submit callback to.</param>
 /// <param name='context'>An optional context pointer to be passed to the submit callback.</param>
 /// <param name='callback'>A callback that will be invoked when a new callback is submitted to the queue.</param>
-/// <param name='token'>A token used in a later call to RemoveAsyncCallbackSubmitted to remove the callback.</param>
-STDAPI AddAsyncQueueCallbackSubmitted(
+/// <param name='token'>A token used in a later call to UnregisterAsyncCallbackSubmitted to remove the callback.</param>
+STDAPI RegisterAsyncQueueCallbackSubmitted(
     _In_ async_queue_handle_t queue,
     _In_opt_ void* context,
     _In_ AsyncQueueCallbackSubmitted* callback,
-    _Out_ uint32_t* token);
+    _Out_ registration_token_t* token);
 
 /// <summary>
-/// Removes a previously added callback.
+/// Unregisters a previously registered callback.
 /// </summary>
-/// <param name='queue'>The queue to remvoe the submit callback from.</param>
-/// <param name='token'>The token returned from AddAsyncQueueCallbackSubmitted.</param>
-STDAPI_(void) RemoveAsyncQueueCallbackSubmitted(
+/// <param name='queue'>The queue to remove the submit callback from.</param>
+/// <param name='token'>The token returned from RegisterAsyncQueueCallbackSubmitted.</param>
+STDAPI_(void) UnregisterAsyncQueueCallbackSubmitted(
     _In_ async_queue_handle_t queue,
-    _In_ uint32_t token);
+    _In_ registration_token_t token);

--- a/Source/Task/AsyncLib.cpp
+++ b/Source/Task/AsyncLib.cpp
@@ -29,8 +29,8 @@ struct AsyncState
     bool waitSatisfied;
 #endif
 
-    const void* token = nullptr;
-    const char* function = nullptr;
+    const void* identity = nullptr;
+    const char* identityName = nullptr;
 
     AsyncState() noexcept :
         timer{ this, TimerCallback }
@@ -629,8 +629,8 @@ STDAPI RunAsync(
 STDAPI BeginAsync(
     _Inout_ AsyncBlock* asyncBlock,
     _In_opt_ void* context,
-    _In_opt_ const void* token,
-    _In_opt_ const char* function,
+    _In_opt_ const void* identity,
+    _In_opt_ const char* identityName,
     _In_ AsyncProvider* provider)
 {
     RETURN_IF_FAILED(AllocState(asyncBlock));
@@ -642,8 +642,8 @@ STDAPI BeginAsync(
     }
     state->provider = provider;
     state->providerData.context = context;
-    state->token = token;
-    state->function = function;
+    state->identity = identity;
+    state->identityName = identityName;
 
     return S_OK;
 }
@@ -759,7 +759,7 @@ STDAPI_(void) CompleteAsync(
 /// </summary>
 STDAPI GetAsyncResult(
     _Inout_ AsyncBlock* asyncBlock,
-    _In_opt_ const void* token,
+    _In_opt_ const void* identity,
     _In_ size_t bufferSize,
     _Out_writes_bytes_to_opt_(bufferSize, *bufferUsed) void* buffer,
     _Out_opt_ size_t* bufferUsed)
@@ -781,18 +781,18 @@ STDAPI GetAsyncResult(
                 *bufferUsed = 0;
             }
         }
-        else if (token != state->token)
+        else if (identity != state->identity)
         {
-            // Call/Result mismatch.  This AsyncBlock was initiated by state->function
+            // Call/Result mismatch.  This AsyncBlock was initiated by state->identityName
             char buf[100];
             int sprintfResult;
-            if (state->function != nullptr)
+            if (state->identityName != nullptr)
             {
                 sprintfResult = snprintf(
                     buf,
                     sizeof(buf),
                     "Call/Result mismatch.  This AsyncBlock was initiated by '%s'.\r\n",
-                    state->function);
+                    state->identityName);
             }
             else
             {

--- a/Source/Task/AsyncQueue.cpp
+++ b/Source/Task/AsyncQueue.cpp
@@ -444,18 +444,18 @@ struct async_queue_t
         return q->AppendItem(&m_refs, callback, context);
     }
 
-    HRESULT AddCallback(
+    HRESULT RegisterCallback(
         _In_opt_ void* context,
         _In_ AsyncQueueCallbackSubmitted* callback,
-        _Out_ uint32_t* token)
+        _Out_ registration_token_t* token)
     {
-        return m_callbackSubmitted.Add(this, context, callback, token);
+        return m_callbackSubmitted.Register(this, context, callback, token);
     }
 
-    void RemoveCallback(
-        _In_ uint32_t token)
+    void UnregisterCallback(
+        _In_ registration_token_t token)
     {
-        m_callbackSubmitted.Remove(token);
+        m_callbackSubmitted.Unregister(token);
     }
 
     void MakeShared(_In_ uint64_t shareId)
@@ -716,15 +716,15 @@ STDAPI_(async_queue_handle_t) DuplicateAsyncQueueHandle(
 }
 
 //
-// Adds a callback that will be called when a new callback
+// Registers a callback that will be called when a new callback
 // is submitted. The callback will be directly invoked when
 // the call is submitted.
 //
-STDAPI AddAsyncQueueCallbackSubmitted(
+STDAPI RegisterAsyncQueueCallbackSubmitted(
     _In_ async_queue_handle_t queue,
     _In_opt_ void* context,
     _In_ AsyncQueueCallbackSubmitted* callback,
-    _Out_ uint32_t* token)
+    _Out_ registration_token_t* token)
 {
     async_queue_t* aq = async_queue_t::GetQueue(queue);
     if (aq == nullptr)
@@ -732,19 +732,19 @@ STDAPI AddAsyncQueueCallbackSubmitted(
         RETURN_HR(E_INVALIDARG);
     }
 
-    RETURN_HR(aq->AddCallback(context, callback, token));
+    RETURN_HR(aq->RegisterCallback(context, callback, token));
 }
 
 //
-// Removes a previously added callback.
+// Unregisters a previously added callback.
 //
-STDAPI_(void) RemoveAsyncQueueCallbackSubmitted(
+STDAPI_(void) UnregisterAsyncQueueCallbackSubmitted(
     _In_ async_queue_handle_t queue,
-    _In_ uint32_t token)
+    _In_ registration_token_t token)
 {
     async_queue_t* aq = async_queue_t::GetQueue(queue);
     if (aq != nullptr)
     {
-        aq->RemoveCallback(token);
+        aq->UnregisterCallback(token);
     }
 }

--- a/Source/Task/Callback_STL.h
+++ b/Source/Task/Callback_STL.h
@@ -49,13 +49,13 @@ public:
     Callback<CallbackType, CallbackDataType, CallbackThunk>& operator= (const Callback<CallbackType, CallbackDataType, CallbackThunk>&) = delete;    
 
     //
-    // Adds a callback function to this callback.
+    // Registers a callback function to this callback.
     //
-    HRESULT Add(
+    HRESULT Register(
         _In_opt_ async_queue_handle_t queue,
         _In_opt_ void* context,
         _In_ CallbackType callback,
-        _Out_ uint32_t* cookie)
+        _Out_ registration_token_t* token)
     {
         if (queue == nullptr)
         {
@@ -82,12 +82,12 @@ public:
         }
 
         entry->Queue = queue;
-        entry->Cookie = m_nextCookie.fetch_add(1);
+        entry->Token = m_nextToken.fetch_add(1);
         entry->Context = context;
         entry->Callback = callback;
         entry->Refs = 1;
 
-        *cookie = entry->Cookie;
+        *token = entry->Token;
 
         {
             std::lock_guard<std::mutex> lock{ m_lock };
@@ -98,11 +98,11 @@ public:
     }
 
     //
-    // Removes a callback for the given cookie.
+    // Unregisters a callback for the given token.
     //
-    void Remove(_In_ uint32_t cookie)
+    void Unregister(_In_ registration_token_t token)
     {
-        CallbackRegistration* remove = Find(cookie, true);
+        CallbackRegistration* remove = Find(token, true);
 
         if (remove != nullptr)
         {
@@ -196,7 +196,7 @@ public:
 
                 CallbackRegistration* cb = CONTAINING_RECORD(entry, CallbackRegistration, ListEntry);
                 invocation->Owner = this;
-                invocation->Cookie = cb->Cookie;
+                invocation->Token = cb->Token;
 
                 if (free)
                 {
@@ -238,49 +238,49 @@ public:
     HRESULT Invoke(
         _In_ CallbackDataType* data)
     {
-        uint32_t* cookies = nullptr;
-        size_t cookieCount = 0;
+        registration_token_t* tokens = nullptr;
+        size_t tokenCount = 0;
 
         {
             std::lock_guard<std::mutex> lock{ m_lock };
 
             // Walk through all the callback entries and grab their
-            // cookies.
+            // tokens.
 
             PLIST_ENTRY entry = m_callbackHead.Flink;
             while (entry != &m_callbackHead)
             {
-                cookieCount++;
+                tokenCount++;
                 entry = entry->Flink;
             }
 
-            if (cookieCount != 0)
+            if (tokenCount != 0)
             {
-                cookies = new (std::nothrow) uint32_t[cookieCount];
+                tokens = new (std::nothrow) registration_token_t[tokenCount];
 
-                if (cookies != nullptr)
+                if (tokens != nullptr)
                 {
                     entry = m_callbackHead.Flink;
-                    cookieCount = 0;
+                    tokenCount = 0;
                     while (entry != &m_callbackHead)
                     {
                         CallbackRegistration* cb = CONTAINING_RECORD(entry, CallbackRegistration, ListEntry);
-                        cookies[cookieCount] = cb->Cookie;
-                        cookieCount++;
+                        tokens[tokenCount] = cb->Token;
+                        tokenCount++;
                         entry = entry->Flink;
                     }
                 }
             }
         }
 
-        if (cookieCount != 0 && cookies == nullptr)
+        if (tokenCount != 0 && tokens == nullptr)
         {
             return E_OUTOFMEMORY;
         }
 
-        for (uint32_t idx = 0; idx < cookieCount; idx++)
+        for (uint32_t idx = 0; idx < tokenCount; idx++)
         {
-            CallbackRegistration* cb = Find(cookies[idx], false);
+            CallbackRegistration* cb = Find(tokens[idx], false);
             if (cb != nullptr)
             {
                 CallbackThunk thunk;
@@ -289,7 +289,7 @@ public:
             }
         }
 
-        delete[] cookies;
+        delete[] tokens;
 
         return S_OK;
     }
@@ -305,7 +305,7 @@ private:
     struct CallbackInvocation
     {
         Callback<CallbackType, CallbackDataType, CallbackThunk>* Owner;
-        uint32_t Cookie;
+        registration_token_t Token;
         CallbackDataType Data;
         CallbackSharedData *SharedData;
     };
@@ -313,7 +313,7 @@ private:
     struct CallbackRegistration
     {
         LIST_ENTRY ListEntry;
-        uint32_t Cookie;
+        registration_token_t Token;
         std::atomic<uint32_t> Refs;
         async_queue_handle_t Queue;
         void* Context;
@@ -321,7 +321,7 @@ private:
     };
 
     std::mutex m_lock;
-    std::atomic<uint32_t> m_nextCookie{ 1 };
+    std::atomic<registration_token_t> m_nextToken{ 1 };
     LIST_ENTRY m_callbackHead;
 
     void Release(_In_ CallbackSharedData* sharedData)
@@ -360,7 +360,7 @@ private:
         delete invocation;
     }
 
-    CallbackRegistration* Find(_In_ uint32_t cookie, _In_ bool remove)
+    CallbackRegistration* Find(_In_ registration_token_t token, _In_ bool remove)
     {
         std::lock_guard<std::mutex> lock{ m_lock };
 
@@ -369,7 +369,7 @@ private:
         while (entry != &m_callbackHead)
         {
             CallbackRegistration* ce = CONTAINING_RECORD(entry, CallbackRegistration, ListEntry);
-            if (ce->Cookie == cookie)
+            if (ce->Token == token)
             {
                 found = ce;
 
@@ -393,7 +393,7 @@ private:
     static void CALLBACK OnQueueCallback(_In_ void* context)
     {
         CallbackInvocation* invocation = reinterpret_cast<CallbackInvocation*>(context);
-        CallbackRegistration* entry = invocation->Owner->Find(invocation->Cookie, false);
+        CallbackRegistration* entry = invocation->Owner->Find(invocation->Token, false);
         if (entry != nullptr)
         {
             CallbackDataType* payload;

--- a/Tests/UnitTests/Tests/AsyncQueueTests.cpp
+++ b/Tests/UnitTests/Tests/AsyncQueueTests.cpp
@@ -372,7 +372,7 @@ public:
     DEFINE_TEST_CASE(VerifySubmittedCallback)
     {
         AutoQueueHandle queue;
-        uint32_t token;
+        registration_token_t token;
         const DWORD workCount = 4;
         const DWORD completeCount = 7;
 
@@ -386,7 +386,7 @@ public:
 
         VERIFY_SUCCEEDED(CreateAsyncQueue(AsyncQueueDispatchMode_Manual, AsyncQueueDispatchMode_Manual, &queue));
 
-        VERIFY_SUCCEEDED(AddAsyncQueueCallbackSubmitted(queue, &submitCount, [](void* cxt, async_queue_handle_t, AsyncQueueCallbackType type)
+        VERIFY_SUCCEEDED(RegisterAsyncQueueCallbackSubmitted(queue, &submitCount, [](void* cxt, async_queue_handle_t, AsyncQueueCallbackType type)
         {
             SubmitCount* s = (SubmitCount*)cxt;
             if (type == AsyncQueueCallbackType_Work)
@@ -414,6 +414,6 @@ public:
         VERIFY_ARE_EQUAL(submitCount.Work, workCount);
         VERIFY_ARE_EQUAL(submitCount.Completion, completeCount);
 
-        RemoveAsyncQueueCallbackSubmitted(queue, token);
+        UnregisterAsyncQueueCallbackSubmitted(queue, token);
     }
 };


### PR DESCRIPTION
This PR addresses spec review feedback for the async lib.  Notably, notifications should use Register/Unregister instead of Add/Remove prefixes, and notification tokens should be their own type and called "token", not "cookie".