### PR TITLE
Remove obsolete API level tag in libcrypto vcxproj

### DIFF
--- a/Build/libcrypto.141.Android/libcrypto.141.Android.vcxproj
+++ b/Build/libcrypto.141.Android/libcrypto.141.Android.vcxproj
@@ -40,7 +40,6 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <ApplicationType>Android</ApplicationType>
     <ApplicationTypeRevision>3.0</ApplicationTypeRevision>
-    <AndroidAPILevel>android-19</AndroidAPILevel>
     <HCLibPlatformType>Android</HCLibPlatformType>
     <AndroidAPILevel Condition="'$(Platform)'!='ARM64'">android-19</AndroidAPILevel>
     <AndroidAPILevel Condition="'$(Platform)'=='ARM64'">android-21</AndroidAPILevel>


### PR DESCRIPTION
I left a stray APILevel tag in libcrypto, it was being overwritten by the correct ones below, but cleaning it up for good measure.