### PR TITLE
Fixing various websocket bugs

### DIFF
--- a/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj
+++ b/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj
@@ -75,7 +75,7 @@
       <ProgramDataBaseFileName>$(OutDir)$(ProjectName).pdb</ProgramDataBaseFileName>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <ShowIncludes Condition="'$(Configuration)'=='Debug'">false</ShowIncludes>
-      <PreprocessorDefinitions>_WIN32_WINNT=0x601;HC_WINHTTP_WEBSOCKETS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WIN32_WINNT=0x601;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj
+++ b/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj
@@ -75,7 +75,7 @@
       <ProgramDataBaseFileName>$(OutDir)$(ProjectName).pdb</ProgramDataBaseFileName>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <ShowIncludes Condition="'$(Configuration)'=='Debug'">false</ShowIncludes>
-      <PreprocessorDefinitions>_WIN32_WINNT=0x601;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WIN32_WINNT=0x601;HC_WINHTTP_WEBSOCKETS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Samples/Win32WebSocket/main.cpp
+++ b/Samples/Win32WebSocket/main.cpp
@@ -208,7 +208,7 @@ int main()
         printf_s("Calling HCWebSocketConnect...\n");
         hr = HCWebSocketConnectAsync(url.data(), "", websocket, asyncBlock);
         WaitForSingleObject(g_eventHandle, INFINITE);
-        
+
         uint32_t numberOfMessagesToSend = 100;
         for (uint32_t i = 1; i <= numberOfMessagesToSend; i++)
         {
@@ -242,6 +242,7 @@ int main()
 
     HCWebSocketCloseHandle(websocket);
     CloseHandle(g_eventHandle);
+    HCCleanup();
     return 0;
 }
 

--- a/Source/Common/pch_common.h
+++ b/Source/Common/pch_common.h
@@ -122,7 +122,6 @@ HC_DECLARE_TRACE_AREA(WEBSOCKET);
     catch (...) { ::xbox::httpclient::detail::UnknownExceptionToResult(file, line); return errCode; }
 
 #define RETURN_IF_PERFORM_CALLED(call) if (call->performCalled) return E_HC_PERFORM_ALREADY_CALLED;
-#define RETURN_IF_WEBSOCKET_CONNECT_CALLED(socket) if (socket->connectCalled) return E_HC_CONNECT_ALREADY_CALLED;
 
 NAMESPACE_XBOX_HTTP_CLIENT_DETAIL_BEGIN
 

--- a/Source/Global/global.h
+++ b/Source/Global/global.h
@@ -129,7 +129,6 @@ public:
         }
     }
 
-    template<typename T>
     static void remove(void *rawContextPtr)
     {
         auto httpSingleton = get_http_singleton(false);

--- a/Source/HTTP/WinHttp/winhttp_http_task.cpp
+++ b/Source/HTTP/WinHttp/winhttp_http_task.cpp
@@ -142,8 +142,19 @@ void winhttp_http_task::complete_task(_In_ HRESULT translatedHR, uint32_t platfo
 {
     if (m_asyncBlock != nullptr)
     {
-        HCHttpCallResponseSetNetworkErrorCode(m_call, translatedHR, platformSpecificError);
-        XAsyncComplete(m_asyncBlock, S_OK, 0);
+#if !HC_NOWEBSOCKETS
+        if (m_isWebSocket)
+        {
+            m_connectHr = translatedHR;
+            m_connectPlatformError = platformSpecificError;
+            XAsyncComplete(m_asyncBlock, S_OK, sizeof(WebSocketCompletionResult));
+        }
+        else
+#endif
+        {
+            HCHttpCallResponseSetNetworkErrorCode(m_call, translatedHR, platformSpecificError);
+            XAsyncComplete(m_asyncBlock, S_OK, 0);
+        }
         m_asyncBlock = nullptr;
     }
 

--- a/Source/HTTP/WinHttp/winhttp_http_task.cpp
+++ b/Source/HTTP/WinHttp/winhttp_http_task.cpp
@@ -142,7 +142,7 @@ void winhttp_http_task::complete_task(_In_ HRESULT translatedHR, uint32_t platfo
 {
     if (m_asyncBlock != nullptr)
     {
-#if !HC_NOWEBSOCKETS
+#if HC_WINHTTP_WEBSOCKETS
         if (m_isWebSocket)
         {
             m_connectHr = translatedHR;
@@ -606,12 +606,13 @@ void CALLBACK winhttp_http_task::completion_callback(
 
             case WINHTTP_CALLBACK_STATUS_CLOSE_COMPLETE:
             {
+#if HC_WINHTTP_WEBSOCKETS
                 USHORT closeReason = 0;
                 DWORD dwReasonLengthConsumed = 0;
                 WinHttpWebSocketQueryCloseStatus(pRequestContext->m_hRequest, &closeReason, nullptr, 0, &dwReasonLengthConsumed);
 
                 pRequestContext->on_websocket_disconnected(closeReason);
-
+#endif
                 break;
             }
         }

--- a/Source/HTTP/WinHttp/winhttp_http_task.cpp
+++ b/Source/HTTP/WinHttp/winhttp_http_task.cpp
@@ -150,7 +150,7 @@ void winhttp_http_task::complete_task(_In_ HRESULT translatedHR, uint32_t platfo
     if (m_hRequest != nullptr && !m_isWebSocket)
     {
         WinHttpSetStatusCallback(m_hRequest, nullptr, WINHTTP_CALLBACK_FLAG_ALL_NOTIFICATIONS, NULL);
-        shared_ptr_cache::remove<winhttp_http_task>(this);
+        shared_ptr_cache::remove(this);
     }
 }
 
@@ -680,7 +680,7 @@ HRESULT winhttp_http_task::connect(
     )
 {
     if (!m_hSession)
-    {        
+    {
         HC_TRACE_ERROR(HTTPCLIENT, "winhttp_http_task [ID %llu] [TID %ul] no session", HCHttpCallGetId(m_call), GetCurrentThreadId());
         return E_INVALIDARG;
     }
@@ -999,6 +999,7 @@ HRESULT winhttp_http_task::on_websocket_disconnected(_In_ USHORT closeReason)
 
 HRESULT winhttp_http_task::disconnect_websocket(_In_ HCWebSocketCloseStatus closeStatus)
 {
+    // TODO this is not true
     // HCWebSocketCloseEventFunction is triggered inside HCWebSocketDisconnect()
 
     m_socketState = WinHttpWebsockState::Closed;

--- a/Source/HTTP/WinHttp/winhttp_http_task.cpp
+++ b/Source/HTTP/WinHttp/winhttp_http_task.cpp
@@ -592,6 +592,17 @@ void CALLBACK winhttp_http_task::completion_callback(
                 }
                 break;
             }
+
+            case WINHTTP_CALLBACK_STATUS_CLOSE_COMPLETE:
+            {
+                USHORT closeReason = 0;
+                DWORD dwReasonLengthConsumed = 0;
+                WinHttpWebSocketQueryCloseStatus(pRequestContext->m_hRequest, &closeReason, nullptr, 0, &dwReasonLengthConsumed);
+
+                pRequestContext->on_websocket_disconnected(closeReason);
+
+                break;
+            }
         }
     }
     catch (std::bad_alloc const& e)
@@ -999,9 +1010,6 @@ HRESULT winhttp_http_task::on_websocket_disconnected(_In_ USHORT closeReason)
 
 HRESULT winhttp_http_task::disconnect_websocket(_In_ HCWebSocketCloseStatus closeStatus)
 {
-    // TODO this is not true
-    // HCWebSocketCloseEventFunction is triggered inside HCWebSocketDisconnect()
-
     m_socketState = WinHttpWebsockState::Closed;
     DWORD dwError = WinHttpWebSocketClose(m_hRequest, WINHTTP_WEB_SOCKET_SUCCESS_CLOSE_STATUS, nullptr, 0);
 

--- a/Source/HTTP/WinHttp/winhttp_http_task.cpp
+++ b/Source/HTTP/WinHttp/winhttp_http_task.cpp
@@ -1013,9 +1013,6 @@ HRESULT winhttp_http_task::disconnect_websocket(_In_ HCWebSocketCloseStatus clos
     m_socketState = WinHttpWebsockState::Closed;
     DWORD dwError = WinHttpWebSocketClose(m_hRequest, WINHTTP_WEB_SOCKET_SUCCESS_CLOSE_STATUS, nullptr, 0);
 
-    // Handlers will be setup again upon connect
-    WinHttpSetStatusCallback(m_hRequest, nullptr, WINHTTP_CALLBACK_FLAG_ALL_NOTIFICATIONS, NULL);
-
     return HRESULT_FROM_WIN32(dwError);
 }
 

--- a/Source/HTTP/WinHttp/winhttp_http_task.h
+++ b/Source/HTTP/WinHttp/winhttp_http_task.h
@@ -190,6 +190,8 @@ public:
     HRESULT on_websocket_disconnected(_In_ USHORT closeReason);
     std::atomic<WinHttpWebsockState> m_socketState = WinHttpWebsockState::Created;
     HCWebsocketHandle m_websocketHandle = nullptr;
+    HRESULT m_connectHr{ S_OK };
+    uint32_t m_connectPlatformError{ 0 };
 #endif
 
 private:

--- a/Source/HTTP/httpcall.cpp
+++ b/Source/HTTP/httpcall.cpp
@@ -469,7 +469,7 @@ try
             {
                 auto context = static_cast<retry_context*>(data->context);
                 HCHttpCallCloseHandle(context->call); // Call is done so remove internal keep alive ref
-                shared_ptr_cache::remove<retry_context>(data->context);
+                shared_ptr_cache::remove(data->context);
                 break;
             }
                 

--- a/Source/WebSocket/Websocketpp/websocketpp_websocket.cpp
+++ b/Source/WebSocket/Websocketpp/websocketpp_websocket.cpp
@@ -412,6 +412,7 @@ private:
             {
                 auto context = shared_ptr_cache::fetch<wspp_websocket_impl>(data->context, true);
                 auto result = reinterpret_cast<WebSocketCompletionResult*>(data->buffer);
+                result->websocket = context->m_hcWebsocketHandle;
                 result->platformErrorCode = context->m_connectError.value();
                 result->errorCode = context->m_connectError ? E_FAIL : S_OK;
             }
@@ -763,8 +764,6 @@ HRESULT CALLBACK Internal_HCWebSocketConnectAsync(
     _In_ HCPerformEnv env
     )
 {
-    // TODO: Handle double connecting on same HCWebsocketHandle, and ensure disconnect/reconnect case works
-
     websocket->uri = uri;
     websocket->subProtocol = subProtocol;
     auto wsppSocket = http_allocate_shared<wspp_websocket_impl>(websocket);

--- a/Source/WebSocket/WinHTTP/winhttp_websocket.cpp
+++ b/Source/WebSocket/WinHTTP/winhttp_websocket.cpp
@@ -57,6 +57,14 @@ public:
         m_httpTask->m_socketState = WinHttpWebsockState::Connecting;
         m_httpTask->m_websocketHandle = websocket;
 
+        XAsyncBegin(asyncBlock, nullptr, nullptr, __FUNCTION__,
+            [](XAsyncOp op, const XAsyncProviderData* data)
+        {
+            // winhttp_http_task invokes WinHttp and completes the async block in a WinHttp callback.
+            // No reason to kick off that work asynchronously, but we still need to begin the async block
+            return S_OK;
+        });
+        shared_ptr_cache::store<winhttp_http_task>(m_httpTask);
         return m_httpTask->connect_and_send_async();
     }
 

--- a/Source/WebSocket/WinRT/winrt_websocket.cpp
+++ b/Source/WebSocket/WinRT/winrt_websocket.cpp
@@ -555,7 +555,7 @@ void MessageWebSocketSendMessage(
                 if (context != nullptr)
                 {
                     HCWebSocketCloseHandle(context->websocketTask->m_websocketHandle);
-                    shared_ptr_cache::remove<SendMessageCallbackContext>(data->context);
+                    shared_ptr_cache::remove(data->context);
                 }
                 break;
             }

--- a/Source/WebSocket/hcwebsocket.cpp
+++ b/Source/WebSocket/hcwebsocket.cpp
@@ -78,7 +78,14 @@ void HC_WEBSOCKET::MessageFunc(
 {
     if (websocket->m_clientMessageFunc)
     {
-        websocket->m_clientMessageFunc(websocket, message, websocket->m_clientContext);
+        try
+        {
+            websocket->m_clientMessageFunc(websocket, message, websocket->m_clientContext);
+        }
+        catch (...)
+        {
+            HC_TRACE_WARNING(WEBSOCKET, "Caught exception in client HCWebSocketMessageFunction");
+        }
     }
 }
 
@@ -91,7 +98,14 @@ void HC_WEBSOCKET::BinaryMessageFunc(
 {
     if (websocket->m_clientBinaryMessageFunc)
     {
-        websocket->m_clientBinaryMessageFunc(websocket, bytes, payloadSize, websocket->m_clientContext);
+        try
+        {
+            websocket->m_clientBinaryMessageFunc(websocket, bytes, payloadSize, websocket->m_clientContext);
+        }
+        catch (...)
+        {
+            HC_TRACE_WARNING(WEBSOCKET, "Caught exception in client HCWebSocketBinaryMessageFunction");
+        }
     }
 }
 
@@ -103,7 +117,14 @@ void HC_WEBSOCKET::CloseFunc(
 {
     if (websocket->m_clientCloseEventFunc)
     {
-        websocket->m_clientCloseEventFunc(websocket, status, websocket->m_clientContext);
+        try
+        {
+            websocket->m_clientCloseEventFunc(websocket, status, websocket->m_clientContext);
+        }
+        catch (...)
+        {
+            HC_TRACE_WARNING(WEBSOCKET, "Caught exception in client HCWebSocketCloseEventFunction");
+        }
     }
     // Release the providers ref
     websocket->disconnectCallExpected = false;

--- a/Source/WebSocket/hcwebsocket.cpp
+++ b/Source/WebSocket/hcwebsocket.cpp
@@ -41,10 +41,6 @@ void HC_WEBSOCKET::DecClientRef()
 {
     if (--m_clientRefCount == 0)
     {
-        m_clientMessageFunc = nullptr;
-        m_clientBinaryMessageFunc = nullptr;
-        m_clientCloseEventFunc = nullptr;
-
         if (disconnectCallExpected)
         {
             HC_TRACE_WARNING(WEBSOCKET, "No client reference remain for HC_WEBSOCKET but it is either connected/connecting. Disconnecting now.");
@@ -76,7 +72,7 @@ void HC_WEBSOCKET::MessageFunc(
     void* context
 )
 {
-    if (websocket->m_clientMessageFunc)
+    if (websocket->m_clientRefCount > 0)
     {
         try
         {
@@ -96,7 +92,7 @@ void HC_WEBSOCKET::BinaryMessageFunc(
     void* context
 )
 {
-    if (websocket->m_clientBinaryMessageFunc)
+    if (websocket->m_clientRefCount > 0)
     {
         try
         {
@@ -115,7 +111,7 @@ void HC_WEBSOCKET::CloseFunc(
     void* context
 )
 {
-    if (websocket->m_clientCloseEventFunc)
+    if (websocket->m_clientRefCount > 0)
     {
         try
         {

--- a/Source/WebSocket/hcwebsocket.h
+++ b/Source/WebSocket/hcwebsocket.h
@@ -48,6 +48,7 @@ private:
     HCWebSocketCloseEventFunction const m_clientCloseEventFunc;
     void* m_clientContext;
 
+    std::recursive_mutex m_mutex;
     std::atomic<int> m_clientRefCount{ 0 };
     std::atomic<int> m_totalRefCount{ 0 };
     std::shared_ptr<HC_WEBSOCKET> m_extraRefHolder;

--- a/Source/WebSocket/hcwebsocket.h
+++ b/Source/WebSocket/hcwebsocket.h
@@ -43,9 +43,9 @@ public:
 
     std::shared_ptr<hc_websocket_impl> impl;
 private:
-    HCWebSocketMessageFunction m_clientMessageFunc;
-    HCWebSocketBinaryMessageFunction m_clientBinaryMessageFunc;
-    HCWebSocketCloseEventFunction m_clientCloseEventFunc;
+    HCWebSocketMessageFunction const m_clientMessageFunc;
+    HCWebSocketBinaryMessageFunction const m_clientBinaryMessageFunc;
+    HCWebSocketCloseEventFunction const m_clientCloseEventFunc;
     void* m_clientContext;
 
     std::atomic<int> m_clientRefCount{ 0 };

--- a/Source/WebSocket/hcwebsocket.h
+++ b/Source/WebSocket/hcwebsocket.h
@@ -96,6 +96,7 @@ struct WebSocketPerformInfo
         connect{ conn },
         sendText{ st },
         sendBinary{ sb },
+        disconnect{ dc },
         context{ ctx }
     {}
 


### PR DESCRIPTION
Several bugs in different websocket:
- Event callbacks can be called after client has no more reference to the websocket object. Fix is to track client references separately and only call client callbacks if there are remaining client references.

WSPP:
- Deadlock caused by sleep in dtor.  Fixed lifetime management using smart pointers and ensuring wspp_impl object is valid until websocket is disconnected.

WinHttp:
- Connect result was not propagated to caller correctly.
- Calling disconnect after connect is called but not yet completed crashes.