### PR TITLE
Fix overflow in timer

### DIFF
--- a/Source/Task/WaitTimer_win32.cpp
+++ b/Source/Task/WaitTimer_win32.cpp
@@ -107,11 +107,16 @@ void WaitTimer::Cancel() noexcept
 uint64_t WaitTimer::GetAbsoluteTime(_In_ uint32_t msFromNow) noexcept
 {
     FILETIME ft;
-    LARGE_INTEGER li;
+    ULARGE_INTEGER li;
     GetSystemTimeAsFileTime(&ft);
     ASSERT((ft.dwHighDateTime & 0x80000000) == 0);
+
+    uint64_t hundredNanosFromNow = msFromNow;
+    hundredNanosFromNow *= 10000ULL;
+
     li.HighPart = ft.dwHighDateTime;
     li.LowPart = ft.dwLowDateTime;
-    li.QuadPart += (msFromNow * 10000);
+    li.QuadPart += hundredNanosFromNow;
+    
     return li.QuadPart;
 }


### PR DESCRIPTION
Overflow in 32 bit relative timer values causes timers to fold their timeouts for longer (> about 7 minutes) times.