### PR TITLE
Fix potential race condition in accessing internal state

### DIFF
--- a/Source/Task/AsyncLib.cpp
+++ b/Source/Task/AsyncLib.cpp
@@ -245,7 +245,7 @@ public:
     bool TrySetTerminalStatus(HRESULT status) noexcept
     {
         ASSERT(m_locked || m_internal->status != E_PENDING);
-        if (m_internal->status == E_PENDING)
+        if (m_locked && m_internal->status == E_PENDING)
         {
             ASSERT(m_userInternal->status == E_PENDING);
             m_userInternal->status = status;


### PR DESCRIPTION
While backporting a compile fix for iOS I noticed a potential race condition here.  This fixes both.