### PR TITLE
Enabling bitcode in apple library

### DIFF
--- a/Build/libHttpClient.Apple.C/libHttpClient.xcodeproj/project.pbxproj
+++ b/Build/libHttpClient.Apple.C/libHttpClient.xcodeproj/project.pbxproj
@@ -602,6 +602,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "-fembed-bitcode-marker";
 				SDKROOT = macosx;
 			};
 			name = Debug;
@@ -655,6 +656,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CFLAGS = "-fembed-bitcode";
 				SDKROOT = macosx;
 			};
 			name = Release;


### PR DESCRIPTION
Without embedding bitcode, the resulting IPA that links in libHttpClient will not be able to be archived or submitted to the app store.