### PR TITLE
Fixing issue where websockets caused exception on Android

### DIFF
--- a/Source/WebSocket/Websocketpp/websocketpp_websocket.cpp
+++ b/Source/WebSocket/Websocketpp/websocketpp_websocket.cpp
@@ -23,7 +23,9 @@
 #include <websocketpp/config/asio_client.hpp>
 #include <websocketpp/config/asio_no_tls_client.hpp>
 #include <websocketpp/client.hpp>
+#if HC_PLATFORM == HC_PLATFORM_ANDROID
 #include "../HTTP/Android/android_platform_context.h"
+#endif
 
 #if defined(_WIN32)
 #pragma warning( pop )

--- a/Source/WebSocket/Websocketpp/websocketpp_websocket.cpp
+++ b/Source/WebSocket/Websocketpp/websocketpp_websocket.cpp
@@ -394,9 +394,12 @@ private:
                 
                 m_websocketThread = std::thread([context](){
 #if HC_PLATFORM == HC_PLATFORM_ANDROID
-                    auto httpSingleton = xbox::httpclient::get_http_singleton(true);
-                    AndroidPlatformContext* platformContext = reinterpret_cast<AndroidPlatformContext*>(httpSingleton->m_platformContext.get());
-                    JavaVM* javaVm = platformContext->GetJavaVm();
+                    JavaVM* javaVm = nullptr;
+                    {   // Allow our singleton to go out of scope quickly once we're done with it
+                        auto httpSingleton = xbox::httpclient::get_http_singleton(true);
+                        AndroidPlatformContext* platformContext = reinterpret_cast<AndroidPlatformContext*>(httpSingleton->m_platformContext.get());
+                        javaVm = platformContext->GetJavaVm();
+                    }
 
                     if (javaVm == nullptr)
                     {


### PR DESCRIPTION
New threads need to be managed by the Java VM during their lifetime