### PR TITLE
[Docs][GRDK] HttpClient Auto-Documentation Fixes

### DIFF
--- a/Include/httpClient/async_jvm.h
+++ b/Include/httpClient/async_jvm.h
@@ -9,4 +9,9 @@
 
 #include <jni.h>
 
+/// <summary>
+/// Set the Java Virtual Machine instance of your app. Currently used only by Android.
+/// </summary>
+/// <param name="jvm">The pointer to the app's JVM.</param>
+/// <returns>Result code for this API operation.  Code appears to always return S_OK.</returns>
 STDAPI XTaskQueueSetJvm(_In_ JavaVM* jvm) noexcept;

--- a/Include/httpClient/httpClient.h
+++ b/Include/httpClient/httpClient.h
@@ -77,6 +77,7 @@ typedef void
 /// pointer to restore the default.</param>
 /// <param name="memFreeFunc">A pointer to the custom freeing callback to use, or a null 
 /// pointer to restore the default.</param>
+/// <returns>Result code for this API operation.  Possible values are S_OK, or E_HC_ALREADY_INITIALIZED.</returns>
 STDAPI HCMemSetFunctions(
     _In_opt_ HCMemAllocFunction memAllocFunc,
     _In_opt_ HCMemFreeFunction memFreeFunc
@@ -129,6 +130,7 @@ STDAPI HCInitialize(_In_opt_ HCInitArgs* args) noexcept;
 /// Immediately reclaims all resources associated with the library.
 /// If you called HCMemSetFunctions(), call this before shutting down your app's memory manager.
 /// </summary>
+/// <returns></returns>
 STDAPI_(void) HCCleanup() noexcept;
 
 /// <summary>
@@ -167,6 +169,7 @@ STDAPI_(int32_t) HCAddCallRoutedHandler(
 /// Removes a previously added HCCallRoutedHandler.
 /// </summary>
 /// <param name="handlerId">Id returned from the HCAddCallRoutedHandler call.</param>
+/// <returns></returns>
 STDAPI_(void) HCRemoveCallRoutedHandler(
     _In_ int32_t handlerId
     ) noexcept;
@@ -490,6 +493,7 @@ STDAPI HCHttpCallResponseGetResponseBodyBytes(
 /// </summary>
 /// <param name="call">The handle of the HTTP call</param>
 /// <param name="statusCode">the HTTP status code of the HTTP call response</param>
+/// <returns>Result code for this API operation.  Possible values are S_OK, E_INVALIDARG, or E_FAIL.</returns>
 STDAPI HCHttpCallResponseGetStatusCode(
     _In_ HCCallHandle call,
     _Out_ uint32_t* statusCode
@@ -678,6 +682,7 @@ STDAPI HCWebSocketSetHeader(
 /// <param name="binaryMessageFunc">A pointer to the binary message handling callback to use, or a null pointer to remove.</param>
 /// <param name="closeFunc">A pointer to the close callback to use, or a null pointer to remove.</param>
 /// <param name="functionContext">Client context to pass to callback function.</param>
+/// <returns>Result code for this API operation.  Possible values are S_OK, E_INVALIDARG, E_HC_NOT_INITIALISED, or E_FAIL.</returns>
 STDAPI HCWebSocketGetEventFunctions(
     _In_ HCWebsocketHandle websocket,
     _Out_opt_ HCWebSocketMessageFunction* messageFunc,

--- a/Include/httpClient/trace.h
+++ b/Include/httpClient/trace.h
@@ -178,12 +178,14 @@ typedef void (CALLBACK HCTraceCallback)(
 /// Set client callback for tracing 
 /// </summary>
 /// <param name="callback">Trace callback</param>
+/// <returns></returns>
 STDAPI_(void) HCTraceSetClientCallback(_In_opt_ HCTraceCallback* callback) noexcept;
 
 /// <summary>
 /// Sets or unsets if the trace is sent to the debugger.
 /// </summary>
 /// <param name="traceToDebugger">If True, sends the trace to the debugger.</param>
+/// <returns></returns>
 STDAPI_(void) HCTraceSetTraceToDebugger(_In_ bool traceToDebugger) noexcept;
 
 
@@ -285,6 +287,14 @@ STDAPI_(void) HCTraceSetTraceToDebugger(_In_ bool traceToDebugger) noexcept;
 typedef uint64_t (CALLBACK HCTracePlatformThisThreadIdCallback)(void*);
 typedef void (CALLBACK HCTracePlatformWriteMessageToDebuggerCallback)(char const*, HCTraceLevel, char const*, void*);
 
+/// <summary>
+/// Sets the Platform Callbacks.
+/// </summary>
+/// <param name="threadIdCallback">The thread ID callback.</param>
+/// <param name="threadIdContext">The thread ID context.</param>
+/// <param name="writeToDebuggerCallback">The write to debbugger callback.</param>
+/// <param name="writeToDebuggerContext">The write to debbugger context.</param>
+/// <returns>Result code for this API operation.  Possible values are S_OK, or E_HC_NOT_INITIALISED.</returns>
 STDAPI HCTraceSetPlatformCallbacks(
     _In_ HCTracePlatformThisThreadIdCallback* threadIdCallback,
     _In_opt_ void* threadIdContext,
@@ -313,6 +323,13 @@ typedef struct HCTraceImplArea
     HCTraceLevel Verbosity;
 } HCTraceImplArea;
 
+/// <summary>
+/// Set the verbosity level of an trace area. This should be accessed through macros, such as 
+/// HC_TRACE_SET_VERBOSITY, rather than called directly.
+/// </summary>
+/// <param name="area">The trace area.</param>
+/// <param name="verbosity">The verbosity level.</param>
+/// <returns></returns>
 EXTERN_C inline
 void STDAPIVCALLTYPE HCTraceImplSetAreaVerbosity(
     struct HCTraceImplArea* area,
@@ -322,12 +339,26 @@ void STDAPIVCALLTYPE HCTraceImplSetAreaVerbosity(
     area->Verbosity = verbosity;
 }
 
+/// <summary>
+/// Get the trace verbosity level of an trace area. This should be accessed through macros, such as 
+/// HC_TRACE_GET_VERBOSITY, rather than called directly.
+/// </summary>
+/// <param name="area">The trace area.</param>
+/// <returns>The verbosity level of the area.</returns>
 EXTERN_C inline
 HCTraceLevel STDAPIVCALLTYPE HCTraceImplGetAreaVerbosity(struct HCTraceImplArea* area) noexcept
 {
     return area->Verbosity;
 }
 
+/// <summary>
+/// Send a trace message. This should be accessed through macros, such as HC_TRACE_MESSAGE, 
+/// rather than called directly.
+/// </summary>
+/// <param name="area">The trace area.</param>
+/// <param name="level">The trace level.</param>
+/// <param name="format">The message format and arguments.</param>
+/// <returns></returns>
 STDAPI_(void) HCTraceImplMessage(
     struct HCTraceImplArea const* area,
     HCTraceLevel level,
@@ -353,6 +384,14 @@ private:
     unsigned long long const m_id;
 };
 
+/// <summary>
+/// HCTraceImplScopeHelper constructor. This should be accessed through macros, such as HC_TRACE_SCOPE, 
+/// rather than called directly.
+/// </summary>
+/// <param name="area">The trace area.</param>
+/// <param name="level">The trace level.</param>
+/// <param name="scope">The trace scope.</param>
+/// <returns></returns>
 inline
 HCTraceImplScopeHelper::HCTraceImplScopeHelper(
     HCTraceImplArea const* area,
@@ -363,6 +402,10 @@ HCTraceImplScopeHelper::HCTraceImplScopeHelper(
     HCTraceImplMessage(m_area, m_level, ">>> %s (%016llX)", m_scope, m_id);
 }
 
+/// <summary>
+/// HCTraceImplScopeHelper destructor.
+/// </summary>
+/// <returns></returns>
 inline
 HCTraceImplScopeHelper::~HCTraceImplScopeHelper() noexcept
 {


### PR DESCRIPTION
Fixes a number of missing documentation in the function headers of the HttpClient library. Once the documenting tool is re-run, a number of "TBD" fields in the API documentation will be fixed. No code changes.