### PR TITLE
Don't include websocket stuff if it's disabled.

### DIFF
--- a/Source/Global/global.cpp
+++ b/Source/Global/global.cpp
@@ -5,7 +5,10 @@
 #include "../HTTP/httpcall.h"
 #include "buildver.h"
 #include "global.h"
+
+#if !HC_NOWEBSOCKETS
 #include "../WebSocket/hcwebsocket.h"
+#endif
 
 using namespace xbox::httpclient;
 

--- a/Source/HTTP/WinHttp/winhttp_http_task.cpp
+++ b/Source/HTTP/WinHttp/winhttp_http_task.cpp
@@ -5,7 +5,10 @@
 #include "../httpcall.h"
 #include "uri.h"
 #include "winhttp_http_task.h"
+
+#if !HC_NOWEBSOCKETS
 #include "hcwebsocket.h"
+#endif
 
 #define CRLF L"\r\n"
 


### PR DESCRIPTION
Websockets pull in unnecessary stuff into projects that don't use/need it.

We use libhttpclient's HC_NOWEBSOCKETS and was running into issues with these being included in a project that didn't have websocket stuff.

Following precedence from hcwebsocket.cpp that blocks the include hcwebsockets.h in a similar way.
