### PR TITLE
Fix lifetime issues with http_singleton

### DIFF
--- a/Source/Global/global.cpp
+++ b/Source/Global/global.cpp
@@ -104,6 +104,10 @@ HRESULT http_singleton::cleanup_async(
         {
         case XAsyncOp::Begin:
         {
+            return XAsyncSchedule(data->async, 0);
+        }
+        case XAsyncOp::DoWork:
+        {
             auto singleton{ static_cast<http_singleton*>(data->context)->shared_from_this() };
             singleton->m_self.reset();
 

--- a/Source/Global/global.cpp
+++ b/Source/Global/global.cpp
@@ -126,7 +126,7 @@ HRESULT http_singleton::cleanup_async(
 
             shared_ptr_cache::cleanup(self);
 
-            // self is the only reference at this point, singleton will be destroyed on this thread.
+            // self is the only reference at this point, the singleton will be destroyed on this thread.
             self.reset();
 
             XAsyncComplete(data->async, S_OK, 0);

--- a/Source/Global/global.cpp
+++ b/Source/Global/global.cpp
@@ -13,9 +13,124 @@
 
 using namespace xbox::httpclient;
 
-static std::shared_ptr<http_singleton> g_httpSingleton_atomicReadsOnly;
-
 NAMESPACE_XBOX_HTTP_CLIENT_BEGIN
+
+enum class singleton_access_mode
+{
+    get,
+    set
+};
+
+std::shared_ptr<http_singleton> singleton_access(
+    _In_ singleton_access_mode mode,
+    _In_opt_ std::shared_ptr<http_singleton> singleton = nullptr
+) noexcept
+{
+    static std::mutex s_mutex;
+    static std::shared_ptr<http_singleton> s_singleton{ nullptr };
+
+    std::lock_guard<std::mutex> lock{ s_mutex };
+    switch (mode)
+    {
+    case singleton_access_mode::get:
+    {
+        assert(!singleton);
+        return s_singleton;
+    }
+    case singleton_access_mode::set:
+    {
+        std::swap(s_singleton, singleton);
+        return singleton;
+    }
+    default: 
+    {
+        assert(false);
+        return nullptr;
+    }
+    }
+}
+
+HRESULT http_singleton::create(
+    _In_ HCInitArgs* args
+) noexcept
+{
+    if (singleton_access(singleton_access_mode::get))
+    {
+        return E_HC_ALREADY_INITIALISED;
+    }
+
+    PerformEnv performEnv;
+    auto hr = Internal_InitializeHttpPlatform(args, performEnv);
+
+    if (SUCCEEDED(hr))
+    {
+        auto rawSingleton = new (http_memory::mem_alloc(sizeof(http_singleton))) http_singleton(
+            GetUserHttpPerformHandler(),
+#if !HC_NOWEBSOCKETS
+            GetUserWebSocketPerformHandlers(),
+#endif
+            std::move(performEnv)
+            );
+
+        auto singleton = std::shared_ptr<http_singleton>(rawSingleton, http_alloc_deleter<http_singleton>());
+
+        // Store self reference to be remove on http_singleton::cleanup_async
+        singleton->m_self = singleton;
+
+        singleton = singleton_access(singleton_access_mode::set, singleton);
+    }
+
+    return S_OK;
+}
+
+HRESULT http_singleton::cleanup_async(
+    _In_ XAsyncBlock* async
+) noexcept
+{
+    auto singleton{ singleton_access(singleton_access_mode::set, nullptr) };
+    if (!singleton)
+    {
+        E_HC_NOT_INITIALISED;
+    }
+
+    return XAsyncBegin(
+        async,
+        singleton.get(),
+        reinterpret_cast<void*>(cleanup_async),
+        __FUNCTION__,
+        [](XAsyncOp op, const XAsyncProviderData* data)
+    {
+        switch (op)
+        {
+        case XAsyncOp::Begin:
+        {
+            auto singleton{ static_cast<http_singleton*>(data->context)->shared_from_this() };
+            singleton->m_self.reset();
+
+            shared_ptr_cache::cleanup(singleton);
+
+            // Wait for all other references to the singleton to go away
+            // Note that the use count check here is only valid because we never create
+            // a weak_ptr to the singleton. If we did that could cause the use count
+            // to increase even though we are the only strong reference
+            while (singleton.use_count() > 1)
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds{ 10 });
+            }
+
+            // Destroy singleton on this thread
+            singleton.reset();
+
+            XAsyncComplete(data->async, S_OK, 0);
+            return S_OK;
+        }
+        default:
+        {
+            return S_OK;
+        }
+        }
+    });
+}
 
 http_singleton::http_singleton(
     HttpPerformInfo const& httpPerformInfo,
@@ -33,7 +148,6 @@ http_singleton::http_singleton(
 
 http_singleton::~http_singleton()
 {
-    g_httpSingleton_atomicReadsOnly = nullptr;
     for (auto& mockCall : m_mocks)
     {
         HCHttpCallCloseHandle(mockCall);
@@ -43,66 +157,7 @@ http_singleton::~http_singleton()
 
 std::shared_ptr<http_singleton> get_http_singleton()
 {
-    auto httpSingleton = std::atomic_load(&g_httpSingleton_atomicReadsOnly);
-    return httpSingleton;
-}
-
-HRESULT init_http_singleton(HCInitArgs* args)
-{
-    HRESULT hr = S_OK;
-
-    // TODO do as a run once? to avoid platform code being inited twice?
-    auto httpSingleton = std::atomic_load(&g_httpSingleton_atomicReadsOnly);
-    if (!httpSingleton)
-    {
-        PerformEnv performEnv;
-        hr = Internal_InitializeHttpPlatform(args, performEnv);
-
-        if (SUCCEEDED(hr))
-        {
-            auto newSingleton = http_allocate_shared<http_singleton>(
-                GetUserHttpPerformHandler(),
-#if !HC_NOWEBSOCKETS
-                GetUserWebSocketPerformHandlers(),
-#endif
-                std::move(performEnv)
-            );
-            std::atomic_compare_exchange_strong(
-                &g_httpSingleton_atomicReadsOnly,
-                &httpSingleton,
-                newSingleton
-            );
-
-            if (newSingleton == nullptr)
-            {
-                hr = E_OUTOFMEMORY;
-            }
-            // At this point there is a singleton (ours or someone else's)
-        }
-    }
-
-    return hr;
-}
-
-void cleanup_http_singleton()
-{
-    std::shared_ptr<http_singleton> httpSingleton;
-    httpSingleton = std::atomic_exchange(&g_httpSingleton_atomicReadsOnly, httpSingleton);
-
-    if (httpSingleton != nullptr)
-    {
-        shared_ptr_cache::cleanup(httpSingleton);
-
-        // Wait for all other references to the singleton to go away
-        // Note that the use count check here is only valid because we never create
-        // a weak_ptr to the singleton. If we did that could cause the use count
-        // to increase even though we are the only strong reference
-        while (httpSingleton.use_count() > 1)
-        {
-            std::this_thread::sleep_for(std::chrono::milliseconds{ 10 });
-        }
-        // httpSingleton will be destroyed on this thread now
-    }
+    return singleton_access(singleton_access_mode::get);
 }
 
 void http_singleton::set_retry_state(

--- a/Source/Global/global.h
+++ b/Source/Global/global.h
@@ -37,7 +37,7 @@ static const uint32_t DEFAULT_TIMEOUT_WINDOW_IN_SECONDS = 20;
 static const uint32_t DEFAULT_HTTP_TIMEOUT_IN_SECONDS = 30;
 static const uint32_t DEFAULT_RETRY_DELAY_IN_SECONDS = 2;
 
-typedef struct http_singleton : public std::enable_shared_from_this<http_singleton>
+typedef struct http_singleton
 {
 public:
     static HRESULT create(_In_ HCInitArgs* args) noexcept;

--- a/Source/Global/global.h
+++ b/Source/Global/global.h
@@ -43,6 +43,13 @@ public:
     static HRESULT create(_In_ HCInitArgs* args) noexcept;
     static HRESULT cleanup_async(_In_ XAsyncBlock* async) noexcept;
 
+    http_singleton(
+        HttpPerformInfo const& httpPerformInfo,
+#if !HC_NOWEBSOCKETS
+        WebSocketPerformInfo const& websocketPerformInfo,
+#endif
+        PerformEnv&& performEnv
+    );
     http_singleton(const http_singleton&) = delete;
     http_singleton& operator=(http_singleton) = delete;
     ~http_singleton();
@@ -91,14 +98,6 @@ public:
     http_internal_unordered_map<void*, std::shared_ptr<void>> m_sharedPtrs;
 
 private:
-    http_singleton(
-        HttpPerformInfo const& httpPerformInfo,
-#if !HC_NOWEBSOCKETS
-        WebSocketPerformInfo const& websocketPerformInfo,
-#endif
-        PerformEnv&& performEnv
-    );
-
     // Self reference to prevent deletion on static shutdown.
     std::shared_ptr<http_singleton> m_self{ nullptr };
 } http_singleton;

--- a/Source/Global/global_publics.cpp
+++ b/Source/Global/global_publics.cpp
@@ -28,14 +28,20 @@ HCInitialize(_In_opt_ HCInitArgs* args) noexcept
 try
 {
     HCTraceImplInit();
-    return xbox::httpclient::init_http_singleton(args);
+    return http_singleton::create(args);
 }
 CATCH_RETURN()
 
 STDAPI_(void) HCCleanup() noexcept
 try
 {
-    xbox::httpclient::cleanup_http_singleton();
+    XAsyncBlock async{};
+    HRESULT hr = http_singleton::cleanup_async(&async);
+    if (SUCCEEDED(hr))
+    {
+        XAsyncGetStatus(&async, true);
+    }
+
     HCTraceImplCleanup();
 }
 CATCH_RETURN_WITH(;)

--- a/Source/WebSocket/hcwebsocket.cpp
+++ b/Source/WebSocket/hcwebsocket.cpp
@@ -735,7 +735,7 @@ try
         return E_INVALIDARG;
     }
 
-    auto headers{ websocket->Headers() };
+    auto& headers{ websocket->Headers() };
     auto it = headers.find(headerName);
     if (it != headers.end())
     {

--- a/Source/WebSocket/hcwebsocket.h
+++ b/Source/WebSocket/hcwebsocket.h
@@ -66,7 +66,7 @@ public:
 
 private:
     XAsyncBlock m_connectAsyncBlock{};
-    WebSocketCompletionResult m_connectResult;
+    WebSocketCompletionResult m_connectResult{};
     XAsyncBlock* m_clientConnectAsyncBlock{ nullptr };
 
     enum class State

--- a/Tests/UnitTests/Tests/MockTests.cpp
+++ b/Tests/UnitTests/Tests/MockTests.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #include "pch.h"
@@ -42,44 +42,23 @@ public:
         HCMockCallHandle mockCall = CreateMockCall("Mock1", false, false);
         VERIFY_ARE_EQUAL(S_OK, HCMockAddMock(mockCall, "", "", nullptr, 0));
 
-        XTaskQueueHandle queue;
-        XTaskQueueCreate(
-            XTaskQueueDispatchMode::Manual,
-            XTaskQueueDispatchMode::Manual,
-            &queue);
+        XAsyncBlock asyncBlock{};
+        VERIFY_ARE_EQUAL(S_OK, HCHttpCallPerformAsync(call, &asyncBlock));
+        VERIFY_SUCCEEDED(XAsyncGetStatus(&asyncBlock, true));
 
-        XAsyncBlock* asyncBlock = new XAsyncBlock;
-        ZeroMemory(asyncBlock, sizeof(XAsyncBlock));
-        asyncBlock->context = call;
-        asyncBlock->queue = queue;
-        asyncBlock->callback = [](XAsyncBlock* asyncBlock)
-        {
-            HRESULT errCode = S_OK;
-            uint32_t platErrCode = 0;
-            uint32_t statusCode = 0;
-            PCSTR responseStr;
-            HCCallHandle call = static_cast<HCCallHandle>(asyncBlock->context);
-            VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetNetworkErrorCode(call, &errCode, &platErrCode));
-            VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetStatusCode(call, &statusCode));
-            VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetResponseString(call, &responseStr));
-            VERIFY_ARE_EQUAL(E_OUTOFMEMORY, errCode);
-            VERIFY_ARE_EQUAL(300, platErrCode);
-            VERIFY_ARE_EQUAL(400, statusCode);
-            VERIFY_ARE_EQUAL_STR("Mock1", responseStr);
-            VERIFY_ARE_EQUAL(S_OK, HCHttpCallCloseHandle(call));
-            g_gotCall = true;
-            delete asyncBlock;
-        };
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallPerformAsync(call, asyncBlock));
+        HRESULT errCode = S_OK;
+        uint32_t platErrCode = 0;
+        uint32_t statusCode = 0;
+        PCSTR responseStr;
+        VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetNetworkErrorCode(call, &errCode, &platErrCode));
+        VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetStatusCode(call, &statusCode));
+        VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetResponseString(call, &responseStr));
+        VERIFY_ARE_EQUAL(E_OUTOFMEMORY, errCode);
+        VERIFY_ARE_EQUAL(300, platErrCode);
+        VERIFY_ARE_EQUAL(400, statusCode);
+        VERIFY_ARE_EQUAL_STR("Mock1", responseStr);
+        VERIFY_ARE_EQUAL(S_OK, HCHttpCallCloseHandle(call));
 
-        while (true)
-        {
-            if (!XTaskQueueDispatch(queue, XTaskQueuePort::Work, 0)) break;
-        }
-        VERIFY_ARE_EQUAL(true, XTaskQueueDispatch(queue, XTaskQueuePort::Completion, 0));
-        VERIFY_ARE_EQUAL(true, g_gotCall);
-
-        XTaskQueueCloseHandle(queue);
         HCCleanup();
     }
 
@@ -93,29 +72,21 @@ public:
         VERIFY_ARE_EQUAL(S_OK, HCMockAddMock(mockCall, nullptr, nullptr, nullptr, 0));
 
         HCCallHandle call = nullptr;
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallCreate(&call));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRetryAllowed(call, false));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetUrl(call, "1", "2"));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRequestBodyString(call, "3"));
-        g_gotCall = false;
 
-        XTaskQueueHandle queue;
-        XTaskQueueCreate(
-            XTaskQueueDispatchMode::Manual,
-            XTaskQueueDispatchMode::Manual,
-            &queue);
-
-        XAsyncBlock* asyncBlock = new XAsyncBlock;
-        ZeroMemory(asyncBlock, sizeof(XAsyncBlock));
-        asyncBlock->context = call;
-        asyncBlock->queue = queue;
-        asyncBlock->callback = [](XAsyncBlock* asyncBlock)
         {
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallCreate(&call));
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRetryAllowed(call, false));
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetUrl(call, "1", "2"));
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRequestBodyString(call, "3"));
+
+            XAsyncBlock asyncBlock{};
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallPerformAsync(call, &asyncBlock));
+            VERIFY_SUCCEEDED(XAsyncGetStatus(&asyncBlock, true));
+
             HRESULT errCode = S_OK;
             uint32_t platErrCode = 0;
             uint32_t statusCode = 0;
             PCSTR responseStr;
-            HCCallHandle call = static_cast<HCCallHandle>(asyncBlock->context);
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetNetworkErrorCode(call, &errCode, &platErrCode));
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetStatusCode(call, &statusCode));
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetResponseString(call, &responseStr));
@@ -124,58 +95,32 @@ public:
             VERIFY_ARE_EQUAL(400, statusCode);
             VERIFY_ARE_EQUAL_STR("Mock1", responseStr);
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallCloseHandle(call));
-            g_gotCall = true;
-            delete asyncBlock;
-        };
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallPerformAsync(call, asyncBlock));
-
-        VERIFY_ARE_EQUAL(false, g_gotCall);
-        while (true)
-        {
-            if (!XTaskQueueDispatch(queue, XTaskQueuePort::Work, 0)) break;
         }
-        VERIFY_ARE_EQUAL(true, XTaskQueueDispatch(queue, XTaskQueuePort::Completion, 0));
-        VERIFY_ARE_EQUAL(true, g_gotCall);
-        g_gotCall = false;
 
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallCreate(&call));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRetryAllowed(call, false));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetUrl(call, "10", "20"));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRequestBodyString(call, "3"));
-
-        XAsyncBlock* asyncBlock2 = new XAsyncBlock;
-        ZeroMemory(asyncBlock2, sizeof(XAsyncBlock));
-        asyncBlock2->context = call;
-        asyncBlock2->queue = queue;
-        asyncBlock2->callback = [](XAsyncBlock* asyncBlock)
         {
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallCreate(&call));
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRetryAllowed(call, false));
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetUrl(call, "10", "20"));
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRequestBodyString(call, "3"));
+
+            XAsyncBlock asyncBlock2{};
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallPerformAsync(call, &asyncBlock2));
+            VERIFY_SUCCEEDED(XAsyncGetStatus(&asyncBlock2, true));
+
             HRESULT errCode = S_OK;
             uint32_t platErrCode = 0;
             uint32_t statusCode = 0;
             PCSTR responseStr;
-            HCCallHandle call = static_cast<HCCallHandle>(asyncBlock->context);
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetNetworkErrorCode(call, &errCode, &platErrCode));
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetStatusCode(call, &statusCode));
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetResponseString(call, &responseStr));
-            VERIFY_ARE_EQUAL(0, errCode);
-            VERIFY_ARE_EQUAL(0, statusCode);
-            VERIFY_ARE_EQUAL_STR("", responseStr);
+            VERIFY_ARE_EQUAL(E_OUTOFMEMORY, errCode);
+            VERIFY_ARE_EQUAL(300, platErrCode);
+            VERIFY_ARE_EQUAL(400, statusCode);
+            VERIFY_ARE_EQUAL_STR("Mock1", responseStr);
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallCloseHandle(call));
-            g_gotCall = true;
-            delete asyncBlock;
-        };
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallPerformAsync(call, asyncBlock2));
-
-        VERIFY_ARE_EQUAL(false, g_gotCall);
-        while (true)
-        {
-            if (!XTaskQueueDispatch(queue, XTaskQueuePort::Work, 0)) break;
         }
-        VERIFY_ARE_EQUAL(true, XTaskQueueDispatch(queue, XTaskQueuePort::Completion, 0));
-        VERIFY_ARE_EQUAL(true, g_gotCall);
-        g_gotCall = false;
 
-        XTaskQueueCloseHandle(queue);
         HCCleanup();
     }
 
@@ -189,29 +134,21 @@ public:
         VERIFY_ARE_EQUAL(S_OK, HCMockAddMock(mockCall, nullptr, nullptr, nullptr, 0));
 
         HCCallHandle call = nullptr;
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallCreate(&call));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRetryAllowed(call, false));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetUrl(call, "1", "2"));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRequestBodyString(call, "requestBody"));
-        g_gotCall = false;
 
-        XTaskQueueHandle queue;
-        XTaskQueueCreate(
-            XTaskQueueDispatchMode::Manual,
-            XTaskQueueDispatchMode::Manual,
-            &queue);
-
-        XAsyncBlock* asyncBlock = new XAsyncBlock;
-        ZeroMemory(asyncBlock, sizeof(XAsyncBlock));
-        asyncBlock->context = call;
-        asyncBlock->queue = queue;
-        asyncBlock->callback = [](XAsyncBlock* asyncBlock)
         {
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallCreate(&call));
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRetryAllowed(call, false));
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetUrl(call, "1", "2"));
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRequestBodyString(call, "requestBody"));
+
+            XAsyncBlock asyncBlock{};
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallPerformAsync(call, &asyncBlock));
+            VERIFY_SUCCEEDED(XAsyncGetStatus(&asyncBlock, true));
+
             HRESULT errCode = S_OK;
             uint32_t platErrCode = 0;
             uint32_t statusCode = 0;
             PCSTR responseStr;
-            HCCallHandle call = static_cast<HCCallHandle>(asyncBlock->context);
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetNetworkErrorCode(call, &errCode, &platErrCode));
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetStatusCode(call, &statusCode));
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetResponseString(call, &responseStr));
@@ -220,74 +157,23 @@ public:
             VERIFY_ARE_EQUAL(400, statusCode);
             VERIFY_ARE_EQUAL_STR("Mock1", responseStr);
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallCloseHandle(call));
-            g_gotCall = true;
-            delete asyncBlock;
-        };
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallPerformAsync(call, asyncBlock));
-
-        VERIFY_ARE_EQUAL(false, g_gotCall);
-        while (true)
-        {
-            if (!XTaskQueueDispatch(queue, XTaskQueuePort::Work, 0)) break;
         }
-        VERIFY_ARE_EQUAL(true, XTaskQueueDispatch(queue, XTaskQueuePort::Completion, 0));
-        VERIFY_ARE_EQUAL(true, g_gotCall);
-        g_gotCall = false;
-
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallCreate(&call));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRetryAllowed(call, false));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetUrl(call, "1", "2"));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRequestBodyString(call, "3"));
-
-        XAsyncBlock* asyncBlock2 = new XAsyncBlock;
-        ZeroMemory(asyncBlock2, sizeof(XAsyncBlock));
-        asyncBlock2->context = call;
-        asyncBlock2->queue = queue;
-        asyncBlock2->callback = [](XAsyncBlock* asyncBlock)
-        {
-            HRESULT errCode = S_OK;
-            uint32_t platErrCode = 0;
-            uint32_t statusCode = 0;
-            PCSTR responseStr;
-            HCCallHandle call = static_cast<HCCallHandle>(asyncBlock->context);
-            VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetNetworkErrorCode(call, &errCode, &platErrCode));
-            VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetStatusCode(call, &statusCode));
-            VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetResponseString(call, &responseStr));
-            VERIFY_ARE_EQUAL(0, errCode);
-            VERIFY_ARE_EQUAL(0, statusCode);
-            VERIFY_ARE_EQUAL_STR("", responseStr);
-            HCHttpCallCloseHandle(call);
-            g_gotCall = true;
-            delete asyncBlock;
-        };
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallPerformAsync(call, asyncBlock2));
-
-        VERIFY_ARE_EQUAL(false, g_gotCall);
-        while (true)
-        {
-            if (!XTaskQueueDispatch(queue, XTaskQueuePort::Work, 0)) break;
-        }
-        VERIFY_ARE_EQUAL(true, XTaskQueueDispatch(queue, XTaskQueuePort::Completion, 0));
-        VERIFY_ARE_EQUAL(true, g_gotCall);
-        g_gotCall = false;
 
         VERIFY_ARE_EQUAL(S_OK, HCMockClearMocks());
 
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallCreate(&call));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetUrl(call, "1", "2"));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRequestBodyString(call, "requestBody"));
-
-        XAsyncBlock* asyncBlock3 = new XAsyncBlock;
-        ZeroMemory(asyncBlock3, sizeof(XAsyncBlock));
-        asyncBlock3->context = call;
-        asyncBlock3->queue = queue;
-        asyncBlock3->callback = [](XAsyncBlock* asyncBlock)
         {
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallCreate(&call));
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetUrl(call, "1", "2"));
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRequestBodyString(call, "requestBody"));
+
+            XAsyncBlock asyncBlock3{};
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallPerformAsync(call, &asyncBlock3));
+            VERIFY_SUCCEEDED(XAsyncGetStatus(&asyncBlock3, true));
+
             HRESULT errCode = S_OK;
             uint32_t platErrCode = 0;
             uint32_t statusCode = 0;
             PCSTR responseStr;
-            HCCallHandle call = static_cast<HCCallHandle>(asyncBlock->context);
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetNetworkErrorCode(call, &errCode, &platErrCode));
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetStatusCode(call, &statusCode));
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetResponseString(call, &responseStr));
@@ -295,60 +181,33 @@ public:
             VERIFY_ARE_EQUAL(0, statusCode);
             VERIFY_ARE_EQUAL_STR("", responseStr);
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallCloseHandle(call));
-            g_gotCall = true;
-            delete asyncBlock;
-        };
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallPerformAsync(call, asyncBlock3));
-
-        VERIFY_ARE_EQUAL(false, g_gotCall);
-        while (true)
-        {
-            if (!XTaskQueueDispatch(queue, XTaskQueuePort::Work, 0)) break;
         }
-        VERIFY_ARE_EQUAL(true, XTaskQueueDispatch(queue, XTaskQueuePort::Completion, 0));
-        VERIFY_ARE_EQUAL(true, g_gotCall);
-        g_gotCall = false;
 
         HCMockClearMocks();
 
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallCreate(&call));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetUrl(call, "1", "2"));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRequestBodyString(call, "requestBody"));
-
-        XAsyncBlock* asyncBlock4 = new XAsyncBlock;
-        ZeroMemory(asyncBlock4, sizeof(XAsyncBlock));
-        asyncBlock4->context = call;
-        asyncBlock4->queue = queue;
-        asyncBlock4->callback = [](XAsyncBlock* asyncBlock)
         {
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallCreate(&call));
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetUrl(call, "1", "2"));
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRequestBodyString(call, "requestBody"));
+
+            XAsyncBlock asyncBlock4{};
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallPerformAsync(call, &asyncBlock4));
+            VERIFY_SUCCEEDED(XAsyncGetStatus(&asyncBlock4, true));
+
             HRESULT errCode = S_OK;
             uint32_t platErrCode = 0;
             uint32_t statusCode = 0;
             PCSTR responseStr;
-            HCCallHandle call = static_cast<HCCallHandle>(asyncBlock->context);
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetNetworkErrorCode(call, &errCode, &platErrCode));
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetStatusCode(call, &statusCode));
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetResponseString(call, &responseStr));
             VERIFY_ARE_EQUAL(0, errCode);
             VERIFY_ARE_EQUAL(0, statusCode);
             VERIFY_ARE_EQUAL_STR("", responseStr);
-            HCHttpCallCloseHandle(call);
-            g_gotCall = true;
-            delete asyncBlock;
-        };
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallPerformAsync(call, asyncBlock4));
-
-        while (true)
-        {
-            if (!XTaskQueueDispatch(queue, XTaskQueuePort::Work, 0)) break;
         }
-        VERIFY_ARE_EQUAL(true, XTaskQueueDispatch(queue, XTaskQueuePort::Completion, 0));
-        g_gotCall = false;
 
-        XTaskQueueCloseHandle(queue);
         HCCleanup();
     }
-
 
     DEFINE_TEST_CASE(ExampleMultiSpecificUrlBodyMock)
     {
@@ -357,34 +216,24 @@ public:
         VERIFY_ARE_EQUAL(S_OK, HCInitialize(nullptr));
 
         HCMockCallHandle mockCall1 = CreateMockCall("Mock1", true, true);
-        HCMockCallHandle mockCall2 = CreateMockCall("Mock2", true, true);
         VERIFY_ARE_EQUAL(S_OK, HCMockAddMock(mockCall1, nullptr, nullptr, nullptr, 0));
-        VERIFY_ARE_EQUAL(S_OK, HCMockAddMock(mockCall2, nullptr, nullptr, nullptr, 0));
 
         HCCallHandle call = nullptr;
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallCreate(&call));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRetryAllowed(call, false));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetUrl(call, "1", "2"));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRequestBodyString(call, "requestBody"));
-        g_gotCall = false;
 
-        XTaskQueueHandle queue;
-        XTaskQueueCreate(
-            XTaskQueueDispatchMode::Manual,
-            XTaskQueueDispatchMode::Manual,
-            &queue);
-
-        XAsyncBlock* asyncBlock = new XAsyncBlock;
-        ZeroMemory(asyncBlock, sizeof(XAsyncBlock));
-        asyncBlock->context = call;
-        asyncBlock->queue = queue;
-        asyncBlock->callback = [](XAsyncBlock* asyncBlock)
         {
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallCreate(&call));
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRetryAllowed(call, false));
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetUrl(call, "1", "2"));
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRequestBodyString(call, "requestBody"));
+
+            XAsyncBlock asyncBlock{};
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallPerformAsync(call, &asyncBlock));
+            VERIFY_SUCCEEDED(XAsyncGetStatus(&asyncBlock, true));
+
             HRESULT errCode = S_OK;
             uint32_t platErrCode = 0;
             uint32_t statusCode = 0;
             PCSTR responseStr;
-            HCCallHandle call = static_cast<HCCallHandle>(asyncBlock->context);
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetNetworkErrorCode(call, &errCode, &platErrCode));
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetStatusCode(call, &statusCode));
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetResponseString(call, &responseStr));
@@ -393,36 +242,25 @@ public:
             VERIFY_ARE_EQUAL(400, statusCode);
             VERIFY_ARE_EQUAL_STR("Mock1", responseStr);
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallCloseHandle(call));
-            g_gotCall = true;
-            delete asyncBlock;
-        };
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallPerformAsync(call, asyncBlock));
-
-        VERIFY_ARE_EQUAL(false, g_gotCall);
-        while (true)
-        {
-            if (!XTaskQueueDispatch(queue, XTaskQueuePort::Work, 0)) break;
         }
-        VERIFY_ARE_EQUAL(true, XTaskQueueDispatch(queue, XTaskQueuePort::Completion, 0));
-        VERIFY_ARE_EQUAL(true, g_gotCall);
-        g_gotCall = false;
 
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallCreate(&call));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRetryAllowed(call, false));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetUrl(call, "1", "2"));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRequestBodyString(call, "requestBody"));
+        HCMockCallHandle mockCall2 = CreateMockCall("Mock2", true, true);
+        VERIFY_ARE_EQUAL(S_OK, HCMockAddMock(mockCall2, nullptr, nullptr, nullptr, 0));
 
-        XAsyncBlock* asyncBlock2 = new XAsyncBlock;
-        ZeroMemory(asyncBlock2, sizeof(XAsyncBlock));
-        asyncBlock2->context = call;
-        asyncBlock2->queue = queue;
-        asyncBlock2->callback = [](XAsyncBlock* asyncBlock)
         {
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallCreate(&call));
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRetryAllowed(call, false));
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetUrl(call, "1", "2"));
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRequestBodyString(call, "requestBody"));
+
+            XAsyncBlock asyncBlock2{};
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallPerformAsync(call, &asyncBlock2));
+            VERIFY_SUCCEEDED(XAsyncGetStatus(&asyncBlock2, true));
+
             HRESULT errCode = S_OK;
             uint32_t platErrCode = 0;
             uint32_t statusCode = 0;
             PCSTR responseStr;
-            HCCallHandle call = static_cast<HCCallHandle>(asyncBlock->context);
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetNetworkErrorCode(call, &errCode, &platErrCode));
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetStatusCode(call, &statusCode));
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetResponseString(call, &responseStr));
@@ -431,37 +269,23 @@ public:
             VERIFY_ARE_EQUAL(400, statusCode);
             VERIFY_ARE_EQUAL_STR("Mock2", responseStr);
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallCloseHandle(call));
-            g_gotCall = true;
-            delete asyncBlock;
-        };
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallPerformAsync(call, asyncBlock2));
-
-        VERIFY_ARE_EQUAL(false, g_gotCall);
-        while (true)
-        {
-            if (!XTaskQueueDispatch(queue, XTaskQueuePort::Work, 0)) break;
         }
-        VERIFY_ARE_EQUAL(true, XTaskQueueDispatch(queue, XTaskQueuePort::Completion, 0));
-        VERIFY_ARE_EQUAL(true, g_gotCall);
-        g_gotCall = false;
 
-        // Call 3 should repeat mock 2
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallCreate(&call));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRetryAllowed(call, false));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetUrl(call, "1", "2"));
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRequestBodyString(call, "requestBody"));
-
-        XAsyncBlock* asyncBlock3 = new XAsyncBlock;
-        ZeroMemory(asyncBlock3, sizeof(XAsyncBlock));
-        asyncBlock3->context = call;
-        asyncBlock3->queue = queue;
-        asyncBlock3->callback = [](XAsyncBlock* asyncBlock)
         {
+            // Call 3 should repeat mock 2
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallCreate(&call));
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRetryAllowed(call, false));
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetUrl(call, "1", "2"));
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallRequestSetRequestBodyString(call, "requestBody"));
+
+            XAsyncBlock asyncBlock3{};
+            VERIFY_ARE_EQUAL(S_OK, HCHttpCallPerformAsync(call, &asyncBlock3));
+            VERIFY_SUCCEEDED(XAsyncGetStatus(&asyncBlock3, true));
+
             HRESULT errCode = S_OK;
             uint32_t platErrCode = 0;
             uint32_t statusCode = 0;
             PCSTR responseStr;
-            HCCallHandle call = static_cast<HCCallHandle>(asyncBlock->context);
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetNetworkErrorCode(call, &errCode, &platErrCode));
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetStatusCode(call, &statusCode));
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallResponseGetResponseString(call, &responseStr));
@@ -470,21 +294,8 @@ public:
             VERIFY_ARE_EQUAL(400, statusCode);
             VERIFY_ARE_EQUAL_STR("Mock2", responseStr);
             VERIFY_ARE_EQUAL(S_OK, HCHttpCallCloseHandle(call));
-            g_gotCall = true;
-            delete asyncBlock;
-        };
-        VERIFY_ARE_EQUAL(S_OK, HCHttpCallPerformAsync(call, asyncBlock3));
-
-        VERIFY_ARE_EQUAL(false, g_gotCall);
-        while (true)
-        {
-            if (!XTaskQueueDispatch(queue, XTaskQueuePort::Work, 0)) break;
         }
-        VERIFY_ARE_EQUAL(true, XTaskQueueDispatch(queue, XTaskQueuePort::Completion, 0));
-        VERIFY_ARE_EQUAL(true, g_gotCall);
-        g_gotCall = false;
 
-        XTaskQueueCloseHandle(queue);
         HCCleanup();
     }
 


### PR DESCRIPTION
*Fix lifetime issues with http_singleton - it will only be cleaned up when HCCleanup is called.
*Fix a couple of minor bugs in HCWebsocket
*Repair broken unit tests (unrelated to bug)