### PR TITLE
Enable android propagating failures.

### DIFF
--- a/Source/HTTP/Android/http_android.cpp
+++ b/Source/HTTP/Android/http_android.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #include "pch.h"
 #include <httpClient/httpClient.h>
+#include <httpClient/httpProvider.h>
 #include "android_http_request.h"
 #include "android_platform_context.h"
 
@@ -17,6 +18,7 @@ JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientRequest_OnRequestCompl
 
     if (response == nullptr) 
     {
+        HCHttpCallResponseSetNetworkErrorCode(sourceCall, E_FAIL, 0);
         XAsyncComplete(sourceRequest->GetAsyncBlock(), E_FAIL, 0);
     }
     else 


### PR DESCRIPTION
It doesn't appear HCHttpCallResponseSetNetworkErrorCode was ever being called in the Android Path.

Also this might be a good place to convert Java exceptions into platform specific errors in the future.

Fixing my earlier issue of #385 