### PR TITLE
Switching to std::recursive_mutex

### DIFF
--- a/Source/Global/global.cpp
+++ b/Source/Global/global.cpp
@@ -105,7 +105,7 @@ void http_singleton::set_retry_state(
     _In_ uint32_t retryAfterCacheId,
     _In_ const http_retry_after_api_state& state)
 {
-    std::lock_guard<std::mutex> lock(m_retryAfterCacheLock); // STL is not safe for multithreaded writes
+    std::lock_guard<std::recursive_mutex> lock(m_retryAfterCacheLock); // STL is not safe for multithreaded writes
     http_retry_after_api_state oldstate = get_retry_state(retryAfterCacheId);
     if (oldstate.statusCode < 400)
     {
@@ -130,7 +130,7 @@ http_retry_after_api_state http_singleton::get_retry_state(_In_ uint32_t retryAf
 
 void http_singleton::clear_retry_state(_In_ uint32_t retryAfterCacheId)
 {
-    std::lock_guard<std::mutex> lock(m_retryAfterCacheLock); // STL is not safe for multithreaded writes
+    std::lock_guard<std::recursive_mutex> lock(m_retryAfterCacheLock); // STL is not safe for multithreaded writes
     m_retryAfterCache.erase(retryAfterCacheId);
 }
 

--- a/Source/Global/global.h
+++ b/Source/Global/global.h
@@ -39,15 +39,15 @@ typedef struct http_singleton
     http_singleton(PerformInfo const& performInfo, PerformEnv&& performEnv);
     ~http_singleton();
 
-    std::mutex m_singletonLock;
+    std::recursive_mutex m_singletonLock;
 
-    std::mutex m_retryAfterCacheLock;
+    std::recursive_mutex m_retryAfterCacheLock;
     std::unordered_map<uint32_t, http_retry_after_api_state> m_retryAfterCache;
     void set_retry_state(_In_ uint32_t retryAfterCacheId, _In_ const http_retry_after_api_state& state);
     http_retry_after_api_state get_retry_state(_In_ uint32_t retryAfterCacheId);
     void clear_retry_state(_In_ uint32_t retryAfterCacheId);
 
-    std::mutex m_callRoutedHandlersLock;
+    std::recursive_mutex m_callRoutedHandlersLock;
     std::atomic<int32_t> m_callRoutedHandlersContext = 0;
     http_internal_unordered_map<int32_t, std::pair<HCCallRoutedHandler, void*>> m_callRoutedHandlers;
 
@@ -72,7 +72,7 @@ typedef struct http_singleton
 #endif
 
     // Mock state
-    std::mutex m_mocksLock;
+    std::recursive_mutex m_mocksLock;
     http_internal_vector<HC_CALL*> m_mocks;
     HC_CALL* m_lastMatchingMock = nullptr;
     bool m_mocksEnabled = false;

--- a/Source/Global/global_publics.cpp
+++ b/Source/Global/global_publics.cpp
@@ -91,7 +91,7 @@ STDAPI_(int32_t) HCAddCallRoutedHandler(
     if (nullptr == httpSingleton)
         return E_HC_NOT_INITIALISED;
 
-    std::lock_guard<std::mutex> lock(httpSingleton->m_callRoutedHandlersLock);
+    std::lock_guard<std::recursive_mutex> lock(httpSingleton->m_callRoutedHandlersLock);
     auto functionContext = httpSingleton->m_callRoutedHandlersContext++;
     httpSingleton->m_callRoutedHandlers[functionContext] = std::make_pair(handler, context);
     return functionContext;
@@ -104,7 +104,7 @@ STDAPI_(void) HCRemoveCallRoutedHandler(
     auto httpSingleton = get_http_singleton(true);
     if (nullptr != httpSingleton)
     {
-        std::lock_guard<std::mutex> lock(httpSingleton->m_callRoutedHandlersLock);
+        std::lock_guard<std::recursive_mutex> lock(httpSingleton->m_callRoutedHandlersLock);
         httpSingleton->m_callRoutedHandlers.erase(handlerContext);
     }
 }

--- a/Source/HTTP/httpcall.cpp
+++ b/Source/HTTP/httpcall.cpp
@@ -403,7 +403,7 @@ void retry_http_call_until_done(
             auto httpSingleton = get_http_singleton(false);
             if (httpSingleton != nullptr)
             {
-                std::lock_guard<std::mutex> lock(httpSingleton->m_callRoutedHandlersLock);
+                std::lock_guard<std::recursive_mutex> lock(httpSingleton->m_callRoutedHandlersLock);
                 for (const auto& pair : httpSingleton->m_callRoutedHandlers)
                 {
                     pair.second.first(retryContext->call, pair.second.second);

--- a/Source/Mock/lhc_mock.cpp
+++ b/Source/Mock/lhc_mock.cpp
@@ -65,7 +65,7 @@ HC_CALL* GetMatchingMock(
     HC_CALL* matchingMock = nullptr;
 
     {
-        std::lock_guard<std::mutex> guard(httpSingleton->m_mocksLock);
+        std::lock_guard<std::recursive_mutex> guard(httpSingleton->m_mocksLock);
         mocks = httpSingleton->m_mocks;
         lastMatchingMock = httpSingleton->m_lastMatchingMock;
     }
@@ -109,7 +109,7 @@ HC_CALL* GetMatchingMock(
     }
 
     {
-        std::lock_guard<std::mutex> guard(httpSingleton->m_mocksLock);
+        std::lock_guard<std::recursive_mutex> guard(httpSingleton->m_mocksLock);
         httpSingleton->m_lastMatchingMock = matchingMock;
     }
 

--- a/Source/Mock/mock_publics.cpp
+++ b/Source/Mock/mock_publics.cpp
@@ -52,7 +52,7 @@ try
         }
     }
 
-    std::lock_guard<std::mutex> guard(httpSingleton->m_mocksLock);
+    std::lock_guard<std::recursive_mutex> guard(httpSingleton->m_mocksLock);
     httpSingleton->m_mocks.push_back(call);
     httpSingleton->m_mocksEnabled = true;
     return S_OK;
@@ -67,7 +67,7 @@ try
     if (nullptr == httpSingleton)
         return E_HC_NOT_INITIALISED;
 
-    std::lock_guard<std::mutex> guard(httpSingleton->m_mocksLock);
+    std::lock_guard<std::recursive_mutex> guard(httpSingleton->m_mocksLock);
 
     for (auto& mockCall : httpSingleton->m_mocks)
     {

--- a/Source/Task/ThreadPool_stl.cpp
+++ b/Source/Task/ThreadPool_stl.cpp
@@ -43,7 +43,7 @@ public:
                 numThreads--;
                 m_pool.emplace_back(std::thread([this]
                 {
-                    std::unique_lock<std::mutex> lock(m_wakeLock);
+                    std::unique_lock<std::recursive_mutex> lock(m_wakeLock);
                     while(true)
                     {
                         m_wake.wait(lock);
@@ -107,7 +107,7 @@ public:
 
     void Terminate() noexcept
     {
-        std::unique_lock<std::mutex> lock(m_activeLock);
+        std::unique_lock<std::recursive_mutex> lock(m_activeLock);
         m_terminate = true;
         m_wake.notify_all();
 
@@ -165,11 +165,11 @@ private:
 
     std::atomic<uint32_t> m_refs { 1 };
 
-    std::mutex m_wakeLock;
+    std::recursive_mutex m_wakeLock;
     std::condition_variable m_wake;
     std::atomic<uint32_t> m_calls { 0 };
 
-    std::mutex m_activeLock;
+    std::recursive_mutex m_activeLock;
     std::condition_variable m_active;
     std::atomic<uint32_t> m_activeCalls { 0 };
 

--- a/Source/WebSocket/Websocketpp/websocketpp_websocket.cpp
+++ b/Source/WebSocket/Websocketpp/websocketpp_websocket.cpp
@@ -215,7 +215,7 @@ public:
 
         {
             // Only actually have to take the lock if touching the queue.
-            std::lock_guard<std::mutex> lock(m_outgoingMessageQueueLock);
+            std::lock_guard<std::recursive_mutex> lock(m_outgoingMessageQueueLock);
             m_outgoingMessageQueue.push(message);
         }
 
@@ -236,7 +236,7 @@ public:
     {
         websocketpp::lib::error_code ec;
         {
-            std::lock_guard<std::mutex> lock(m_wsppClientLock);
+            std::lock_guard<std::recursive_mutex> lock(m_wsppClientLock);
             if (m_state == CONNECTED)
             {
                 m_state = CLOSING;
@@ -472,7 +472,7 @@ private:
 
         try
         {
-            std::lock_guard<std::mutex> lock(m_wsppClientLock);
+            std::lock_guard<std::recursive_mutex> lock(m_wsppClientLock);
             if (m_client->is_tls_client())
             {
                 auto& client = m_client->client<websocketpp::config::asio_tls_client>();
@@ -509,7 +509,7 @@ private:
         auto sendContext = http_allocate_shared<send_msg_context>();
         sendContext->pThis = shared_from_this();
         {
-            std::lock_guard<std::mutex> lock(m_outgoingMessageQueueLock);
+            std::lock_guard<std::recursive_mutex> lock(m_outgoingMessageQueueLock);
             ASSERT(!m_outgoingMessageQueue.empty());
             sendContext->message = std::move(m_outgoingMessageQueue.front());
             m_outgoingMessageQueue.pop();
@@ -655,12 +655,12 @@ private:
     websocketpp::close::status::value m_closeCode;
 
     // Used to safe guard the wspp client.
-    std::mutex m_wsppClientLock;
+    std::recursive_mutex m_wsppClientLock;
     std::atomic<State> m_state = CREATED;
     std::unique_ptr<websocketpp_client_base> m_client;
 
     // Guards access to m_outgoing_msg_queue
-    std::mutex m_outgoingMessageQueueLock;
+    std::recursive_mutex m_outgoingMessageQueueLock;
 
     // Queue to order the sends
     http_internal_queue<websocket_outgoing_message> m_outgoingMessageQueue;

--- a/Source/WebSocket/WinRT/winrt_websocket.cpp
+++ b/Source/WebSocket/WinRT/winrt_websocket.cpp
@@ -60,7 +60,7 @@ public:
 
     IAsyncAction^ m_connectAsyncOp;
 
-    std::mutex m_outgoingMessageQueueLock;
+    std::recursive_mutex m_outgoingMessageQueueLock;
     std::queue<std::shared_ptr<websocket_outgoing_message>> m_outgoingMessageQueue;
     HCWebsocketHandle m_websocketHandle;
     std::atomic<bool> m_outgoingMessageSendInProgress;
@@ -324,7 +324,7 @@ HRESULT CALLBACK Internal_HCWebSocketSendMessageAsync(
     }
 
     {
-        std::lock_guard<std::mutex> lock(websocketTask->m_outgoingMessageQueueLock);
+        std::lock_guard<std::recursive_mutex> lock(websocketTask->m_outgoingMessageQueueLock);
         HC_TRACE_INFORMATION(WEBSOCKET, "Websocket [ID %llu]: send msg queue size: %lld", websocketTask->m_websocketHandle->id, websocketTask->m_outgoingMessageQueue.size());
         websocketTask->m_outgoingMessageQueue.push(msg);
     }
@@ -454,7 +454,7 @@ void MessageWebSocketSendMessage(
     std::shared_ptr<websocket_outgoing_message> msg;
 
     {
-        std::lock_guard<std::mutex> lock(websocketTask->m_outgoingMessageQueueLock);
+        std::lock_guard<std::recursive_mutex> lock(websocketTask->m_outgoingMessageQueueLock);
         if (websocketTask->m_outgoingMessageQueue.size() > 0)
         {
             msg = websocketTask->m_outgoingMessageQueue.front();


### PR DESCRIPTION
std::mutex -- any thread can release the std::mutex no matter which thread originally took the std::mutex, but if the same thread relocks the mutex it throws an error

std::recursive_mutex - the thread that grabs the std::mutex must be the same thread that releases, but that thread can lock multiple times

We're using mutexes as a guard against other threads touching shared state at the same time, so std::recursive_mutex is what we want to use.
