### PR TITLE
Add manual proxy setting support for HTTP calls

### DIFF
--- a/Include/httpClient/httpClient.h
+++ b/Include/httpClient/httpClient.h
@@ -180,6 +180,14 @@ STDAPI_(void) HCRemoveCallRoutedHandler(
     _In_ int32_t handlerId
     ) noexcept;
 
+/// <summary>
+/// Manually sets an explicit proxy address. If it is passed a null proxy, it will reset
+/// to default. Does not include proxying web socket traffic.
+/// </summary>
+/// <param name="proxyUri">The proxy address to use in the "[ip]:[port]" format</param> 
+/// <returns>Result code for this API operation. Possible values are S_OK, E_HC_NOT_INITIALISED, or E_FAIL.</returns>
+STDAPI HCSetGlobalProxy(_In_ const char* proxyUri) noexcept;
+
 /////////////////////////////////////////////////////////////////////////////////////////
 // Http APIs
 //

--- a/Source/Global/global.cpp
+++ b/Source/Global/global.cpp
@@ -143,6 +143,15 @@ void http_singleton::clear_retry_state(_In_ uint32_t retryAfterCacheId)
     m_retryAfterCache.erase(retryAfterCacheId);
 }
 
+HRESULT http_singleton::set_global_proxy(_In_ const char* proxyUri)
+{
+#if HC_PLATFORM == HC_PLATFORM_WIN32
+    return Internal_SetGlobalProxy(m_performEnv.get(), proxyUri);
+#else
+    return E_NOTIMPL;
+#endif
+}
+
 HttpPerformInfo& GetUserHttpPerformHandler() noexcept
 {
     static HttpPerformInfo handler(&Internal_HCHttpCallPerformAsync, nullptr);

--- a/Source/Global/global.h
+++ b/Source/Global/global.h
@@ -64,6 +64,8 @@ typedef struct http_singleton
     HttpPerformInfo const m_httpPerform;
     PerformEnv const m_performEnv;
 
+    HRESULT set_global_proxy(_In_ const char* proxyUri);
+
     std::atomic<std::uint64_t> m_lastId{ 0 };
     bool m_retryAllowed = true;
     uint32_t m_timeoutInSeconds = DEFAULT_HTTP_TIMEOUT_IN_SECONDS;

--- a/Source/Global/global_publics.cpp
+++ b/Source/Global/global_publics.cpp
@@ -41,6 +41,20 @@ try
 CATCH_RETURN_WITH(;)
 
 STDAPI
+HCSetGlobalProxy(_In_ const char* proxyUri) noexcept
+try
+{
+    auto httpSingleton = get_http_singleton(false);
+    if (nullptr == httpSingleton)
+    {
+        return E_HC_NOT_INITIALISED;
+    }
+
+    return httpSingleton->set_global_proxy(proxyUri);
+}
+CATCH_RETURN()
+
+STDAPI
 HCSetHttpCallPerformFunction(
     _In_ HCCallPerformFunction performFunc,
     _In_opt_ void* performContext

--- a/Source/HTTP/Unittest/http_unittest.cpp
+++ b/Source/HTTP/Unittest/http_unittest.cpp
@@ -31,4 +31,13 @@ void CALLBACK Internal_HCHttpCallPerformAsync(
     assert(!env);
     XAsyncComplete(asyncBlock, S_OK, 0);
 }
+
+HRESULT
+Internal_SetGlobalProxy(
+    _In_ HC_PERFORM_ENV* performEnv,
+    _In_ const char* proxyUri) noexcept
+{
+    return E_NOTIMPL;
+}
+
 #endif

--- a/Source/HTTP/WinHttp/winhttp_http_task.cpp
+++ b/Source/HTTP/WinHttp/winhttp_http_task.cpp
@@ -18,18 +18,25 @@ using namespace xbox::httpclient;
 #define WINHTTP_WEBSOCKET_RECVBUFFER_SIZE (1024 * 4)
 #define WINHTTP_WEBSOCKET_RECVBUFFER_MAXSIZE (1024 * 20)
 
+void get_proxy_name(
+    _In_ xbox::httpclient::proxy_type proxyType,
+    _In_ xbox::httpclient::Uri proxyUri,
+    _Out_ DWORD* pAccessType,
+    _Out_ http_internal_wstring* pwProxyName);
+
 HC_PERFORM_ENV::HC_PERFORM_ENV()
 {
-    m_proxyType = get_ie_proxy_info(proxy_protocol::https, m_proxyUri);
+    xbox::httpclient::Uri proxyUri;
+    m_proxyType = get_ie_proxy_info(proxy_protocol::https, proxyUri);
 
     DWORD accessType = WINHTTP_ACCESS_TYPE_DEFAULT_PROXY;
-    const wchar_t* wProxyName = nullptr;
-    get_proxy_name(m_proxyType, &accessType, &wProxyName);
+    http_internal_wstring wProxyName;
+    get_proxy_name(m_proxyType, proxyUri, &accessType, &wProxyName);
 
     m_hSession = WinHttpOpen(
         nullptr,
         accessType,
-        wProxyName,
+        wProxyName.length() > 0 ? wProxyName.c_str() : WINHTTP_NO_PROXY_NAME,
         WINHTTP_NO_PROXY_BYPASS,
         WINHTTP_FLAG_ASYNC);
 }
@@ -42,17 +49,18 @@ HC_PERFORM_ENV::~HC_PERFORM_ENV()
     }
 }
 
-void HC_PERFORM_ENV::get_proxy_name(
+void get_proxy_name(
     _In_ proxy_type proxyType,
+    _In_ xbox::httpclient::Uri proxyUri,
     _Out_ DWORD* pAccessType,
-    _Out_ const wchar_t** pwProxyName)
+    _Out_ http_internal_wstring* pwProxyName)
 {
     switch (proxyType)
     {
         case proxy_type::no_proxy:
         {
             *pAccessType = WINHTTP_ACCESS_TYPE_NO_PROXY;
-            *pwProxyName = WINHTTP_NO_PROXY_NAME;
+            *pwProxyName = L"";
             break;
         }
 
@@ -60,28 +68,25 @@ void HC_PERFORM_ENV::get_proxy_name(
         {
             *pAccessType = WINHTTP_ACCESS_TYPE_NAMED_PROXY;
 
-            http_internal_wstring wProxyHost = utf16_from_utf8(m_proxyUri.Host());
+            http_internal_wstring wProxyHost = utf16_from_utf8(proxyUri.Host());
 
             // WinHttpOpen cannot handle trailing slash in the name, so here is some string gymnastics to keep WinHttpOpen happy
-            if (m_proxyUri.IsPortDefault())
+            if (proxyUri.IsPortDefault())
             {
-                m_wProxyName = wProxyHost;
-                *pwProxyName = m_wProxyName.c_str();
+                *pwProxyName = wProxyHost;
             }
             else
             {
-                if (m_proxyUri.Port() > 0)
+                if (proxyUri.Port() > 0)
                 {
                     http_internal_basic_stringstream<wchar_t> ss;
                     ss.imbue(std::locale::classic());
-                    ss << wProxyHost << L":" << m_proxyUri.Port();
-                    m_wProxyName = ss.str();
-                    *pwProxyName = m_wProxyName.c_str();
+                    ss << wProxyHost << L":" << proxyUri.Port();
+                    *pwProxyName = ss.str().c_str();
                 }
                 else
                 {
-                    m_wProxyName = wProxyHost;
-                    *pwProxyName = m_wProxyName.c_str();
+                    *pwProxyName = wProxyHost;
                 }
             }
             break;
@@ -92,7 +97,7 @@ void HC_PERFORM_ENV::get_proxy_name(
         case proxy_type::default_proxy:
         {
             *pAccessType = WINHTTP_ACCESS_TYPE_DEFAULT_PROXY;
-            *pwProxyName = WINHTTP_NO_PROXY_NAME;
+            *pwProxyName = L"";
             break;
         }
     }
@@ -1073,6 +1078,64 @@ HRESULT Internal_InitializeHttpPlatform(HCInitArgs* args, PerformEnv& performEnv
 void Internal_CleanupHttpPlatform(HC_PERFORM_ENV* performEnv) noexcept
 {
     delete performEnv;
+}
+
+HRESULT
+Internal_SetGlobalProxy(
+    _In_ HC_PERFORM_ENV* performEnv,
+    _In_ const char* proxyUri) noexcept
+{
+    assert(performEnv != nullptr);
+
+    auto desiredType = xbox::httpclient::proxy_type::default_proxy;
+    WINHTTP_PROXY_INFO info = { 0 };
+    http_internal_wstring wProxyName;
+
+    if (proxyUri == nullptr)
+    {
+        HC_TRACE_INFORMATION(HTTPCLIENT, "Internal_SetGlobalProxy [TID %ul] reseting proxy", GetCurrentThreadId());
+
+        xbox::httpclient::Uri ieProxyUri;
+        desiredType = get_ie_proxy_info(proxy_protocol::https, ieProxyUri);
+
+        DWORD accessType = WINHTTP_ACCESS_TYPE_DEFAULT_PROXY;
+        get_proxy_name(desiredType, ieProxyUri, &accessType, &wProxyName);
+
+        info.dwAccessType = accessType;
+        if (wProxyName.length() > 0)
+        {
+            info.lpszProxy = const_cast<LPWSTR>(wProxyName.c_str());
+        }
+    }
+    else
+    {
+        HC_TRACE_INFORMATION(HTTPCLIENT, "Internal_SetGlobalProxy [TID %ul] setting proxy to '%s'", GetCurrentThreadId(), proxyUri);
+
+        wProxyName = utf16_from_utf8(proxyUri);
+
+        info.dwAccessType = WINHTTP_ACCESS_TYPE_NAMED_PROXY;
+        info.lpszProxy = const_cast<LPWSTR>(wProxyName.c_str());
+
+        desiredType = xbox::httpclient::proxy_type::named_proxy;
+    }
+
+    auto result = WinHttpSetOption(
+        performEnv->m_hSession,
+        WINHTTP_OPTION_PROXY,
+        &info,
+        sizeof(WINHTTP_PROXY_INFO));
+    if (!result)
+    {
+        DWORD dwError = GetLastError();
+        HC_TRACE_ERROR(HTTPCLIENT, "Internal_SetGlobalProxy [TID %ul] WinHttpSetOption errorcode %d", GetCurrentThreadId(), dwError);
+        return E_FAIL;
+    }
+    else
+    {
+        performEnv->m_proxyType = desiredType;
+    }
+
+    return S_OK;
 }
 
 void CALLBACK Internal_HCHttpCallPerformAsync(

--- a/Source/HTTP/WinHttp/winhttp_http_task.h
+++ b/Source/HTTP/WinHttp/winhttp_http_task.h
@@ -11,14 +11,8 @@ struct HC_PERFORM_ENV
 public:
     HC_PERFORM_ENV();
     virtual ~HC_PERFORM_ENV();
-    void get_proxy_name(
-        _In_ xbox::httpclient::proxy_type proxyType,
-        _Out_ DWORD* pAccessType,
-        _Out_ const wchar_t** pwProxyName);
 
     HINTERNET m_hSession = nullptr;
-    xbox::httpclient::Uri m_proxyUri;
-    http_internal_wstring m_wProxyName;
     xbox::httpclient::proxy_type m_proxyType = xbox::httpclient::proxy_type::default_proxy;
 };
 

--- a/Source/HTTP/httpcall.h
+++ b/Source/HTTP/httpcall.h
@@ -70,6 +70,11 @@ HRESULT Internal_InitializeHttpPlatform(HCInitArgs* args, PerformEnv& performEnv
 
 void Internal_CleanupHttpPlatform(HC_PERFORM_ENV* performEnv) noexcept;
 
+HRESULT Internal_SetGlobalProxy(
+    _In_ HC_PERFORM_ENV* performEnv,
+    _In_ const char* proxyUri
+) noexcept;
+
 void CALLBACK Internal_HCHttpCallPerformAsync(
     _In_ HCCallHandle call,
     _Inout_ XAsyncBlock* asyncBlock,


### PR DESCRIPTION
Enables a software specified named proxy. Currently only supported for win32 using the winhttp implementation. Tested setting, resetting, various valid and invalid input, active proxy, proxy running but disabled, etc. Validated tests did not regress.