### PR TITLE
Add stress test, work around live lock issue in async queue.

### DIFF
--- a/Source/Task/AsyncLib.cpp
+++ b/Source/Task/AsyncLib.cpp
@@ -766,6 +766,10 @@ STDAPI ScheduleAsync(
         state.Get(),
         WorkerCallback));
 
+    // NOTE: The callback now owns the state ref.  It could have run
+    // already, and state may be holding a dead pointer.  Regardless,
+    // state should be detached here as it no longer owns
+    // the ref.  
     state.Detach();
     return S_OK;
 }


### PR DESCRIPTION
This change adds a stress test that creates 20,000 async calls at once to flush out some timing issues we have under load.  This test also uncovered a live lock in the new "lockless" async queue logic that can cause queue removals to fight against each other and forever spin.

We are redesigning the queue data structures to be more lock-free, so for now I have just coded a work-around that takes a lock for removal, which is what the queue used to do before we tried to make it lock free.

I also ditched "spinlock" which can cause processor starvation if the same core is waiting on the same spinlock.  Switching back to std::mutex for reliability.