### PR TITLE
Fix for nested queue close w/delayed callbacks

### DIFF
--- a/Source/Task/TaskQueue.cpp
+++ b/Source/Task/TaskQueue.cpp
@@ -759,6 +759,7 @@ void TaskQueuePortImpl::CancelPendingEntries(
     // are placed back on the pending list.
     
     m_timer.Cancel();
+    m_timerDue = UINT64_MAX;
     
     QueueEntryNode* queueEntryNode;
     QueueEntry* queueEntry = m_pendingList->pop_front(&queueEntryNode);


### PR DESCRIPTION
This fixes a bug Luca found where if you have a delayed callback in a task queue and you close a composite queue the delayed callback can fire immediately.  This happened because when canceling the callback timer for queue rundown we didn't clear the due time field, so when we started the timer back up we thought the call at the head of the list was due.

Other changes:

* Rundown logic at final release hardened.  It was possible to race here and rundown a queue that wasn't destined to die.
* Additional tests.
* Fix tests for added Begin opcode.  