### PR TITLE
fix for https://github.com/microsoft/libHttpClient/issues/458

### DIFF
--- a/Source/Task/TaskQueue.cpp
+++ b/Source/Task/TaskQueue.cpp
@@ -530,7 +530,7 @@ void __stdcall TaskQueuePortImpl::Terminate(
     {
     case XTaskQueueDispatchMode::SerializedThreadPool:
     case XTaskQueueDispatchMode::ThreadPool:
-        m_threadPool.Submit();
+        m_threadPool.Submit(true);
         break;
 
     case XTaskQueueDispatchMode::Immediate:

--- a/Source/Task/ThreadPool.h
+++ b/Source/Task/ThreadPool.h
@@ -26,7 +26,7 @@ public:
     // Submits a new callback to the thread pool.  The callback passed to Initialize will
     // be invoked on a thread pool thread. May throw / crash if called after termination
     // or before init.
-    void Submit();
+    void Submit(bool isTerminating = false);
 
 private:
     ThreadPoolImpl* m_impl;

--- a/Source/Task/ThreadPool_stl.cpp
+++ b/Source/Task/ThreadPool_stl.cpp
@@ -176,7 +176,7 @@ public:
         m_pool.clear();
     }
 
-    void Submit() noexcept
+    void Submit(bool isTerminating) noexcept
     {
         {
             std::unique_lock<std::mutex> lock(m_wakeLock);
@@ -269,9 +269,9 @@ void ThreadPool::Terminate() noexcept
     }
 }
 
-void ThreadPool::Submit()
+void ThreadPool::Submit(bool isTerminating)
 {
-    m_impl->Submit();
+    m_impl->Submit(isTerminating);
 }
 
 #if defined(HC_PLATFORM) && HC_PLATFORM == HC_PLATFORM_ANDROID


### PR DESCRIPTION
This fixes the issue where SubmitThreadpoolWork crashes during program shutdown. This is due to the fact that this function is using IllegalToCallDuringShutdown parameter to validate calls.

Added a simple boolean parameter (false by default) that does call TPCallback directly instead of a work submission to avoid crash and still trigger events 