### PR TITLE
Composite task queues based on process queue can terminate

### DIFF
--- a/Source/Task/TaskQueue.cpp
+++ b/Source/Task/TaskQueue.cpp
@@ -1234,10 +1234,7 @@ HRESULT TaskQueueImpl::Initialize(
     m_work.Source = referenced_ptr<ITaskQueue>(workPort->m_queue);
     m_completion.Source = referenced_ptr<ITaskQueue>(completionPort->m_queue);
 
-    m_termination.allowed = 
-        m_work.Source->CanTerminate() &&
-        m_completion.Source->CanTerminate();
-
+    m_termination.allowed = true;
     m_allowClose = true;
     
     RETURN_IF_FAILED(m_work.Port->Attach(&m_work));


### PR DESCRIPTION
It should be possible to terminate a composite queue created from ports of a system queue.  This was being prohibited because an older design linked port lifetime to queue lifetime.