### PR TITLE
Add support for targeting ARM64 for Android projects

### DIFF
--- a/Build/libHttpClient.141.Android.C/libHttpClient.141.Android.C.vcxproj
+++ b/Build/libHttpClient.141.Android.C/libHttpClient.141.Android.C.vcxproj
@@ -30,7 +30,8 @@
     <ProjectGuid>{5e0ce391-1ac5-4930-921e-2577a4b5c530}</ProjectGuid>
     <Keyword>Android</Keyword>
     <PlatformToolset>Clang_5_0</PlatformToolset>
-    <AndroidAPILevel>android-19</AndroidAPILevel>
+    <AndroidAPILevel Condition="'$(Platform)'!='ARM64'">android-19</AndroidAPILevel>
+    <AndroidAPILevel Condition="'$(Platform)'=='ARM64'">android-21</AndroidAPILevel>
     <RootNamespace>libHttpClient_141_Android_C</RootNamespace>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <ApplicationType>Android</ApplicationType>

--- a/Build/libcrypto.141.Android/libcrypto.141.Android.vcxproj
+++ b/Build/libcrypto.141.Android/libcrypto.141.Android.vcxproj
@@ -42,6 +42,8 @@
     <ApplicationTypeRevision>3.0</ApplicationTypeRevision>
     <AndroidAPILevel>android-19</AndroidAPILevel>
     <HCLibPlatformType>Android</HCLibPlatformType>
+    <AndroidAPILevel Condition="'$(Platform)'!='ARM64'">android-19</AndroidAPILevel>
+    <AndroidAPILevel Condition="'$(Platform)'=='ARM64'">android-21</AndroidAPILevel>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup>

--- a/Build/libssl.141.Android/libssl.141.Android.vcxproj
+++ b/Build/libssl.141.Android/libssl.141.Android.vcxproj
@@ -40,7 +40,8 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <ApplicationType>Android</ApplicationType>
     <ApplicationTypeRevision>3.0</ApplicationTypeRevision>
-    <AndroidAPILevel>android-19</AndroidAPILevel>
+    <AndroidAPILevel Condition="'$(Platform)'!='ARM64'">android-19</AndroidAPILevel>
+    <AndroidAPILevel Condition="'$(Platform)'=='ARM64'">android-21</AndroidAPILevel>
     <HCLibPlatformType>Android</HCLibPlatformType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/Utilities/CMake/template-libHttpClient.141.Android.C.vcxproj
+++ b/Utilities/CMake/template-libHttpClient.141.Android.C.vcxproj
@@ -30,7 +30,8 @@
     <ProjectGuid>{5e0ce391-1ac5-4930-921e-2577a4b5c530}</ProjectGuid>
     <Keyword>Android</Keyword>
     <PlatformToolset>Clang_5_0</PlatformToolset>
-    <AndroidAPILevel>android-19</AndroidAPILevel>
+    <AndroidAPILevel Condition="'$(Platform)'!='ARM64'">android-19</AndroidAPILevel>
+    <AndroidAPILevel Condition="'$(Platform)'=='ARM64'">android-21</AndroidAPILevel>
     <RootNamespace>libHttpClient_141_Android_C</RootNamespace>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <ApplicationType>Android</ApplicationType>


### PR DESCRIPTION
ARM64 support will be required for all Android apps as of August of this year (https://android-developers.googleblog.com/2019/01/get-your-apps-ready-for-64-bit.html). However, 64 bit support was not added to the Android NDK until API level 21 (https://developer.android.com/about/versions/android-5.0-changes#64BitSupport).

This adds a condition check to the Android vcxprojects to target android-21 when the platform is ARM64, and to continue to target android-19 for all other platforms.