### PR TITLE
Android: Set the network error code when creating a request

### DIFF
--- a/Source/HTTP/Android/http_android.cpp
+++ b/Source/HTTP/Android/http_android.cpp
@@ -68,6 +68,7 @@ void Internal_HCHttpCallPerformAsync(
 
     if (!SUCCEEDED(result))
     {
+        HCHttpCallResponseSetNetworkErrorCode(call, result, 0);
         XAsyncComplete(asyncBlock, result, 0);
         return;
     }


### PR DESCRIPTION
Set the network error code when creating an HTTP request and there is a network error. The network error code was never being set for this condition. This enables a user to query the network error code after a request.