### PR TITLE
Fixing bugs in http mock framework

### DIFF
--- a/Source/Global/global.h
+++ b/Source/Global/global.h
@@ -84,7 +84,6 @@ typedef struct http_singleton
     // Mock state
     std::recursive_mutex m_mocksLock;
     http_internal_vector<HC_MOCK_CALL*> m_mocks;
-    HC_MOCK_CALL* m_lastMatchingMock = nullptr;
 
     std::recursive_mutex m_sharedPtrsLock;
     http_internal_unordered_map<void*, std::shared_ptr<void>> m_sharedPtrs;

--- a/Source/HTTP/httpcall.h
+++ b/Source/HTTP/httpcall.h
@@ -17,7 +17,7 @@ struct HC_CALL
     {
         refCount = 1;
     }
-    ~HC_CALL();
+    virtual ~HC_CALL();
 
     http_internal_string method;
     http_internal_string url;

--- a/Source/Mock/mock_publics.cpp
+++ b/Source/Mock/mock_publics.cpp
@@ -113,6 +113,7 @@ try
         if (*iter == call)
         {
             mocks.erase(iter);
+            HCHttpCallCloseHandle(call);
             return S_OK;
         }
     }


### PR DESCRIPTION
* Mock call is never cleaned up when HCMockRemoveMock is called despite the doc comments indicating that it should be.
* Race condition where mock can be removed after being identified as a matching mock