### PR TITLE
Fix missing definition of JVM

### DIFF
--- a/Source/Common/Android/utils_android.cpp
+++ b/Source/Common/Android/utils_android.cpp
@@ -6,6 +6,9 @@
 
 NAMESPACE_XBOX_HTTP_CLIENT_BEGIN
 
+// TODO this code needs reworking as it does not quite do the right thing at the moment
+std::atomic<JavaVM*> JVM{ nullptr };
+
 static void abort_if_no_jvm()
 {
     if (JVM == nullptr)


### PR DESCRIPTION
This change allows the android build to link, but does not actually make it work.