### PR TITLE
Add Begin opcode to async provider

### DIFF
--- a/Include/XAsyncProvider.h
+++ b/Include/XAsyncProvider.h
@@ -14,6 +14,14 @@ extern "C"
 enum class XAsyncOp : uint32_t
 {
     /// <summary>
+    /// An async provider is invoked with this opcode during XAsyncBegin or XAsyncBeginAlloc.
+    /// If the provider implements this op code, they should start their asynchronous task,
+    /// either by calling XAsyncSchedule or through exterior means.  This callback is
+    /// called synchronously in the XAsyncBegin call chain, so it should never block.
+    /// </summary>
+    Begin,
+
+    /// <summary>
     /// An async provider is invoked with this opcode when XAsyncSchedule has been called to
     /// schedule work. Implementations should perform their asynchronous work and then call
     /// XAsyncComplete with the data payload size. If additional work needs to be done they

--- a/Source/Task/AsyncLib.cpp
+++ b/Source/Task/AsyncLib.cpp
@@ -647,6 +647,16 @@ STDAPI XAsyncBegin(
     state->identity = identity;
     state->identityName = identityName;
 
+    // We've successfully setup the call.  Now kick off a
+    // Begin opcode.  If this call fails, we use it to fail
+    // the async call, instead of failing XAsyncBegin.
+
+    HRESULT hr = provider(XAsyncOp::Begin, &state->providerData);
+    if (FAILED(hr))
+    {
+        XAsyncComplete(asyncBlock, hr, 0);
+    }
+
     return S_OK;
 }
 
@@ -694,6 +704,16 @@ STDAPI XAsyncBeginAlloc(
     ASSERT(state->providerData.context != nullptr);
     memset(state->providerData.context, 0, contextSize);
     *context = state->providerData.context;
+
+    // We've successfully setup the call.  Now kick off a
+    // Begin opcode.  If this call fails, we use it to fail
+    // the async call, instead of failing XAsyncBegin.
+    
+    HRESULT hr = provider(XAsyncOp::Begin, &state->providerData);
+    if (FAILED(hr))
+    {
+        XAsyncComplete(asyncBlock, hr, 0);
+    }
 
     return S_OK;
 }


### PR DESCRIPTION
Adding this opcode allows async implementations to be entirely started / controlled by the async provider callback.