### PR TITLE
On Android, attach the threadpool threads to the JavaVM

### DIFF
--- a/Build/libHttpClient.141.Android.C/libHttpClient.141.Android.C.vcxproj
+++ b/Build/libHttpClient.141.Android.C/libHttpClient.141.Android.C.vcxproj
@@ -131,6 +131,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\XAsync.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\XAsyncProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\XTaskQueue.h" />
+    <ClInclude Include="..\..\Include\httpClient\async_jvm.h" />
   </ItemGroup>
   <ItemGroup>
   </ItemGroup>

--- a/Build/libHttpClient.141.Android.C/libHttpClient.141.Android.C.vcxproj
+++ b/Build/libHttpClient.141.Android.C/libHttpClient.141.Android.C.vcxproj
@@ -67,6 +67,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\async_jvm.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Common\Android\utils_android.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Common\Android\utils_android.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Common\EntryList.h" />
@@ -131,7 +132,6 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\XAsync.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\XAsyncProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\XTaskQueue.h" />
-    <ClInclude Include="..\..\Include\httpClient\async_jvm.h" />
   </ItemGroup>
   <ItemGroup>
   </ItemGroup>

--- a/Build/libHttpClient.141.Android.C/libHttpClient.141.Android.C.vcxproj.filters
+++ b/Build/libHttpClient.141.Android.C/libHttpClient.141.Android.C.vcxproj.filters
@@ -186,6 +186,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\XTaskQueue.h">
       <Filter>C++ Public Includes</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Include\httpClient\async_jvm.h">
+      <Filter>C++ Public Includes</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="C++ Source">

--- a/Build/libHttpClient.141.Android.C/libHttpClient.141.Android.C.vcxproj.filters
+++ b/Build/libHttpClient.141.Android.C/libHttpClient.141.Android.C.vcxproj.filters
@@ -75,6 +75,9 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\async_jvm.h">
+      <Filter>C++ Source\Task\Android</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Common\Android\utils_android.h">
       <Filter>C++ Source\Common\Android</Filter>
     </ClInclude>
@@ -184,9 +187,6 @@
       <Filter>C++ Public Includes</Filter>
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\XTaskQueue.h">
-      <Filter>C++ Public Includes</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\Include\httpClient\async_jvm.h">
       <Filter>C++ Public Includes</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Include/httpClient/async.h
+++ b/Include/httpClient/async.h
@@ -15,3 +15,7 @@
 #include <XAsyncProvider.h>
 #include <XTaskQueue.h>
 #endif
+
+#if HC_PLATFORM == HC_PLATFORM_ANDROID
+#include <httpClient/async_jvm.h>
+#endif

--- a/Include/httpClient/async_jvm.h
+++ b/Include/httpClient/async_jvm.h
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 #pragma once
 
 #if !defined(__cplusplus)

--- a/Include/httpClient/async_jvm.h
+++ b/Include/httpClient/async_jvm.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#if !defined(__cplusplus)
+    #error C++11 required
+#endif
+
+#include <jni.h>
+
+STDAPI XTaskQueueSetJvm(_In_ JavaVM* jvm) noexcept;

--- a/Source/HTTP/Android/android_platform_context.cpp
+++ b/Source/HTTP/Android/android_platform_context.cpp
@@ -9,6 +9,10 @@ HRESULT Internal_InitializeHttpPlatform(HCInitArgs* args, PerformEnv& performEnv
     assert(!performEnv);
     JavaVM* javaVm = args->javaVM;
     JNIEnv* jniEnv = nullptr;
+
+    // Pass the jvm down to XTaskQueue
+    XTaskQueueSetJvm(javaVm);
+
     // Java classes can only be resolved when we are on a Java-initiated thread. When we are on
     // a C++ background thread and attach to Java we do not have the full class-loader information.
     // This call should be made on JNI_OnLoad or another java thread and we will cache a global reference

--- a/Source/Task/ThreadPool_stl.cpp
+++ b/Source/Task/ThreadPool_stl.cpp
@@ -49,7 +49,7 @@ public:
                 {
 #if defined(HC_PLATFORM) && HC_PLATFORM == HC_PLATFORM_ANDROID
                     JNIEnv* jniEnv = nullptr;
-                    JavaVM* jvm = s_javaVm;
+                    JavaVM* jvm = nullptr;
 #endif
 
                     std::unique_lock<std::mutex> lock(m_wakeLock);

--- a/Source/Task/ThreadPool_stl.cpp
+++ b/Source/Task/ThreadPool_stl.cpp
@@ -247,4 +247,6 @@ STDAPI XTaskQueueSetJvm(_In_ JavaVM* jvm) noexcept
     ThreadPoolImpl::s_javaVm = jvm;
     return S_OK;
 }
+
+std::atomic<JavaVM*> ThreadPoolImpl::s_javaVm;
 #endif

--- a/Utilities/CMake/CMakeLists.txt
+++ b/Utilities/CMake/CMakeLists.txt
@@ -77,7 +77,7 @@ include_directories(
     $(ProjectDir)../../../include
     $(ProjectDir)../../../include/httpClient
     )
-    
+
 set(CMAKE_SUPPRESS_REGENERATION true)
 
 set(Public_Source_Files
@@ -113,6 +113,7 @@ set(Task_Windows_Source_Files
     )
 
 set(Task_Android_Source_Files
+    ../../../Include/httpClient/async_jvm.h
     ../../../Source/Task/ThreadPool_stl.cpp
     ../../../Source/Task/WaitTimer_stl.cpp
     )
@@ -169,7 +170,7 @@ set(Common_Windows_Source_Files
     ../../../Source/Common/Win/utils_win.cpp
     ../../../Source/Common/Win/utils_win.h
     )
-    
+
 set(Common_Android_Source_Files
     ../../../Source/Common/Android/utils_android.cpp
     ../../../Source/Common/Android/utils_android.h
@@ -406,4 +407,3 @@ set(CMAKE_STATIC_LINKER_FLAGS "/INCREMENTAL:NO")
 message(STATUS "CMAKE_SYSTEM_VERSION='${CMAKE_SYSTEM_VERSION}'")
 message(STATUS "CMAKE_SYSTEM_NAME='${CMAKE_SYSTEM_NAME}'")
 message(STATUS "SHORT_VERSION='${SHORT_VERSION}'")
-


### PR DESCRIPTION
libHttpClient needs to be pumped on a thread that is attached to the JavaVM to function on Android.
When using `XTaskQueueDispatchMode::ThreadPool` the threads the pumping is done are managed by the task system, so we need a way to attach those to the JavaVM.

This change adds a function `XTaskQueueSetJvm` that takes a pointer to the JavaVM, the threadpool threads will detect it and use it from then on. `HCInitialize` will also implicitly do this when called.