### PR TITLE
PR feedback from Windows

### DIFF
--- a/Source/Task/LocklessQueue.h
+++ b/Source/Task/LocklessQueue.h
@@ -190,7 +190,7 @@ public:
     bool push_back(_In_ const TData& data)
     {
         TData copy = data;
-        return move_back(copy);
+        return move_back(std::move(copy));
     }
 
     //
@@ -212,7 +212,7 @@ public:
     void push_back(_In_ const TData& data, _In_ uint64_t address)
     {
         TData copy = data;
-        move_back(copy, address);
+        move_back(std::move(copy), address);
     }
 
     //
@@ -729,7 +729,7 @@ private:
 
     // Workers for pushing nodes to the back
     // of the queue.  This always moves data
-    bool move_back(_In_ TData& data) noexcept
+    bool move_back(_In_ TData&& data) noexcept
     {
         Address address;
         Node* node = m_heap.alloc(address);
@@ -746,7 +746,7 @@ private:
 
     // Workers for pushing nodes to the back
     // of the queue.  This always moves data
-    void move_back(_In_ TData& data, _In_ uint64_t address) noexcept
+    void move_back(_In_ TData&& data, _In_ uint64_t address) noexcept
     {
         Address a;
         a = address;

--- a/Source/Task/LocklessQueue.h
+++ b/Source/Task/LocklessQueue.h
@@ -182,12 +182,15 @@ public:
 
     //
     // Pushes the given data onto the back
-    // of the queue.  A copy is made of TData.
+    // of the queue.  A copy is made of TData
+    // (which may throw, if TData's copy constructor can
+    // throw exceptions).
     // If the push fails this returns false.
     //
-    bool push_back(_In_ TData data) noexcept
+    bool push_back(_In_ const TData& data)
     {
-        return move_back(data);
+        TData copy = data;
+        return move_back(copy);
     }
 
     //
@@ -202,11 +205,14 @@ public:
     //
     // Pushes the given data onto the back of the queue,
     // using a reserved node pointer.  This never fails as
-    // the node pointer was preallocated.
+    // the node pointer was preallocated. A copy of TData is
+    // made (which may throw, if TData's copy constructor can
+    // throw exceptions).
     //
-    void push_back(_In_ TData data, _In_ uint64_t address)
+    void push_back(_In_ const TData& data, _In_ uint64_t address)
     {
-        move_back(data, address);
+        TData copy = data;
+        move_back(copy, address);
     }
 
     //
@@ -214,7 +220,7 @@ public:
     // using a reserved node pointer.  This never fails as
     // the node pointer was preallocated.
     //
-    void push_back(_In_ TData&& data, _In_ uint64_t address)
+    void push_back(_In_ TData&& data, _In_ uint64_t address) noexcept
     {
         move_back(std::move(data), address);
     }
@@ -740,7 +746,7 @@ private:
 
     // Workers for pushing nodes to the back
     // of the queue.  This always moves data
-    void move_back(_In_ TData& data, _In_ uint64_t address)
+    void move_back(_In_ TData& data, _In_ uint64_t address) noexcept
     {
         Address a;
         a = address;

--- a/Source/Task/LocklessQueue.h
+++ b/Source/Task/LocklessQueue.h
@@ -196,7 +196,7 @@ public:
     //
     bool push_back(_In_ TData&& data) noexcept
     {
-        return move_back(data);
+        return move_back(std::move(data));
     }
 
     //
@@ -216,7 +216,7 @@ public:
     //
     void push_back(_In_ TData&& data, _In_ uint64_t address)
     {
-        move_back(data, address);
+        move_back(std::move(data), address);
     }
 
     //

--- a/Source/Task/ThreadPool_win32.cpp
+++ b/Source/Task/ThreadPool_win32.cpp
@@ -34,9 +34,6 @@ namespace OS
             m_work = CreateThreadpoolWork(TPCallback, this, nullptr);
             RETURN_LAST_ERROR_IF_NULL(m_work);
 
-            InitializeCriticalSection(&m_cs);
-            InitializeConditionVariable(&m_cv);
-
             return S_OK;
         }
 
@@ -44,35 +41,24 @@ namespace OS
         {
             if (m_work != nullptr)
             {
-                // We cannot wait for work callbacks to complete because
-                // the final release may be called from within the callback.
-                // We know when our callbacks are invoking user code however,
-                // and we block on that.
-                EnterCriticalSection(&m_cs);
-
-                while (m_activeCalls != 0)
-                {
-                    SleepConditionVariableCS(&m_cv, &m_cs, INFINITE);
-                }
-
-                LeaveCriticalSection(&m_cs);
-
+                // Wait for callbacks to complete.  We don't want to
+                // cancel existing callbacks because it's important they
+                // get a chance to drain.
+                WaitForThreadpoolWorkCallbacks(m_work, FALSE);
                 CloseThreadpoolWork(m_work);
                 m_work = nullptr;
-                DeleteCriticalSection(&m_cs);
             }
         }
 
         void Submit() noexcept
         {
-            m_activeCalls++;
             SubmitThreadpoolWork(m_work);
         }
 
     private:
 
         static void CALLBACK TPCallback(
-            _In_ PTP_CALLBACK_INSTANCE,
+            _In_ PTP_CALLBACK_INSTANCE instance,
             _In_ void* context, PTP_WORK) noexcept
         {
             ThreadPoolImpl* pthis = static_cast<ThreadPoolImpl*>(context);
@@ -90,7 +76,7 @@ namespace OS
             // final release does need to wait on outstanding
             // calls.
 
-            ActionCompleteImpl ac(pthis);
+            ActionCompleteImpl ac(pthis, instance);
             pthis->AddRef();
             pthis->m_callback(pthis->m_context, ac);
 
@@ -103,8 +89,9 @@ namespace OS
 
         struct ActionCompleteImpl : ThreadPoolActionComplete
         {
-            ActionCompleteImpl(ThreadPoolImpl* owner) :
-                m_owner(owner)
+            ActionCompleteImpl(ThreadPoolImpl* owner, PTP_CALLBACK_INSTANCE instance) :
+                m_owner(owner),
+                m_instance(instance)
             {
             }
 
@@ -113,20 +100,17 @@ namespace OS
             void operator()() override
             {
                 Invoked = true;
-                m_owner->m_activeCalls--;
-                WakeAllConditionVariable(&m_owner->m_cv);
+                DisassociateCurrentThreadFromCallback(m_instance);
             }
 
         private:
             ThreadPoolImpl* m_owner = nullptr;
+            PTP_CALLBACK_INSTANCE m_instance = nullptr;
         };
 
         std::atomic<uint32_t> m_refs{ 1 };
-        CONDITION_VARIABLE m_cv;
-        CRITICAL_SECTION m_cs;
         PTP_WORK m_work = nullptr;
         void* m_context = nullptr;
-        std::atomic<uint32_t> m_activeCalls{ 0 };
         ThreadPoolCallback* m_callback = nullptr;
     };
 


### PR DESCRIPTION
This is an update that addresses minor PR feedback from the Windows team.  Mainly:

1. Duplication of code in push_back.
2. Whitespace issues.

Also in this change:

1. Switch from C_ASSERT to static_assert.  It turns out this is supported across all platforms after all as long as you use the variant with a message.

2. Re-arrange members so Android compiler doesn't generate warnings about initialization order.