### PR TITLE
Detect if there's no network before attempting to make requests

### DIFF
--- a/Build/libHttpClient.141.Android.Java/app/src/main/java/com/xbox/httpClient/HttpClientRequest.java
+++ b/Build/libHttpClient.141.Android.Java/app/src/main/java/com/xbox/httpClient/HttpClientRequest.java
@@ -1,5 +1,8 @@
 package com.xbox.httpclient;
 
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.util.Log;
 
 import java.io.IOException;
@@ -18,6 +21,12 @@ public class HttpClientRequest {
 
     public HttpClientRequest() {
         requestBuilder = new Request.Builder();
+    }
+
+    public static boolean isNetworkAvailable(Context context) {
+        ConnectivityManager connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
+        return activeNetworkInfo != null && activeNetworkInfo.isConnected();
     }
 
     public static HttpClientRequest createClientRequest() {

--- a/Include/httpClient/httpClient.h
+++ b/Include/httpClient/httpClient.h
@@ -8,6 +8,9 @@
 #include <httpClient/async.h>
 #include <httpClient/asyncQueue.h>
 
+#if HC_PLATFORM == HC_PLATFORM_ANDROID
+#include "jni.h"
+#endif
 
 /////////////////////////////////////////////////////////////////////////////////////////
 // Memory APIs
@@ -702,3 +705,17 @@ hc_websocket_handle_t HCWebSocketDuplicateHandle(
 STDAPI HCWebSocketCloseHandle(
     _In_ hc_websocket_handle_t websocket
     ) HC_NOEXCEPT;
+
+/// <summary>
+/// Used to wrap the JavaVM and ApplicationContext on Android devices.
+/// </summary>
+#if HC_PLATFORM == HC_PLATFORM_ANDROID
+typedef struct _HC_PLATFORM_INIT_ARGS {
+	JavaVM *JavaVM;
+	jobject ApplicationContext;
+} HC_PLATFORM_INIT_ARGS;
+#else 
+typedef struct _HC_PLATFORM_INIT_ARGS {
+	void* dummy;
+} HC_PLATFORM_INIT_ARGS;
+#endif

--- a/Include/httpClient/httpClient.h
+++ b/Include/httpClient/httpClient.h
@@ -711,11 +711,11 @@ STDAPI HCWebSocketCloseHandle(
 /// </summary>
 #if HC_PLATFORM == HC_PLATFORM_ANDROID
 typedef struct _HC_PLATFORM_INIT_ARGS {
-	JavaVM *JavaVM;
-	jobject ApplicationContext;
+    JavaVM *JavaVM;
+    jobject ApplicationContext;
 } HC_PLATFORM_INIT_ARGS;
 #else 
 typedef struct _HC_PLATFORM_INIT_ARGS {
-	void* dummy;
+    void* dummy;
 } HC_PLATFORM_INIT_ARGS;
 #endif

--- a/Include/httpClient/pal.h
+++ b/Include/httpClient/pal.h
@@ -296,6 +296,7 @@ typedef struct _LIST_ENTRY {
 #define E_HC_PERFORM_ALREADY_CALLED     MAKE_E_HC(0x5003)
 #define E_HC_ALREADY_INITIALISED        MAKE_E_HC(0x5004)
 #define E_HC_CONNECT_ALREADY_CALLED     MAKE_E_HC(0x5005)
+#define E_HC_NO_NETWORK                 MAKE_E_HC(0x5006)
 
 typedef uint32_t hc_memory_type;
 typedef struct HC_WEBSOCKET* hc_websocket_handle_t;

--- a/Source/HTTP/Android/android_http_request.cpp
+++ b/Source/HTTP/Android/android_http_request.cpp
@@ -24,7 +24,6 @@ HRESULT HttpRequest::Initialize()
     JNIEnv* jniEnv = nullptr;
     HRESULT result = GetJniEnv(&jniEnv);
 
-
     if (SUCCEEDED(result)) 
     {
         jmethodID networkAvailabilityFunc = jniEnv->GetStaticMethodID(m_httpRequestClass, "isNetworkAvailable", "(Landroid/content/Context;)Z");

--- a/Source/HTTP/Android/android_http_request.cpp
+++ b/Source/HTTP/Android/android_http_request.cpp
@@ -4,10 +4,11 @@
 #include <httpClient/httpClient.h>
 #include <vector>
 
-HttpRequest::HttpRequest(AsyncBlock* asyncBlock, JavaVM* javaVm, jclass httpRequestClass, jclass httpResponseClass) :
+HttpRequest::HttpRequest(AsyncBlock* asyncBlock, JavaVM* javaVm, jobject applicationContext, jclass httpRequestClass, jclass httpResponseClass) :
     m_httpRequestInstance(nullptr), 
     m_asyncBlock(asyncBlock),
     m_javaVm(javaVm),
+	m_applicationContext(applicationContext),
     m_httpRequestClass(httpRequestClass),
     m_httpResponseClass(httpResponseClass)
 {
@@ -23,8 +24,23 @@ HRESULT HttpRequest::Initialize()
     JNIEnv* jniEnv = nullptr;
     HRESULT result = GetJniEnv(&jniEnv);
 
+
     if (SUCCEEDED(result)) 
     {
+        jmethodID networkAvailabilityFunc = jniEnv->GetStaticMethodID(m_httpRequestClass, "isNetworkAvailable", "(Landroid/content/Context;)Z");
+        if (networkAvailabilityFunc == nullptr)
+        {
+            HC_TRACE_ERROR(HTTPCLIENT, "Could not find isNetworkAvailable static method");
+            return E_FAIL;
+        }
+
+        jboolean isNetworkAvailable = jniEnv->CallStaticBooleanMethod(m_httpRequestClass, networkAvailabilityFunc, m_applicationContext);
+        if (!isNetworkAvailable)
+        {
+            HC_TRACE_ERROR(HTTPCLIENT, "Could not initialize HttpRequest - no network available");
+            return E_HC_NO_NETWORK;
+        }
+
         jmethodID httpRequestCtor = jniEnv->GetMethodID(m_httpRequestClass, "<init>", "()V");
         if (httpRequestCtor == nullptr) 
         {

--- a/Source/HTTP/Android/android_http_request.cpp
+++ b/Source/HTTP/Android/android_http_request.cpp
@@ -8,7 +8,7 @@ HttpRequest::HttpRequest(AsyncBlock* asyncBlock, JavaVM* javaVm, jobject applica
     m_httpRequestInstance(nullptr), 
     m_asyncBlock(asyncBlock),
     m_javaVm(javaVm),
-	m_applicationContext(applicationContext),
+    m_applicationContext(applicationContext),
     m_httpRequestClass(httpRequestClass),
     m_httpResponseClass(httpResponseClass)
 {

--- a/Source/HTTP/Android/android_http_request.h
+++ b/Source/HTTP/Android/android_http_request.h
@@ -4,7 +4,7 @@
 
 class HttpRequest {
 public:
-    HttpRequest(AsyncBlock* asyncBlock, JavaVM* javaVm, jclass httpRequestClass, jclass httpResponseClass);
+	HttpRequest(AsyncBlock* asyncBlock, JavaVM* javaVm, jobject applicationContext, jclass httpRequestClass, jclass httpResponseClass);
     virtual ~HttpRequest();
 
     HRESULT Initialize();
@@ -27,6 +27,7 @@ private:
     AsyncBlock* m_asyncBlock;
 
     JavaVM* m_javaVm;
+	jobject m_applicationContext;
     jclass m_httpRequestClass;
     jclass m_httpResponseClass;
 };

--- a/Source/HTTP/Android/android_http_request.h
+++ b/Source/HTTP/Android/android_http_request.h
@@ -4,7 +4,7 @@
 
 class HttpRequest {
 public:
-	HttpRequest(AsyncBlock* asyncBlock, JavaVM* javaVm, jobject applicationContext, jclass httpRequestClass, jclass httpResponseClass);
+    HttpRequest(AsyncBlock* asyncBlock, JavaVM* javaVm, jobject applicationContext, jclass httpRequestClass, jclass httpResponseClass);
     virtual ~HttpRequest();
 
     HRESULT Initialize();
@@ -27,7 +27,7 @@ private:
     AsyncBlock* m_asyncBlock;
 
     JavaVM* m_javaVm;
-	jobject m_applicationContext;
+    jobject m_applicationContext;
     jclass m_httpRequestClass;
     jclass m_httpResponseClass;
 };

--- a/Source/HTTP/Android/android_platform_context.cpp
+++ b/Source/HTTP/Android/android_platform_context.cpp
@@ -6,7 +6,8 @@
 HRESULT IHCPlatformContext::InitializeHttpPlatformContext(void* initialContext, IHCPlatformContext** platformContext)
 {
     assert(initialContext != nullptr);
-    JavaVM* javaVm = static_cast<JavaVM*>(initialContext);
+    HC_PLATFORM_INIT_ARGS* initArgs = static_cast<HC_PLATFORM_INIT_ARGS*>(initialContext);
+    JavaVM* javaVm = initArgs->JavaVM;
     JNIEnv* jniEnv = nullptr;
     // Java classes can only be resolved when we are on a Java-initiated thread. When we are on
     // a C++ background thread and attach to Java we do not have the full class-loader information.
@@ -37,12 +38,13 @@ HRESULT IHCPlatformContext::InitializeHttpPlatformContext(void* initialContext, 
     jclass globalRequestClass = reinterpret_cast<jclass>(jniEnv->NewGlobalRef(localHttpRequest));
     jclass globalResponseClass = reinterpret_cast<jclass>(jniEnv->NewGlobalRef(localHttpResponse));
 
-    *platformContext = new AndroidPlatformContext(javaVm, globalRequestClass, globalResponseClass);
+    *platformContext = new AndroidPlatformContext(javaVm, initArgs->ApplicationContext, globalRequestClass, globalResponseClass);
     return S_OK;
 }
 
-AndroidPlatformContext::AndroidPlatformContext(JavaVM* javaVm, jclass requestClass, jclass responseClass) :
+AndroidPlatformContext::AndroidPlatformContext(JavaVM* javaVm, jobject applicationContext, jclass requestClass, jclass responseClass) :
     m_javaVm{ javaVm },
+    m_applicationContext{ applicationContext },
     m_httpRequestClass{ requestClass },
     m_httpResponseClass{ responseClass }
 {

--- a/Source/HTTP/Android/android_platform_context.h
+++ b/Source/HTTP/Android/android_platform_context.h
@@ -6,15 +6,17 @@
 class AndroidPlatformContext : public IHCPlatformContext
 {
 public:
-    AndroidPlatformContext(JavaVM* javaVm, jclass requestClass, jclass responseClass);
+    AndroidPlatformContext(JavaVM* javaVm, jobject applicationContext, jclass requestClass, jclass responseClass);
     virtual ~AndroidPlatformContext();
 
     JavaVM* GetJavaVm() { return m_javaVm; }
+    jobject GetApplicationContext() { return m_applicationContext; }
     jclass GetHttpRequestClass() { return m_httpRequestClass; }
     jclass GetHttpResponseClass() { return m_httpResponseClass; }
 
 private:
     JavaVM * m_javaVm;
+    jobject m_applicationContext;
     jclass m_httpRequestClass;
     jclass m_httpResponseClass;
 };

--- a/Source/HTTP/Android/http_android.cpp
+++ b/Source/HTTP/Android/http_android.cpp
@@ -36,7 +36,16 @@ void Internal_HCHttpCallPerformAsync(
 {
     auto httpSingleton = xbox::httpclient::get_http_singleton(true);
     AndroidPlatformContext* platformContext = reinterpret_cast<AndroidPlatformContext*>(httpSingleton->m_platformContext.get());
-    std::unique_ptr<HttpRequest> httpRequest{ new HttpRequest(asyncBlock, platformContext->GetJavaVm(), platformContext->GetHttpRequestClass(), platformContext->GetHttpResponseClass()) };
+    std::unique_ptr<HttpRequest> httpRequest{
+        new HttpRequest(
+            asyncBlock,
+            platformContext->GetJavaVm(),
+            platformContext->GetApplicationContext(),
+            platformContext->GetHttpRequestClass(),
+            platformContext->GetHttpResponseClass()
+        )
+    };
+
     HRESULT result = httpRequest->Initialize();
 
     if (!SUCCEEDED(result))

--- a/Source/HTTP/httpcall.cpp
+++ b/Source/HTTP/httpcall.cpp
@@ -193,6 +193,11 @@ bool http_call_should_retry(
         return false;
     }
 
+	if (call->networkErrorCode == E_HC_NO_NETWORK)
+	{
+		return false;
+	}
+
     auto httpStatus = call->statusCode;
 
     if (httpStatus == 408 || // Request Timeout

--- a/Source/HTTP/httpcall.cpp
+++ b/Source/HTTP/httpcall.cpp
@@ -193,10 +193,10 @@ bool http_call_should_retry(
         return false;
     }
 
-	if (call->networkErrorCode == E_HC_NO_NETWORK)
-	{
-		return false;
-	}
+    if (call->networkErrorCode == E_HC_NO_NETWORK)
+    {
+        return false;
+    }
 
     auto httpStatus = call->statusCode;
 

--- a/Source/HTTP/iOS/http_ios.mm
+++ b/Source/HTTP/iOS/http_ios.mm
@@ -32,8 +32,14 @@ void ios_http_task::completion_handler(NSData* data, NSURLResponse* response, NS
     {
         uint32_t errorCode = static_cast<uint32_t>([error code]);
         HC_TRACE_ERROR(HTTPCLIENT, "HCHttpCallPerform [ID %u] error from NSURLRequest code: %u", HCHttpCallGetId(m_call), errorCode);
-        HCHttpCallResponseSetNetworkErrorCode(m_call, E_FAIL, errorCode);
-        CompleteAsync(m_asyncBlock, E_FAIL, 0);
+        HRESULT errorResult = E_FAIL;
+        if ([error code] == NSURLErrorNotConnectedToInternet)
+        {
+            errorResult = E_HC_NO_NETWORK;
+        }
+
+        HCHttpCallResponseSetNetworkErrorCode(m_call, errorResult, errorCode);
+        CompleteAsync(m_asyncBlock, errorResult, 0);
         return;
     }
     


### PR DESCRIPTION
Allowing libHttpClient to perform platform-dependent network detection before attempting to make requests. 

These platform calls ensure we are connected to some kind of network, regardless of whether or not that network is connected to the internet. Therefore, we should still retry as expected in transient network failures.