### PR TITLE
Fix termination and composite queues for XAL

### DIFF
--- a/Build/libHttpClient.140.UWP.C/libHttpClient.140.UWP.C.vcxproj
+++ b/Build/libHttpClient.140.UWP.C/libHttpClient.140.UWP.C.vcxproj
@@ -148,6 +148,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\lhc_mock.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\mock_publics.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AsyncLib.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AtomicVector.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\LocklessList.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\StaticArray.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\TaskQueue.cpp" />

--- a/Build/libHttpClient.140.UWP.C/libHttpClient.140.UWP.C.vcxproj.filters
+++ b/Build/libHttpClient.140.UWP.C/libHttpClient.140.UWP.C.vcxproj.filters
@@ -138,6 +138,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\lhc_mock.h">
       <Filter>C++ Source\Mock</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AtomicVector.h">
+      <Filter>C++ Source\Task</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\LocklessList.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>

--- a/Build/libHttpClient.140.Win32.C/libHttpClient.140.Win32.C.vcxproj
+++ b/Build/libHttpClient.140.Win32.C/libHttpClient.140.Win32.C.vcxproj
@@ -131,6 +131,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\lhc_mock.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\mock_publics.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AsyncLib.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AtomicVector.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\LocklessList.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\StaticArray.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\TaskQueue.cpp" />

--- a/Build/libHttpClient.140.Win32.C/libHttpClient.140.Win32.C.vcxproj.filters
+++ b/Build/libHttpClient.140.Win32.C/libHttpClient.140.Win32.C.vcxproj.filters
@@ -114,6 +114,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\lhc_mock.h">
       <Filter>C++ Source\Mock</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AtomicVector.h">
+      <Filter>C++ Source\Task</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\LocklessList.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>

--- a/Build/libHttpClient.140.XDK.C/libHttpClient.140.XDK.C.vcxproj
+++ b/Build/libHttpClient.140.XDK.C/libHttpClient.140.XDK.C.vcxproj
@@ -120,6 +120,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\lhc_mock.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\mock_publics.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AsyncLib.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AtomicVector.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\LocklessList.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\StaticArray.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\TaskQueue.cpp" />

--- a/Build/libHttpClient.140.XDK.C/libHttpClient.140.XDK.C.vcxproj.filters
+++ b/Build/libHttpClient.140.XDK.C/libHttpClient.140.XDK.C.vcxproj.filters
@@ -138,6 +138,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\lhc_mock.h">
       <Filter>C++ Source\Mock</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AtomicVector.h">
+      <Filter>C++ Source\Task</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\LocklessList.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>

--- a/Build/libHttpClient.141.Android.C/libHttpClient.141.Android.C.vcxproj
+++ b/Build/libHttpClient.141.Android.C/libHttpClient.141.Android.C.vcxproj
@@ -105,6 +105,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\lhc_mock.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\mock_publics.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AsyncLib.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AtomicVector.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\LocklessList.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\StaticArray.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\TaskQueue.cpp" />

--- a/Build/libHttpClient.141.Android.C/libHttpClient.141.Android.C.vcxproj.filters
+++ b/Build/libHttpClient.141.Android.C/libHttpClient.141.Android.C.vcxproj.filters
@@ -123,6 +123,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\lhc_mock.h">
       <Filter>C++ Source\Mock</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AtomicVector.h">
+      <Filter>C++ Source\Task</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\LocklessList.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>

--- a/Build/libHttpClient.141.UWP.C/libHttpClient.141.UWP.C.vcxproj
+++ b/Build/libHttpClient.141.UWP.C/libHttpClient.141.UWP.C.vcxproj
@@ -148,6 +148,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\lhc_mock.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\mock_publics.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AsyncLib.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AtomicVector.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\LocklessList.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\StaticArray.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\TaskQueue.cpp" />

--- a/Build/libHttpClient.141.UWP.C/libHttpClient.141.UWP.C.vcxproj.filters
+++ b/Build/libHttpClient.141.UWP.C/libHttpClient.141.UWP.C.vcxproj.filters
@@ -138,6 +138,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\lhc_mock.h">
       <Filter>C++ Source\Mock</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AtomicVector.h">
+      <Filter>C++ Source\Task</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\LocklessList.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>

--- a/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj
+++ b/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj
@@ -131,6 +131,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\lhc_mock.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\mock_publics.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AsyncLib.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AtomicVector.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\LocklessList.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\StaticArray.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\TaskQueue.cpp" />

--- a/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj.filters
+++ b/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj.filters
@@ -114,6 +114,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\lhc_mock.h">
       <Filter>C++ Source\Mock</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AtomicVector.h">
+      <Filter>C++ Source\Task</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\LocklessList.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>

--- a/Build/libHttpClient.141.XDK.C/libHttpClient.141.XDK.C.vcxproj
+++ b/Build/libHttpClient.141.XDK.C/libHttpClient.141.XDK.C.vcxproj
@@ -120,6 +120,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\lhc_mock.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\mock_publics.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AsyncLib.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AtomicVector.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\LocklessList.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\StaticArray.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\TaskQueue.cpp" />

--- a/Build/libHttpClient.141.XDK.C/libHttpClient.141.XDK.C.vcxproj.filters
+++ b/Build/libHttpClient.141.XDK.C/libHttpClient.141.XDK.C.vcxproj.filters
@@ -138,6 +138,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\lhc_mock.h">
       <Filter>C++ Source\Mock</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AtomicVector.h">
+      <Filter>C++ Source\Task</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\LocklessList.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>

--- a/Build/libHttpClient.Apple.C/libHttpClient.xcodeproj/project.pbxproj
+++ b/Build/libHttpClient.Apple.C/libHttpClient.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		D3C5B553214848B6004BE1FF /* ios_WaitTimer_target.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ios_WaitTimer_target.mm; sourceTree = "<group>"; };
 		D3C5B554214848B6004BE1FF /* ios_WaitTimer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ios_WaitTimer.mm; sourceTree = "<group>"; };
 		D3C5B55821484A8A004BE1FF /* ios_WaitTimerImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ios_WaitTimerImpl.h; sourceTree = "<group>"; };
+		D3C6513F21DA3C4D002A8F59 /* AtomicVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AtomicVector.h; sourceTree = "<group>"; };
 		D3DAA84721C0E4090009C7F6 /* XTaskQueuePriv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XTaskQueuePriv.h; sourceTree = "<group>"; };
 		D3DAA84821C0E4090009C7F6 /* TaskQueueP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TaskQueueP.h; sourceTree = "<group>"; };
 		D3DAA84921C0E4090009C7F6 /* TaskQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TaskQueue.cpp; sourceTree = "<group>"; };
@@ -265,6 +266,7 @@
 		58A7E9AD209ADEB100CC6774 /* Task */ = {
 			isa = PBXGroup;
 			children = (
+				D3C6513F21DA3C4D002A8F59 /* AtomicVector.h */,
 				D3DAA85021C0E4090009C7F6 /* LocklessList.h */,
 				D3DAA84A21C0E4090009C7F6 /* referenced_ptr.h */,
 				D3DAA84B21C0E4090009C7F6 /* StaticArray.h */,

--- a/Build/libHttpClient.UnitTest.141.TAEF/libHttpClient.UnitTest.141.TAEF.vcxproj
+++ b/Build/libHttpClient.UnitTest.141.TAEF/libHttpClient.UnitTest.141.TAEF.vcxproj
@@ -135,6 +135,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\lhc_mock.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\mock_publics.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AsyncLib.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AtomicVector.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\LocklessList.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\StaticArray.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\TaskQueue.cpp" />

--- a/Build/libHttpClient.UnitTest.141.TAEF/libHttpClient.UnitTest.141.TAEF.vcxproj.filters
+++ b/Build/libHttpClient.UnitTest.141.TAEF/libHttpClient.UnitTest.141.TAEF.vcxproj.filters
@@ -138,6 +138,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\lhc_mock.h">
       <Filter>C++ Source\Mock</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AtomicVector.h">
+      <Filter>C++ Source\Task</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\LocklessList.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>

--- a/Build/libHttpClient.UnitTest.141.TE/libHttpClient.UnitTest.141.TE.vcxproj
+++ b/Build/libHttpClient.UnitTest.141.TE/libHttpClient.UnitTest.141.TE.vcxproj
@@ -211,6 +211,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\lhc_mock.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\mock_publics.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AsyncLib.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AtomicVector.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\LocklessList.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\StaticArray.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\TaskQueue.cpp" />

--- a/Build/libHttpClient.UnitTest.141.TE/libHttpClient.UnitTest.141.TE.vcxproj.filters
+++ b/Build/libHttpClient.UnitTest.141.TE/libHttpClient.UnitTest.141.TE.vcxproj.filters
@@ -135,6 +135,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\lhc_mock.h">
       <Filter>C++ Source\Mock</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AtomicVector.h">
+      <Filter>C++ Source\Task</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\LocklessList.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>

--- a/Source/Task/AtomicVector.h
+++ b/Source/Task/AtomicVector.h
@@ -1,0 +1,77 @@
+
+// Copyright (c) Microsoft Corporation
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma once
+
+// A wrapper around a vector that allows lock-free enumeration of the
+// contents.  Add/Remove requires a lock.
+template <class TElement>
+class AtomicVector
+{
+public:
+
+    typedef void VisitCallback(_In_ void*, _In_ TElement);
+    typedef bool RemovePredicate(_In_ void*, _In_ TElement);
+
+    HRESULT Add(_In_ const TElement value) try
+    {
+        std::lock_guard<std::mutex> lock(m_lock);
+        uint32_t bufferReadIdx = (m_indexAndRef & 0x80000000 ? 1 : 0);
+        uint32_t bufferWriteIdx = 1 - bufferReadIdx;
+
+        m_buffers[bufferWriteIdx] = m_buffers[bufferReadIdx];
+        m_buffers[bufferWriteIdx].emplace_back(value);
+
+        // Now spin wait to swap the active buffer.
+        uint32_t expected = bufferReadIdx << 31;
+        uint32_t desired = bufferWriteIdx << 31;
+
+        while (!m_indexAndRef.compare_exchange_weak(expected, desired)) {}
+
+        return S_OK;
+    } CATCH_RETURN();
+
+    void Remove(_In_ void* context, _In_ RemovePredicate* predicate)
+    {
+        std::lock_guard<std::mutex> lock(m_lock);
+        uint32_t bufferReadIdx = (m_indexAndRef & 0x80000000 ? 1 : 0);
+        uint32_t bufferWriteIdx = 1 - bufferReadIdx;
+
+        m_buffers[bufferWriteIdx] = m_buffers[bufferReadIdx];
+
+        for (auto it = m_buffers[bufferWriteIdx].begin(); it != m_buffers[bufferWriteIdx].end(); it++)
+        {
+            if (predicate(context, *it))
+            {
+                m_buffers[bufferWriteIdx].erase(it);
+                break;
+            }
+        }
+
+        // Now spin wait to swap the active buffer.
+        uint32_t expected = bufferReadIdx << 31;
+        uint32_t desired = bufferWriteIdx << 31;
+
+        while (!m_indexAndRef.compare_exchange_weak(expected, desired)) {}
+    }
+
+    void Visit(_In_ void* context, _In_ VisitCallback* callback)
+    {
+        uint32_t indexAndRef = ++m_indexAndRef;
+        uint32_t bufferIdx = (indexAndRef & 0x80000000 ? 1 : 0);
+
+        for (auto const &it : m_buffers[bufferIdx])
+        {
+            callback(context, it);
+        }
+
+        m_indexAndRef--;
+    }
+
+private:
+
+    std::mutex m_lock;
+    std::vector<TElement> m_buffers[2];
+    std::atomic<uint32_t> m_indexAndRef = { 0 };
+};

--- a/Source/Task/LocklessList.h
+++ b/Source/Task/LocklessList.h
@@ -105,6 +105,7 @@ public:
         m_head = reinterpret_cast<std::uintptr_t>(&m_initialNode);
         m_tail = reinterpret_cast<std::uintptr_t>(&m_initialNode);;
         m_initialNode.next = 0;
+        m_initialNode.data = nullptr;
         ASSERT((m_head & 0x1F) == 0); // Alignment problem
     }
     

--- a/Source/Task/LocklessList.h
+++ b/Source/Task/LocklessList.h
@@ -119,7 +119,7 @@ public:
         }
     }
     
-    // Returns true if we believve the list is empty.
+    // Returns true if we believe the list is empty.
     bool empty() noexcept
     {
         return ToNode(m_head) == ToNode(m_tail);

--- a/Source/Task/TaskQueue.cpp
+++ b/Source/Task/TaskQueue.cpp
@@ -468,6 +468,7 @@ HRESULT __stdcall TaskQueuePortImpl::PrepareTerminate(
 
     term->context = context;
     term->callback = callback;
+    term->owner = owner;
     term->node = node.release();
 
     // Mark the port as canceled, but don't overwrite

--- a/Source/Task/TaskQueueImpl.h
+++ b/Source/Task/TaskQueueImpl.h
@@ -37,7 +37,7 @@ public:
         {
             m_refs++;
             FinalRelease();
-            refs = m_refs--;
+            refs = --m_refs;
             if (refs == 0)
             {
                 delete this;
@@ -93,7 +93,7 @@ public:
 
     HRESULT Register(_In_ void* context, _In_ XTaskQueueMonitorCallback* callback, _Out_ XTaskQueueRegistrationToken* token);
     void Unregister(_In_ XTaskQueueRegistrationToken token);
-    void Invoke(_In_ ITaskQueuePortContext* portContext);
+    void Invoke(_In_ XTaskQueuePort port);
 
 private:
 
@@ -152,6 +152,7 @@ public:
 
     HRESULT Initialize(
         _In_ XTaskQueueDispatchMode mode,
+        _In_ XTaskQueuePort nativePort,
         _Out_ SubmitCallback* submitCallback);
 
     XTaskQueuePortHandle __stdcall GetHandle() { return &m_header; }
@@ -236,6 +237,7 @@ private:
 
     XTaskQueuePortObject m_header = { };
     XTaskQueueDispatchMode m_dispatchMode = XTaskQueueDispatchMode::Manual;
+    XTaskQueuePort m_nativePort;
     SubmitCallback* m_callbackSubmitted = nullptr;
     std::atomic<uint32_t> m_processingCallback{ 0 };
     std::condition_variable_any m_event;
@@ -286,7 +288,7 @@ private:
 
     void SignalQueue();
 
-    void ProcessThreadPoolCallback();
+    void ProcessThreadPoolCallback(_In_ ThreadPoolActionComplete& complete);
 
 #ifdef _WIN32
     HRESULT InitializeWaitRegistration(

--- a/Source/Task/TaskQueueImpl.h
+++ b/Source/Task/TaskQueueImpl.h
@@ -230,6 +230,7 @@ private:
         ITaskQueuePortContext* portContext;
         TaskQueuePortImpl* port;
         QueueEntry* queueEntry;
+        std::atomic_flag appended;
     };
 #endif
 
@@ -293,6 +294,7 @@ private:
 
     bool AppendWaitRegistrationEntry(
         _In_ WaitRegistration* waitReg,
+        _In_ bool addRef = true,
         _In_ bool signal = true);
 
     void ProcessWaitCallback(
@@ -311,13 +313,8 @@ class TaskQueuePortContextImpl : public ITaskQueuePortContext
 public:
     
     TaskQueuePortContextImpl(
-        _In_ XTaskQueuePort port) : m_type(port)
-    {
-    }
-    
-    void Initialize(
         _In_ ITaskQueue* queue,
-        _In_ XTaskQueuePort port);
+        _In_ XTaskQueuePort type);
     
     uint32_t __stdcall AddRef() override;
     uint32_t __stdcall Release() override;

--- a/Source/Task/TaskQueueP.h
+++ b/Source/Task/TaskQueueP.h
@@ -59,6 +59,9 @@ struct ITaskQueuePort: IApi
 
     virtual void __stdcall Terminate(
         _In_ void* token) = 0;
+
+    virtual HRESULT __stdcall Attach(
+        _In_ ITaskQueuePortContext* portContext) = 0;
     
     virtual void __stdcall Detach(
         _In_ ITaskQueuePortContext* portContext) = 0;
@@ -97,6 +100,8 @@ struct ITaskQueuePortContext : IApi
     
     virtual void __stdcall SetStatus(
         _In_ TaskQueuePortStatus status) = 0;
+
+    virtual void __stdcall ItemQueued() = 0;
 };
 
 // The task queue.  The public flat API is built entirely on

--- a/Source/Task/ThreadPool.h
+++ b/Source/Task/ThreadPool.h
@@ -1,6 +1,11 @@
 #pragma once
 
-using ThreadPoolCallback = void(_In_opt_ void*);
+struct ThreadPoolActionComplete
+{
+    virtual void operator()() = 0;
+};
+
+using ThreadPoolCallback = void(_In_opt_ void*, _In_ ThreadPoolActionComplete& complete);
 
 class ThreadPoolImpl;
 

--- a/Source/Task/ThreadPool_win32.cpp
+++ b/Source/Task/ThreadPool_win32.cpp
@@ -17,8 +17,11 @@ public:
         m_context = context;
         m_callback = callback;
         m_work = CreateThreadpoolWork(TPCallback, this, nullptr);
-
         RETURN_LAST_ERROR_IF_NULL(m_work);
+
+        InitializeCriticalSection(&m_cs);
+        InitializeConditionVariable(&m_cv);
+
         return S_OK;
     }
 
@@ -26,14 +29,28 @@ public:
     {
         if (m_work != nullptr)
         {
-            WaitForThreadpoolWorkCallbacks(m_work, TRUE);
+            // We cannot wait for work callbacks to complete because
+            // the final release may be called from within the callback.
+            // We know when our callbacks are invoking user code however,
+            // and we block on that.
+            EnterCriticalSection(&m_cs);
+
+            while (m_calls != 0)
+            {
+                SleepConditionVariableCS(&m_cv, &m_cs, INFINITE);
+            }
+
+            LeaveCriticalSection(&m_cs);
+
             CloseThreadpoolWork(m_work);
             m_work = nullptr;
+            DeleteCriticalSection(&m_cs);
         }
     }
 
     void Submit() noexcept
     {
+        m_calls++;
         SubmitThreadpoolWork(m_work);
     }
 
@@ -44,11 +61,42 @@ private:
         _In_ void* context, PTP_WORK) noexcept
     {
         ThreadPoolImpl* pthis = static_cast<ThreadPoolImpl*>(context);
-        pthis->m_callback(pthis->m_context);
+
+        ActionCompleteImpl ac(pthis);
+        pthis->m_callback(pthis->m_context, ac);
+
+        if (!ac.Invoked)
+        {
+            pthis->m_calls--;
+            WakeAllConditionVariable(&pthis->m_cv);
+        }
     }
 
+    struct ActionCompleteImpl : ThreadPoolActionComplete
+    {
+        ActionCompleteImpl(ThreadPoolImpl* owner) :
+            m_owner(owner)
+        {
+        }
+
+        bool Invoked = false;
+
+        void operator()() override
+        {
+            Invoked = true;
+            m_owner->m_calls--;
+            WakeAllConditionVariable(&m_owner->m_cv);
+        }
+
+    private:
+        ThreadPoolImpl* m_owner = nullptr;
+    };
+
+    CONDITION_VARIABLE m_cv;
+    CRITICAL_SECTION m_cs;
     PTP_WORK m_work = nullptr;
     void* m_context = nullptr;
+    std::atomic<uint32_t> m_calls = { 0 };
     ThreadPoolCallback* m_callback = nullptr;
 };
 

--- a/Tests/UnitTests/Tests/LocklessListTests.cpp
+++ b/Tests/UnitTests/Tests/LocklessListTests.cpp
@@ -193,4 +193,62 @@ public:
             VERIFY_IS_TRUE(ops[idx]);
         }
     }
+
+    TEST_METHOD(VerifyRemoveAndReAdd)
+    {
+        LocklessList<uint32_t> list;
+        const uint32_t total = 10;
+
+        for (uint32_t idx = 0; idx < total; idx++)
+        {
+            uint32_t* n = new uint32_t(idx);
+            VERIFY_IS_TRUE(list.push_back(n));
+        }
+
+        uint32_t* initial = nullptr;
+        uint32_t evenCount = 0;
+        uint32_t evenPushCount = 0;
+        uint32_t oddCount = 0;
+
+        uint32_t* node = list.pop_front();
+        while (node != nullptr)
+        {
+            if (node == initial)
+            {
+                list.push_back(node);
+                break;
+            }
+
+            if ((*node) & 1)
+            {
+                oddCount++;
+                delete node;
+            }
+            else
+            {
+                if (initial == nullptr)
+                {
+                    initial = node;
+                }
+                list.push_back(node);
+                evenPushCount++;
+            }
+
+            node = list.pop_front();
+        }
+
+        // Now pop off what's left - they should be all the
+        // evens.
+        node = list.pop_front();
+        while (node != nullptr)
+        {
+            VERIFY_ARE_EQUAL(0u, ((*node) & 1u));
+            delete node;
+            evenCount++;
+            node = list.pop_front();
+        }
+
+        VERIFY_ARE_EQUAL(oddCount, evenPushCount);
+        VERIFY_ARE_EQUAL(oddCount, evenCount);
+    }
 };

--- a/Tests/UnitTests/Tests/TaskQueueTests.cpp
+++ b/Tests/UnitTests/Tests/TaskQueueTests.cpp
@@ -1093,6 +1093,6 @@ public:
         while (XTaskQueueDispatch(compositeQueue, XTaskQueuePort::Completion, 100));
 
         VERIFY_ARE_EQUAL(queuePort, XTaskQueuePort::Work);
-        VERIFY_ARE_EQUAL(compositeQueuePort, (XTaskQueuePort)(-1)); // composite queues don't monitor;
+        VERIFY_ARE_EQUAL(compositeQueuePort, XTaskQueuePort::Completion);
     }
 };

--- a/Tests/UnitTests/Tests/TaskQueueTests.cpp
+++ b/Tests/UnitTests/Tests/TaskQueueTests.cpp
@@ -994,7 +994,7 @@ public:
         {
             TestData* pd = (TestData*)context;
             pd->queueTerminated = true;
-            //XTaskQueueCloseHandle(pd->queue.Release());
+            XTaskQueueCloseHandle(pd->queue.Release());
         };
 
         data.CompletionCallback = completionCallback;
@@ -1093,6 +1093,6 @@ public:
         while (XTaskQueueDispatch(compositeQueue, XTaskQueuePort::Completion, 100));
 
         VERIFY_ARE_EQUAL(queuePort, XTaskQueuePort::Work);
-        VERIFY_ARE_EQUAL(compositeQueuePort, XTaskQueuePort::Completion);
+        VERIFY_ARE_EQUAL(compositeQueuePort, (XTaskQueuePort)(-1)); // composite queues don't monitor;
     }
 };

--- a/Utilities/CMake/CMakeLists.txt
+++ b/Utilities/CMake/CMakeLists.txt
@@ -94,6 +94,7 @@ set(Public_Source_Files
 
 set(Task_Source_Files
     ../../../Source/Task/AsyncLib.cpp
+    ../../../Source/Task/AtomicVector.h
     ../../../Source/Task/LocklessList.h
     ../../../Source/Task/referenced_ptr.h
     ../../../Source/Task/StaticArray.h


### PR DESCRIPTION
There are a couple of issues with termination on Task Queue, especially when combined with composite queues:

1. Terminating a composite queue terminates the master queue.  This was by design, but XAL is using this pattern.  Terminating a composite now only affects that queue and leaves the master intact.
2. Closing a queue in a termination callback would deadlock waiting for the callback to complete.  