### PR TITLE
Http header keys are case insensitive

### DIFF
--- a/Source/HTTP/httpcall.cpp
+++ b/Source/HTTP/httpcall.cpp
@@ -533,7 +533,7 @@ try
 }
 CATCH_RETURN()
 
-bool CaseInsensitiveStringCompare::operator()(http_internal_string const& l, http_internal_string const& r) const
+bool http_header_compare::operator()(http_internal_string const& l, http_internal_string const& r) const
 {
     return str_icmp(l, r) < 0;
 }

--- a/Source/HTTP/httpcall.cpp
+++ b/Source/HTTP/httpcall.cpp
@@ -532,3 +532,8 @@ try
     return S_OK;
 }
 CATCH_RETURN()
+
+bool CaseInsensitiveStringCompare::operator()(http_internal_string const& l, http_internal_string const& r) const
+{
+    return str_icmp(l, r) < 0;
+}

--- a/Source/HTTP/httpcall.h
+++ b/Source/HTTP/httpcall.h
@@ -4,6 +4,11 @@
 #pragma once
 #include "pch.h"
 
+struct CaseInsensitiveStringCompare
+{
+    bool operator()(http_internal_string const& l, http_internal_string const& r) const;
+};
+
 typedef struct HC_CALL
 {
     HC_CALL() :
@@ -27,11 +32,11 @@ typedef struct HC_CALL
     http_internal_string url;
     http_internal_vector<uint8_t> requestBodyBytes;
     http_internal_string requestBodyString;
-    http_internal_map<http_internal_string, http_internal_string> requestHeaders;
+    http_internal_map<http_internal_string, http_internal_string, CaseInsensitiveStringCompare> requestHeaders;
 
     http_internal_string responseString;
     http_internal_vector<uint8_t> responseBodyBytes;
-    http_internal_map<http_internal_string, http_internal_string> responseHeaders;
+    http_internal_map<http_internal_string, http_internal_string, CaseInsensitiveStringCompare> responseHeaders;
     uint32_t statusCode;
     HRESULT networkErrorCode;
     uint32_t platformNetworkErrorCode;

--- a/Source/HTTP/httpcall.h
+++ b/Source/HTTP/httpcall.h
@@ -4,10 +4,12 @@
 #pragma once
 #include "pch.h"
 
-struct CaseInsensitiveStringCompare
+struct http_header_compare
 {
     bool operator()(http_internal_string const& l, http_internal_string const& r) const;
 };
+
+using http_header_map = http_internal_map<http_internal_string, http_internal_string, http_header_compare>;
 
 typedef struct HC_CALL
 {
@@ -32,11 +34,11 @@ typedef struct HC_CALL
     http_internal_string url;
     http_internal_vector<uint8_t> requestBodyBytes;
     http_internal_string requestBodyString;
-    http_internal_map<http_internal_string, http_internal_string, CaseInsensitiveStringCompare> requestHeaders;
+    http_header_map requestHeaders;
 
     http_internal_string responseString;
     http_internal_vector<uint8_t> responseBodyBytes;
-    http_internal_map<http_internal_string, http_internal_string, CaseInsensitiveStringCompare> responseHeaders;
+    http_header_map responseHeaders;
     uint32_t statusCode;
     HRESULT networkErrorCode;
     uint32_t platformNetworkErrorCode;


### PR DESCRIPTION
Http header keys are case insensitive, make the header maps in HC_CALL use a case insensitive comparator