### PR TITLE
Websocket connect task should return S_OK even when the connection attempt fails

### DIFF
--- a/Source/Global/global.cpp
+++ b/Source/Global/global.cpp
@@ -71,8 +71,8 @@ HRESULT init_http_singleton(void* context)
     {
         IHCPlatformContext* platformContext = nullptr;
         hr = IHCPlatformContext::InitializeHttpPlatformContext(context, &platformContext);
-        
-        if (SUCCEEDED(hr)) 
+
+        if (SUCCEEDED(hr))
         {
             auto newSingleton = http_allocate_shared<http_singleton>(platformContext);
                 std::atomic_compare_exchange_strong(

--- a/Source/WebSocket/WinRT/winrt_websocket.cpp
+++ b/Source/WebSocket/WinRT/winrt_websocket.cpp
@@ -227,7 +227,7 @@ try
                 HC_TRACE_INFORMATION(WEBSOCKET, "Websocket [ID %llu] connect complete", websocket->id);
             }
 
-            CompleteAsync(asyncBlock, websocketTask->m_connectAsyncOpResult, sizeof(WebSocketCompletionResult));
+            CompleteAsync(asyncBlock, S_OK, sizeof(WebSocketCompletionResult));
         });
     }
     catch (Platform::Exception^ e)


### PR DESCRIPTION
The error code and platform error code are returned as part of the async result payload.  If the error code is E_FAIL, the payload is not returned.