### PR TITLE
Fix corner case error handling

### DIFF
--- a/Build/libHttpClient.140.UWP.C/libHttpClient.140.UWP.C.vcxproj
+++ b/Build/libHttpClient.140.UWP.C/libHttpClient.140.UWP.C.vcxproj
@@ -158,6 +158,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\ThreadPool_win32.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer_win32.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\referenced_ptr.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\WinRT\winrt_websocket.cpp" />

--- a/Build/libHttpClient.140.UWP.C/libHttpClient.140.UWP.C.vcxproj.filters
+++ b/Build/libHttpClient.140.UWP.C/libHttpClient.140.UWP.C.vcxproj.filters
@@ -159,6 +159,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h">
+      <Filter>C++ Source\Task</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>

--- a/Build/libHttpClient.140.Win32.C/libHttpClient.140.Win32.C.vcxproj
+++ b/Build/libHttpClient.140.Win32.C/libHttpClient.140.Win32.C.vcxproj
@@ -141,6 +141,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\ThreadPool_win32.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer_win32.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\referenced_ptr.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\Websocketpp\websocketpp_websocket.cpp" />

--- a/Build/libHttpClient.140.Win32.C/libHttpClient.140.Win32.C.vcxproj.filters
+++ b/Build/libHttpClient.140.Win32.C/libHttpClient.140.Win32.C.vcxproj.filters
@@ -138,6 +138,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h">
+      <Filter>C++ Source\Task</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>
@@ -183,46 +186,46 @@
   </ItemGroup>
   <ItemGroup>
     <Filter Include="C++ Source">
-      <UniqueIdentifier>{B348936D-D09B-3ACE-A476-12C7C5E48781}</UniqueIdentifier>
+      <UniqueIdentifier>{AB68AAD7-BF0D-34C3-BFBA-FB7594810503}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Common">
-      <UniqueIdentifier>{6D290126-3831-3A04-903B-F2ADD104D81C}</UniqueIdentifier>
+      <UniqueIdentifier>{8B9EEA6A-3165-3A83-8CEB-648270B8C445}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Common\Win">
-      <UniqueIdentifier>{E705B256-E422-3FF4-95FA-7E24B8A5474F}</UniqueIdentifier>
+      <UniqueIdentifier>{28B59420-8446-3F26-9AB1-72123FF92816}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Global">
-      <UniqueIdentifier>{B5E18BF5-6C51-323C-96A0-81422D9D6069}</UniqueIdentifier>
+      <UniqueIdentifier>{A616C757-EB09-3284-8BA4-4C0B391C1672}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\HTTP">
-      <UniqueIdentifier>{6DAD9E7F-080C-3264-920E-77D0AFFE8CC9}</UniqueIdentifier>
+      <UniqueIdentifier>{7607E023-D56D-300A-AAE7-35C1337C6EF3}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\HTTP\WinHttp">
-      <UniqueIdentifier>{01466804-77B8-33C2-AAEE-469619C39927}</UniqueIdentifier>
+      <UniqueIdentifier>{6095F35A-0F36-3DA9-8D1A-8F2DA598B6E0}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Logger">
-      <UniqueIdentifier>{FD710BAD-78A2-39F4-9CB7-90B1627CC1D5}</UniqueIdentifier>
+      <UniqueIdentifier>{658327C4-885D-3CF1-9061-DA642B97898A}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Logger\Win">
-      <UniqueIdentifier>{CE716A57-F0D2-3112-9432-4955DE919940}</UniqueIdentifier>
+      <UniqueIdentifier>{89A6373D-D2E3-3B5B-B6CF-4AB7CDFB13B8}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Mock">
-      <UniqueIdentifier>{ECB59FD8-67C4-354A-90B2-DFC893C0F2E5}</UniqueIdentifier>
+      <UniqueIdentifier>{57AC3982-96A9-3B0B-A7DF-8DF69AD19ECC}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Task">
-      <UniqueIdentifier>{09ED63FC-76E4-368A-B7E4-40A1D70ABD31}</UniqueIdentifier>
+      <UniqueIdentifier>{075BEBE6-800C-3FB2-84E2-6443C472E199}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Task\Win">
-      <UniqueIdentifier>{82CDC498-C15D-38CB-ABAF-432B4881A142}</UniqueIdentifier>
+      <UniqueIdentifier>{D0B227E9-0B82-3AF7-82EC-9581DA9FD1A3}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\WebSocket">
-      <UniqueIdentifier>{09CB3AE4-1639-3274-BB94-99AAC498EA50}</UniqueIdentifier>
+      <UniqueIdentifier>{0974FCD6-8409-3FA3-A118-A58ED0FD041C}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\WebSocket\Win">
-      <UniqueIdentifier>{802954F0-B5AC-3B13-A5F2-01E8A7888AAE}</UniqueIdentifier>
+      <UniqueIdentifier>{350A88A7-908E-346C-8EEC-8C500141D764}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Public Includes">
-      <UniqueIdentifier>{42CA3718-AE3E-3CEB-A859-F23D0D7A9918}</UniqueIdentifier>
+      <UniqueIdentifier>{2F64C9BE-5116-3E71-971F-592C0D76A89D}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/Build/libHttpClient.140.XDK.C/libHttpClient.140.XDK.C.vcxproj
+++ b/Build/libHttpClient.140.XDK.C/libHttpClient.140.XDK.C.vcxproj
@@ -130,6 +130,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\ThreadPool_win32.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer_win32.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\referenced_ptr.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\WinRT\winrt_websocket.cpp" />

--- a/Build/libHttpClient.140.XDK.C/libHttpClient.140.XDK.C.vcxproj.filters
+++ b/Build/libHttpClient.140.XDK.C/libHttpClient.140.XDK.C.vcxproj.filters
@@ -159,6 +159,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h">
+      <Filter>C++ Source\Task</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>

--- a/Build/libHttpClient.141.Android.C/libHttpClient.141.Android.C.vcxproj
+++ b/Build/libHttpClient.141.Android.C/libHttpClient.141.Android.C.vcxproj
@@ -46,7 +46,6 @@
     <ApplicationTypeRevision>3.0</ApplicationTypeRevision>
     <HCLibPlatformType>Android</HCLibPlatformType>
     <HCLibImpl>true</HCLibImpl>
-	<AndroidSdkBuildToolsVersion>25.0.3</AndroidSdkBuildToolsVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup>
@@ -126,6 +125,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\ThreadPool_stl.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer_stl.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\referenced_ptr.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\Websocketpp\websocketpp_websocket.cpp" />

--- a/Build/libHttpClient.141.Android.C/libHttpClient.141.Android.C.vcxproj.filters
+++ b/Build/libHttpClient.141.Android.C/libHttpClient.141.Android.C.vcxproj.filters
@@ -147,6 +147,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h">
+      <Filter>C++ Source\Task</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>

--- a/Build/libHttpClient.141.UWP.C/libHttpClient.141.UWP.C.vcxproj
+++ b/Build/libHttpClient.141.UWP.C/libHttpClient.141.UWP.C.vcxproj
@@ -169,6 +169,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\ThreadPool_win32.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer_win32.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\referenced_ptr.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\WinRT\winrt_websocket.cpp" />

--- a/Build/libHttpClient.141.UWP.C/libHttpClient.141.UWP.C.vcxproj.filters
+++ b/Build/libHttpClient.141.UWP.C/libHttpClient.141.UWP.C.vcxproj.filters
@@ -159,6 +159,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h">
+      <Filter>C++ Source\Task</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>

--- a/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj
+++ b/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj
@@ -150,6 +150,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\ThreadPool_win32.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer_win32.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\referenced_ptr.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\Websocketpp\websocketpp_websocket.cpp" />

--- a/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj.filters
+++ b/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj.filters
@@ -138,6 +138,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h">
+      <Filter>C++ Source\Task</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>
@@ -183,46 +186,46 @@
   </ItemGroup>
   <ItemGroup>
     <Filter Include="C++ Source">
-      <UniqueIdentifier>{B348936D-D09B-3ACE-A476-12C7C5E48781}</UniqueIdentifier>
+      <UniqueIdentifier>{AB68AAD7-BF0D-34C3-BFBA-FB7594810503}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Common">
-      <UniqueIdentifier>{6D290126-3831-3A04-903B-F2ADD104D81C}</UniqueIdentifier>
+      <UniqueIdentifier>{8B9EEA6A-3165-3A83-8CEB-648270B8C445}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Common\Win">
-      <UniqueIdentifier>{E705B256-E422-3FF4-95FA-7E24B8A5474F}</UniqueIdentifier>
+      <UniqueIdentifier>{28B59420-8446-3F26-9AB1-72123FF92816}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Global">
-      <UniqueIdentifier>{B5E18BF5-6C51-323C-96A0-81422D9D6069}</UniqueIdentifier>
+      <UniqueIdentifier>{A616C757-EB09-3284-8BA4-4C0B391C1672}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\HTTP">
-      <UniqueIdentifier>{6DAD9E7F-080C-3264-920E-77D0AFFE8CC9}</UniqueIdentifier>
+      <UniqueIdentifier>{7607E023-D56D-300A-AAE7-35C1337C6EF3}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\HTTP\WinHttp">
-      <UniqueIdentifier>{01466804-77B8-33C2-AAEE-469619C39927}</UniqueIdentifier>
+      <UniqueIdentifier>{6095F35A-0F36-3DA9-8D1A-8F2DA598B6E0}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Logger">
-      <UniqueIdentifier>{FD710BAD-78A2-39F4-9CB7-90B1627CC1D5}</UniqueIdentifier>
+      <UniqueIdentifier>{658327C4-885D-3CF1-9061-DA642B97898A}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Logger\Win">
-      <UniqueIdentifier>{CE716A57-F0D2-3112-9432-4955DE919940}</UniqueIdentifier>
+      <UniqueIdentifier>{89A6373D-D2E3-3B5B-B6CF-4AB7CDFB13B8}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Mock">
-      <UniqueIdentifier>{ECB59FD8-67C4-354A-90B2-DFC893C0F2E5}</UniqueIdentifier>
+      <UniqueIdentifier>{57AC3982-96A9-3B0B-A7DF-8DF69AD19ECC}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Task">
-      <UniqueIdentifier>{09ED63FC-76E4-368A-B7E4-40A1D70ABD31}</UniqueIdentifier>
+      <UniqueIdentifier>{075BEBE6-800C-3FB2-84E2-6443C472E199}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Task\Win">
-      <UniqueIdentifier>{82CDC498-C15D-38CB-ABAF-432B4881A142}</UniqueIdentifier>
+      <UniqueIdentifier>{D0B227E9-0B82-3AF7-82EC-9581DA9FD1A3}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\WebSocket">
-      <UniqueIdentifier>{09CB3AE4-1639-3274-BB94-99AAC498EA50}</UniqueIdentifier>
+      <UniqueIdentifier>{0974FCD6-8409-3FA3-A118-A58ED0FD041C}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\WebSocket\Win">
-      <UniqueIdentifier>{802954F0-B5AC-3B13-A5F2-01E8A7888AAE}</UniqueIdentifier>
+      <UniqueIdentifier>{350A88A7-908E-346C-8EEC-8C500141D764}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Public Includes">
-      <UniqueIdentifier>{42CA3718-AE3E-3CEB-A859-F23D0D7A9918}</UniqueIdentifier>
+      <UniqueIdentifier>{2F64C9BE-5116-3E71-971F-592C0D76A89D}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/Build/libHttpClient.141.XDK.C/libHttpClient.141.XDK.C.vcxproj
+++ b/Build/libHttpClient.141.XDK.C/libHttpClient.141.XDK.C.vcxproj
@@ -131,6 +131,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\ThreadPool_win32.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer_win32.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\referenced_ptr.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\WinRT\winrt_websocket.cpp" />

--- a/Build/libHttpClient.141.XDK.C/libHttpClient.141.XDK.C.vcxproj.filters
+++ b/Build/libHttpClient.141.XDK.C/libHttpClient.141.XDK.C.vcxproj.filters
@@ -159,6 +159,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h">
+      <Filter>C++ Source\Task</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>

--- a/Build/libHttpClient.142.Android.C/libHttpClient.142.Android.C.vcxproj
+++ b/Build/libHttpClient.142.Android.C/libHttpClient.142.Android.C.vcxproj
@@ -35,7 +35,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{5e0ce391-1ac5-4930-921e-2577a4b5c530}</ProjectGuid>
+    <ProjectGuid>{80FE2440-4F89-4A47-88C6-E86447BC2319}</ProjectGuid>
     <Keyword>Android</Keyword>
     <PlatformToolset>Clang_5_0</PlatformToolset>
     <AndroidAPILevel Condition="'$(Platform)'!='ARM64' AND '$(Platform)'!='x64'">android-19</AndroidAPILevel>
@@ -46,7 +46,6 @@
     <ApplicationTypeRevision>3.0</ApplicationTypeRevision>
     <HCLibPlatformType>Android</HCLibPlatformType>
     <HCLibImpl>true</HCLibImpl>
-	<AndroidSdkBuildToolsVersion>25.0.3</AndroidSdkBuildToolsVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup>
@@ -126,6 +125,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\ThreadPool_stl.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer_stl.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\referenced_ptr.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\Websocketpp\websocketpp_websocket.cpp" />

--- a/Build/libHttpClient.142.Android.C/libHttpClient.142.Android.C.vcxproj.filters
+++ b/Build/libHttpClient.142.Android.C/libHttpClient.142.Android.C.vcxproj.filters
@@ -147,6 +147,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h">
+      <Filter>C++ Source\Task</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>
@@ -192,46 +195,46 @@
   </ItemGroup>
   <ItemGroup>
     <Filter Include="C++ Source">
-      <UniqueIdentifier>{A740C412-FB5D-3AAA-8C89-79F901BDFCAA}</UniqueIdentifier>
+      <UniqueIdentifier>{AB68AAD7-BF0D-34C3-BFBA-FB7594810503}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Common">
-      <UniqueIdentifier>{27CFE030-22C9-3F80-BE9E-6C85269BA8CF}</UniqueIdentifier>
+      <UniqueIdentifier>{8B9EEA6A-3165-3A83-8CEB-648270B8C445}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Common\Android">
-      <UniqueIdentifier>{7F5C193A-6335-3652-8522-F362DE77CEC5}</UniqueIdentifier>
+      <UniqueIdentifier>{F6086770-20F5-36E7-9347-F8E511A64421}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Global">
-      <UniqueIdentifier>{3A5140CA-AFB5-3F07-934D-A8067647C112}</UniqueIdentifier>
+      <UniqueIdentifier>{A616C757-EB09-3284-8BA4-4C0B391C1672}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\HTTP">
-      <UniqueIdentifier>{4C46FCD2-8942-35E4-A9F6-E32517A218FC}</UniqueIdentifier>
+      <UniqueIdentifier>{7607E023-D56D-300A-AAE7-35C1337C6EF3}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\HTTP\Android">
-      <UniqueIdentifier>{3FE50A42-C399-35C5-807F-53541A10E202}</UniqueIdentifier>
+      <UniqueIdentifier>{15D2B7C4-8092-30BB-B45A-23FB8BB289F7}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Logger">
-      <UniqueIdentifier>{F9631A84-9D6B-300A-B12D-A52D1FCE33D5}</UniqueIdentifier>
+      <UniqueIdentifier>{658327C4-885D-3CF1-9061-DA642B97898A}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Logger\Android">
-      <UniqueIdentifier>{1CBA16A9-7A69-31BB-8A4F-0C4D1CC3CF66}</UniqueIdentifier>
+      <UniqueIdentifier>{5DE6DC08-DC97-3EDE-86DC-D80C73AB8212}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Mock">
-      <UniqueIdentifier>{7E7975B0-87A8-3B63-AC39-F4B973EBFE5E}</UniqueIdentifier>
+      <UniqueIdentifier>{57AC3982-96A9-3B0B-A7DF-8DF69AD19ECC}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Task">
-      <UniqueIdentifier>{A5C44A5C-F557-3485-B0F3-96924ED16997}</UniqueIdentifier>
+      <UniqueIdentifier>{075BEBE6-800C-3FB2-84E2-6443C472E199}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Task\Android">
-      <UniqueIdentifier>{B18AF8F5-F9A5-3AA5-BCEA-7699667F4BEF}</UniqueIdentifier>
+      <UniqueIdentifier>{B2E61810-6BF3-36DB-9286-C42708123F18}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\WebSocket">
-      <UniqueIdentifier>{0EAC292A-EAC0-3C04-9776-AA439EE69493}</UniqueIdentifier>
+      <UniqueIdentifier>{0974FCD6-8409-3FA3-A118-A58ED0FD041C}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\WebSocket\Android">
-      <UniqueIdentifier>{1B92AFE8-7559-338C-9B27-68248D7AF766}</UniqueIdentifier>
+      <UniqueIdentifier>{683D025C-B830-3477-9275-4EA8A76EDB09}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Public Includes">
-      <UniqueIdentifier>{D805E6E3-877C-379F-9EEB-B64746DE0E67}</UniqueIdentifier>
+      <UniqueIdentifier>{2F64C9BE-5116-3E71-971F-592C0D76A89D}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/Build/libHttpClient.142.UWP.C/libHttpClient.142.UWP.C.vcxproj
+++ b/Build/libHttpClient.142.UWP.C/libHttpClient.142.UWP.C.vcxproj
@@ -169,6 +169,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\ThreadPool_win32.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer_win32.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\referenced_ptr.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\WinRT\winrt_websocket.cpp" />

--- a/Build/libHttpClient.142.UWP.C/libHttpClient.142.UWP.C.vcxproj.filters
+++ b/Build/libHttpClient.142.UWP.C/libHttpClient.142.UWP.C.vcxproj.filters
@@ -159,6 +159,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h">
+      <Filter>C++ Source\Task</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>
@@ -201,46 +204,46 @@
   </ItemGroup>
   <ItemGroup>
     <Filter Include="C++ Source">
-      <UniqueIdentifier>{A740C412-FB5D-3AAA-8C89-79F901BDFCAA}</UniqueIdentifier>
+      <UniqueIdentifier>{AB68AAD7-BF0D-34C3-BFBA-FB7594810503}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Common">
-      <UniqueIdentifier>{27CFE030-22C9-3F80-BE9E-6C85269BA8CF}</UniqueIdentifier>
+      <UniqueIdentifier>{8B9EEA6A-3165-3A83-8CEB-648270B8C445}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Common\Win">
-      <UniqueIdentifier>{DFE90BE8-BA04-38D4-B957-489922F25F6C}</UniqueIdentifier>
+      <UniqueIdentifier>{28B59420-8446-3F26-9AB1-72123FF92816}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Global">
-      <UniqueIdentifier>{3A5140CA-AFB5-3F07-934D-A8067647C112}</UniqueIdentifier>
+      <UniqueIdentifier>{A616C757-EB09-3284-8BA4-4C0B391C1672}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\HTTP">
-      <UniqueIdentifier>{4C46FCD2-8942-35E4-A9F6-E32517A218FC}</UniqueIdentifier>
+      <UniqueIdentifier>{7607E023-D56D-300A-AAE7-35C1337C6EF3}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\HTTP\XMLHttp">
-      <UniqueIdentifier>{9BC3BA0D-F317-3F19-87DD-76A8B0C73BEF}</UniqueIdentifier>
+      <UniqueIdentifier>{E77621FA-48B7-342B-A48A-7652D1F73D57}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Logger">
-      <UniqueIdentifier>{F9631A84-9D6B-300A-B12D-A52D1FCE33D5}</UniqueIdentifier>
+      <UniqueIdentifier>{658327C4-885D-3CF1-9061-DA642B97898A}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Logger\Win">
-      <UniqueIdentifier>{42447043-740A-346F-BF7B-15D083F4D78C}</UniqueIdentifier>
+      <UniqueIdentifier>{89A6373D-D2E3-3B5B-B6CF-4AB7CDFB13B8}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Mock">
-      <UniqueIdentifier>{7E7975B0-87A8-3B63-AC39-F4B973EBFE5E}</UniqueIdentifier>
+      <UniqueIdentifier>{57AC3982-96A9-3B0B-A7DF-8DF69AD19ECC}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Task">
-      <UniqueIdentifier>{A5C44A5C-F557-3485-B0F3-96924ED16997}</UniqueIdentifier>
+      <UniqueIdentifier>{075BEBE6-800C-3FB2-84E2-6443C472E199}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Task\Win">
-      <UniqueIdentifier>{4075F186-2D52-323A-9287-AE69359740B8}</UniqueIdentifier>
+      <UniqueIdentifier>{D0B227E9-0B82-3AF7-82EC-9581DA9FD1A3}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\WebSocket">
-      <UniqueIdentifier>{0EAC292A-EAC0-3C04-9776-AA439EE69493}</UniqueIdentifier>
+      <UniqueIdentifier>{0974FCD6-8409-3FA3-A118-A58ED0FD041C}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\WebSocket\WinRT">
-      <UniqueIdentifier>{DA11A23D-43F8-30E7-A583-24AACCBE0501}</UniqueIdentifier>
+      <UniqueIdentifier>{E4F43182-9F97-3EBF-8BB9-4E51EB7E5C4D}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Public Includes">
-      <UniqueIdentifier>{D805E6E3-877C-379F-9EEB-B64746DE0E67}</UniqueIdentifier>
+      <UniqueIdentifier>{2F64C9BE-5116-3E71-971F-592C0D76A89D}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/Build/libHttpClient.142.Win32.C/libHttpClient.142.Win32.C.vcxproj
+++ b/Build/libHttpClient.142.Win32.C/libHttpClient.142.Win32.C.vcxproj
@@ -150,6 +150,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\ThreadPool_win32.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer_win32.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\referenced_ptr.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\Websocketpp\websocketpp_websocket.cpp" />

--- a/Build/libHttpClient.142.Win32.C/libHttpClient.142.Win32.C.vcxproj.filters
+++ b/Build/libHttpClient.142.Win32.C/libHttpClient.142.Win32.C.vcxproj.filters
@@ -138,6 +138,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h">
+      <Filter>C++ Source\Task</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>
@@ -183,46 +186,46 @@
   </ItemGroup>
   <ItemGroup>
     <Filter Include="C++ Source">
-      <UniqueIdentifier>{A740C412-FB5D-3AAA-8C89-79F901BDFCAA}</UniqueIdentifier>
+      <UniqueIdentifier>{AB68AAD7-BF0D-34C3-BFBA-FB7594810503}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Common">
-      <UniqueIdentifier>{27CFE030-22C9-3F80-BE9E-6C85269BA8CF}</UniqueIdentifier>
+      <UniqueIdentifier>{8B9EEA6A-3165-3A83-8CEB-648270B8C445}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Common\Win">
-      <UniqueIdentifier>{DFE90BE8-BA04-38D4-B957-489922F25F6C}</UniqueIdentifier>
+      <UniqueIdentifier>{28B59420-8446-3F26-9AB1-72123FF92816}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Global">
-      <UniqueIdentifier>{3A5140CA-AFB5-3F07-934D-A8067647C112}</UniqueIdentifier>
+      <UniqueIdentifier>{A616C757-EB09-3284-8BA4-4C0B391C1672}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\HTTP">
-      <UniqueIdentifier>{4C46FCD2-8942-35E4-A9F6-E32517A218FC}</UniqueIdentifier>
+      <UniqueIdentifier>{7607E023-D56D-300A-AAE7-35C1337C6EF3}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\HTTP\WinHttp">
-      <UniqueIdentifier>{B97A6D17-B3B3-3752-AFCE-0EC15FD7B2D2}</UniqueIdentifier>
+      <UniqueIdentifier>{6095F35A-0F36-3DA9-8D1A-8F2DA598B6E0}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Logger">
-      <UniqueIdentifier>{F9631A84-9D6B-300A-B12D-A52D1FCE33D5}</UniqueIdentifier>
+      <UniqueIdentifier>{658327C4-885D-3CF1-9061-DA642B97898A}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Logger\Win">
-      <UniqueIdentifier>{42447043-740A-346F-BF7B-15D083F4D78C}</UniqueIdentifier>
+      <UniqueIdentifier>{89A6373D-D2E3-3B5B-B6CF-4AB7CDFB13B8}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Mock">
-      <UniqueIdentifier>{7E7975B0-87A8-3B63-AC39-F4B973EBFE5E}</UniqueIdentifier>
+      <UniqueIdentifier>{57AC3982-96A9-3B0B-A7DF-8DF69AD19ECC}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Task">
-      <UniqueIdentifier>{A5C44A5C-F557-3485-B0F3-96924ED16997}</UniqueIdentifier>
+      <UniqueIdentifier>{075BEBE6-800C-3FB2-84E2-6443C472E199}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Task\Win">
-      <UniqueIdentifier>{4075F186-2D52-323A-9287-AE69359740B8}</UniqueIdentifier>
+      <UniqueIdentifier>{D0B227E9-0B82-3AF7-82EC-9581DA9FD1A3}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\WebSocket">
-      <UniqueIdentifier>{0EAC292A-EAC0-3C04-9776-AA439EE69493}</UniqueIdentifier>
+      <UniqueIdentifier>{0974FCD6-8409-3FA3-A118-A58ED0FD041C}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\WebSocket\Win">
-      <UniqueIdentifier>{35985716-80A2-3783-AE12-674A2189F43D}</UniqueIdentifier>
+      <UniqueIdentifier>{350A88A7-908E-346C-8EEC-8C500141D764}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Public Includes">
-      <UniqueIdentifier>{D805E6E3-877C-379F-9EEB-B64746DE0E67}</UniqueIdentifier>
+      <UniqueIdentifier>{2F64C9BE-5116-3E71-971F-592C0D76A89D}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/Build/libHttpClient.142.XDK.C/libHttpClient.142.XDK.C.vcxproj
+++ b/Build/libHttpClient.142.XDK.C/libHttpClient.142.XDK.C.vcxproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ApplicationEnvironment>title</ApplicationEnvironment>
-    <ProjectGuid>{9E0EB8C2-40CD-448F-9B98-DAF9830EF9AD}</ProjectGuid>
+    <ProjectGuid>{57C681F7-280F-45B8-9FA9-D556C24F2053}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <ProjectName>libHttpClient.142.XDK.C</ProjectName>
     <RootNamespace>xbox.httpclient</RootNamespace>

--- a/Build/libHttpClient.142.XDK.C/libHttpClient.142.XDK.C.vcxproj.filters
+++ b/Build/libHttpClient.142.XDK.C/libHttpClient.142.XDK.C.vcxproj.filters
@@ -201,46 +201,46 @@
   </ItemGroup>
   <ItemGroup>
     <Filter Include="C++ Source">
-      <UniqueIdentifier>{A740C412-FB5D-3AAA-8C89-79F901BDFCAA}</UniqueIdentifier>
+      <UniqueIdentifier>{AB68AAD7-BF0D-34C3-BFBA-FB7594810503}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Common">
-      <UniqueIdentifier>{27CFE030-22C9-3F80-BE9E-6C85269BA8CF}</UniqueIdentifier>
+      <UniqueIdentifier>{8B9EEA6A-3165-3A83-8CEB-648270B8C445}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Common\Win">
-      <UniqueIdentifier>{DFE90BE8-BA04-38D4-B957-489922F25F6C}</UniqueIdentifier>
+      <UniqueIdentifier>{28B59420-8446-3F26-9AB1-72123FF92816}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Global">
-      <UniqueIdentifier>{3A5140CA-AFB5-3F07-934D-A8067647C112}</UniqueIdentifier>
+      <UniqueIdentifier>{A616C757-EB09-3284-8BA4-4C0B391C1672}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\HTTP">
-      <UniqueIdentifier>{4C46FCD2-8942-35E4-A9F6-E32517A218FC}</UniqueIdentifier>
+      <UniqueIdentifier>{7607E023-D56D-300A-AAE7-35C1337C6EF3}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\HTTP\XMLHttp">
-      <UniqueIdentifier>{9BC3BA0D-F317-3F19-87DD-76A8B0C73BEF}</UniqueIdentifier>
+      <UniqueIdentifier>{E77621FA-48B7-342B-A48A-7652D1F73D57}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Logger">
-      <UniqueIdentifier>{F9631A84-9D6B-300A-B12D-A52D1FCE33D5}</UniqueIdentifier>
+      <UniqueIdentifier>{658327C4-885D-3CF1-9061-DA642B97898A}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Logger\Win">
-      <UniqueIdentifier>{42447043-740A-346F-BF7B-15D083F4D78C}</UniqueIdentifier>
+      <UniqueIdentifier>{89A6373D-D2E3-3B5B-B6CF-4AB7CDFB13B8}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Mock">
-      <UniqueIdentifier>{7E7975B0-87A8-3B63-AC39-F4B973EBFE5E}</UniqueIdentifier>
+      <UniqueIdentifier>{57AC3982-96A9-3B0B-A7DF-8DF69AD19ECC}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Task">
-      <UniqueIdentifier>{A5C44A5C-F557-3485-B0F3-96924ED16997}</UniqueIdentifier>
+      <UniqueIdentifier>{075BEBE6-800C-3FB2-84E2-6443C472E199}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Task\Win">
-      <UniqueIdentifier>{4075F186-2D52-323A-9287-AE69359740B8}</UniqueIdentifier>
+      <UniqueIdentifier>{D0B227E9-0B82-3AF7-82EC-9581DA9FD1A3}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\WebSocket">
-      <UniqueIdentifier>{0EAC292A-EAC0-3C04-9776-AA439EE69493}</UniqueIdentifier>
+      <UniqueIdentifier>{0974FCD6-8409-3FA3-A118-A58ED0FD041C}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\WebSocket\WinRT">
-      <UniqueIdentifier>{DA11A23D-43F8-30E7-A583-24AACCBE0501}</UniqueIdentifier>
+      <UniqueIdentifier>{E4F43182-9F97-3EBF-8BB9-4E51EB7E5C4D}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Public Includes">
-      <UniqueIdentifier>{D805E6E3-877C-379F-9EEB-B64746DE0E67}</UniqueIdentifier>
+      <UniqueIdentifier>{2F64C9BE-5116-3E71-971F-592C0D76A89D}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/Build/libHttpClient.UnitTest.141.TAEF/libHttpClient.UnitTest.141.TAEF.vcxproj
+++ b/Build/libHttpClient.UnitTest.141.TAEF/libHttpClient.UnitTest.141.TAEF.vcxproj
@@ -157,6 +157,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\ThreadPool_win32.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer_win32.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\referenced_ptr.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\Unittest\websocket_unittest.cpp" />

--- a/Build/libHttpClient.UnitTest.141.TAEF/libHttpClient.UnitTest.141.TAEF.vcxproj.filters
+++ b/Build/libHttpClient.UnitTest.141.TAEF/libHttpClient.UnitTest.141.TAEF.vcxproj.filters
@@ -159,6 +159,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h">
+      <Filter>C++ Source\Task</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>

--- a/Build/libHttpClient.UnitTest.141.TE/libHttpClient.UnitTest.141.TE.vcxproj
+++ b/Build/libHttpClient.UnitTest.141.TE/libHttpClient.UnitTest.141.TE.vcxproj
@@ -221,6 +221,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\ThreadPool_win32.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer_win32.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\referenced_ptr.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\Unittest\websocket_unittest.cpp" />

--- a/Build/libHttpClient.UnitTest.141.TE/libHttpClient.UnitTest.141.TE.vcxproj.filters
+++ b/Build/libHttpClient.UnitTest.141.TE/libHttpClient.UnitTest.141.TE.vcxproj.filters
@@ -156,6 +156,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h">
+      <Filter>C++ Source\Task</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>

--- a/Build/libHttpClient.UnitTest.142.TAEF/libHttpClient.UnitTest.142.TAEF.vcxproj
+++ b/Build/libHttpClient.UnitTest.142.TAEF/libHttpClient.UnitTest.142.TAEF.vcxproj
@@ -20,7 +20,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectName>libHttpClient.UnitTest.142.TAEF</ProjectName>
-    <ProjectGuid>{EBFE0314-0869-46B8-ABCE-A3EE223893B8}</ProjectGuid>
+    <ProjectGuid>{9E0EB8C2-40CD-448F-9B98-DAF9830EF9AD}</ProjectGuid>
     <RootNamespace>libHttpClient.Test</RootNamespace>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
@@ -145,6 +145,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\ThreadPool_win32.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer_win32.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\referenced_ptr.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\Unittest\websocket_unittest.cpp" />

--- a/Build/libHttpClient.UnitTest.142.TAEF/libHttpClient.UnitTest.142.TAEF.vcxproj.filters
+++ b/Build/libHttpClient.UnitTest.142.TAEF/libHttpClient.UnitTest.142.TAEF.vcxproj.filters
@@ -159,6 +159,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h">
+      <Filter>C++ Source\Task</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>

--- a/Build/libHttpClient.UnitTest.142.TE/libHttpClient.UnitTest.142.TE.vcxproj
+++ b/Build/libHttpClient.UnitTest.142.TE/libHttpClient.UnitTest.142.TE.vcxproj
@@ -221,6 +221,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\ThreadPool_win32.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer_win32.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\referenced_ptr.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\Unittest\websocket_unittest.cpp" />

--- a/Build/libHttpClient.UnitTest.142.TE/libHttpClient.UnitTest.142.TE.vcxproj.filters
+++ b/Build/libHttpClient.UnitTest.142.TE/libHttpClient.UnitTest.142.TE.vcxproj.filters
@@ -156,6 +156,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h">
+      <Filter>C++ Source\Task</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h">
       <Filter>C++ Source\Task</Filter>
     </ClInclude>

--- a/Include/XAsyncProvider.h
+++ b/Include/XAsyncProvider.h
@@ -79,6 +79,13 @@ struct XAsyncProviderData
     /// to XAsyncBegin.  It should be freed during the Cleanup opcode.
     /// </summary>
     void* context;
+
+    /// <summary>
+    /// Valid during a Begin opcode and contains user-provided context passed into
+    /// XAsyncBeginAlloc. This gives the Begin opcode a chance to copy parameters
+    /// from the async call into the allocated context.
+    /// </summary>
+    void* initContext;
 };
 
 /// <summary>
@@ -132,6 +139,7 @@ STDAPI XAsyncBegin(
 /// <param name='identity'>An optional arbitrary pointer that can be used to identify this call.</param>
 /// <param name='identityName'>An optional string that names the async call.  This is typically the __FUNCTION__ compiler macro.</param>
 /// <param name='provider'>The function callback to invoke to implement the async call.</param>
+/// <param name='initContext'>An optional context pointer that can be used to intialize the newly allocated context in the async provider.</param>
 /// <param name='contextSize'>The size, in bytes, of additional context memory to allocate.</param>
 /// <param name='context'>The allocated context object pointer.</param>
 STDAPI XAsyncBeginAlloc(
@@ -139,6 +147,7 @@ STDAPI XAsyncBeginAlloc(
     _In_opt_ const void* identity,
     _In_opt_ const char* identityName,
     _In_ XAsyncProvider* provider,
+    _In_opt_ void* initContext,
     _In_ size_t contextSize,
     _Out_ void** context
     ) noexcept;

--- a/Include/XAsyncProvider.h
+++ b/Include/XAsyncProvider.h
@@ -79,13 +79,6 @@ struct XAsyncProviderData
     /// to XAsyncBegin.  It should be freed during the Cleanup opcode.
     /// </summary>
     void* context;
-
-    /// <summary>
-    /// Valid during a Begin opcode and contains user-provided context passed into
-    /// XAsyncBeginAlloc. This gives the Begin opcode a chance to copy parameters
-    /// from the async call into the allocated context.
-    /// </summary>
-    void* initContext;
 };
 
 /// <summary>
@@ -118,38 +111,6 @@ STDAPI XAsyncBegin(
     _In_opt_ const void* identity,
     _In_opt_ const char* identityName,
     _In_ XAsyncProvider* provider
-    ) noexcept;
-
-/// <summary>
-/// Initializes an async block for use.  Once begun calls such
-/// as XAsyncGetStatus will provide meaningful data. It is assumed the
-/// async work will begin on some system defined thread after this call
-/// returns. The token and function parameters can be used to help identify
-/// mismatched Begin/GetResult calls.  The token is typically the function
-/// pointer of the async API you are implementing, and the functionName parameter
-/// is typically the __FUNCTION__ compiler macro.  
-///
-/// This variant of XAsyncBegin will allocate additional memory of size contextSize
-/// and use this as the context pointer for async provider callbacks.  The memory
-/// pointer is returned in 'context'.  The lifetime of this memory is managed
-/// by the async library and will be freed automatically when the call 
-/// completes.
-/// </summary>
-/// <param name='asyncBlock'>A pointer to the XAsyncBlock that holds data for the call.</param>
-/// <param name='identity'>An optional arbitrary pointer that can be used to identify this call.</param>
-/// <param name='identityName'>An optional string that names the async call.  This is typically the __FUNCTION__ compiler macro.</param>
-/// <param name='provider'>The function callback to invoke to implement the async call.</param>
-/// <param name='initContext'>An optional context pointer that can be used to intialize the newly allocated context in the async provider.</param>
-/// <param name='contextSize'>The size, in bytes, of additional context memory to allocate.</param>
-/// <param name='context'>The allocated context object pointer.</param>
-STDAPI XAsyncBeginAlloc(
-    _Inout_ XAsyncBlock* asyncBlock,
-    _In_opt_ const void* identity,
-    _In_opt_ const char* identityName,
-    _In_ XAsyncProvider* provider,
-    _In_opt_ void* initContext,
-    _In_ size_t contextSize,
-    _Out_ void** context
     ) noexcept;
 
 /// <summary>

--- a/Source/Common/ResultMacros.h
+++ b/Source/Common/ResultMacros.h
@@ -18,3 +18,5 @@
     HC_TRACE_ERROR(HTTPCLIENT, fmt, ##__VA_ARGS__);    \
     ASSERT(false);                                     \
 
+
+#define FAIL_FAST_IF_FAILED(hr)                                 do { HRESULT __hrRet = hr; if (FAILED(__hrRet)) { FAIL_FAST_MSG("%s 0x%08", #hr, __hrRet); }} while (0, 0)

--- a/Source/Common/pch_common.h
+++ b/Source/Common/pch_common.h
@@ -27,7 +27,7 @@
 
 #include <WinSock2.h>
 #include <windows.h>
-#include <combaseapi.h>
+#include <objbase.h>
 
 #else
 #define __STDC_LIMIT_MACROS

--- a/Source/Common/pch_common.h
+++ b/Source/Common/pch_common.h
@@ -27,6 +27,7 @@
 
 #include <WinSock2.h>
 #include <windows.h>
+#include <combaseapi.h>
 
 #else
 #define __STDC_LIMIT_MACROS

--- a/Source/Task/TaskQueue.cpp
+++ b/Source/Task/TaskQueue.cpp
@@ -1264,7 +1264,6 @@ TaskQueueImpl::TaskQueueImpl() :
 
     m_termination.allowed = true;
     m_termination.terminated = false;
-    m_termination.terminating = false;
 }
 
 TaskQueueImpl::~TaskQueueImpl()
@@ -1412,11 +1411,6 @@ void __stdcall TaskQueueImpl::UnregisterSubmitCallback(
     m_callbackSubmitted.Unregister(token);
 }
 
-bool __stdcall TaskQueueImpl::IsTerminated()
-{
-    return m_termination.terminating || m_termination.terminated;
-}
-
 bool __stdcall TaskQueueImpl::CanTerminate()
 {
     return m_termination.allowed;
@@ -1452,8 +1446,6 @@ HRESULT __stdcall TaskQueueImpl::Terminate(
         m_work.Port->CancelTermination(workToken);
         RETURN_HR(hr);
     }
-
-    m_termination.terminating = true;
 
     // At this point both ports have been marked for termination and have pre-alocated any state they
     // need, so we can proceed with the actual termination.

--- a/Source/Task/TaskQueueImpl.h
+++ b/Source/Task/TaskQueueImpl.h
@@ -391,6 +391,7 @@ public:
     void __stdcall UnregisterSubmitCallback(
         _In_ XTaskQueueRegistrationToken token) override;
 
+    bool __stdcall IsTerminated() override;
     bool __stdcall CanTerminate() override;
     bool __stdcall CanClose() override;
 
@@ -429,6 +430,7 @@ private:
     {
         bool allowed;
         bool terminated;
+        bool terminating;
         std::mutex lock;
         std::condition_variable cv;
     };

--- a/Source/Task/TaskQueueImpl.h
+++ b/Source/Task/TaskQueueImpl.h
@@ -188,8 +188,6 @@ public:
     void __stdcall Terminate(
         _In_ void* token);
 
-    void __stdcall ResumeTerminations();
-
     virtual HRESULT __stdcall Attach(
         _In_ ITaskQueuePortContext* portContext);
 
@@ -405,7 +403,6 @@ public:
     void __stdcall UnregisterSubmitCallback(
         _In_ XTaskQueueRegistrationToken token) override;
 
-    bool __stdcall IsTerminated() override;
     bool __stdcall CanTerminate() override;
     bool __stdcall CanClose() override;
 
@@ -444,7 +441,6 @@ private:
     {
         bool allowed;
         bool terminated;
-        bool terminating;
         std::mutex lock;
         std::condition_variable cv;
     };

--- a/Source/Task/TaskQueueP.h
+++ b/Source/Task/TaskQueueP.h
@@ -141,7 +141,6 @@ struct ITaskQueue : IApi
     virtual void __stdcall UnregisterSubmitCallback(
         _In_ XTaskQueueRegistrationToken token) = 0;
 
-    virtual bool __stdcall IsTerminated() = 0;
     virtual bool __stdcall CanTerminate() = 0;
     virtual bool __stdcall CanClose() = 0;
 

--- a/Source/Task/TaskQueueP.h
+++ b/Source/Task/TaskQueueP.h
@@ -67,12 +67,18 @@ struct ITaskQueuePort: IApi
         _In_ ITaskQueuePortContext* portContext) = 0;
 
     virtual bool __stdcall DrainOneItem() = 0;
-    
+
     virtual bool __stdcall Wait(
         _In_ ITaskQueuePortContext* portContext,
         _In_ uint32_t timeout) = 0;
 
     virtual bool __stdcall IsEmpty() = 0;
+
+    virtual HRESULT __stdcall SuspendTermination(
+        _In_ ITaskQueuePortContext* portContext) = 0;
+
+    virtual void __stdcall ResumeTermination(
+        _In_ ITaskQueuePortContext* portContext) = 0;
 };
 
 // The status of a port on the queue.
@@ -102,6 +108,9 @@ struct ITaskQueuePortContext : IApi
         _In_ TaskQueuePortStatus status) = 0;
 
     virtual void __stdcall ItemQueued() = 0;
+
+    virtual bool __stdcall AddSuspend() = 0;
+    virtual bool __stdcall RemoveSuspend() = 0;
 };
 
 // The task queue.  The public flat API is built entirely on

--- a/Source/Task/TaskQueueP.h
+++ b/Source/Task/TaskQueueP.h
@@ -132,6 +132,7 @@ struct ITaskQueue : IApi
     virtual void __stdcall UnregisterSubmitCallback(
         _In_ XTaskQueueRegistrationToken token) = 0;
 
+    virtual bool __stdcall IsTerminated() = 0;
     virtual bool __stdcall CanTerminate() = 0;
     virtual bool __stdcall CanClose() = 0;
 

--- a/Source/Task/XAsyncProviderPriv.h
+++ b/Source/Task/XAsyncProviderPriv.h
@@ -1,0 +1,39 @@
+// Copyright(c) Microsoft Corporation. All rights reserved.
+//
+// These APIs should be reserved for driving unit test harnesses.
+
+#pragma once
+
+#include "XAsyncProvider.h"
+
+/// <summary>
+/// Initializes an async block for use.  Once begun calls such
+/// as XAsyncGetStatus will provide meaningful data. It is assumed the
+/// async work will begin on some system defined thread after this call
+/// returns. The token and function parameters can be used to help identify
+/// mismatched Begin/GetResult calls.  The token is typically the function
+/// pointer of the async API you are implementing, and the functionName parameter
+/// is typically the __FUNCTION__ compiler macro.  
+///
+/// This variant of XAsyncBegin will allocate additional memory of size contextSize
+/// and use this as the context pointer for async provider callbacks.  The memory
+/// pointer is returned in 'context'.  The lifetime of this memory is managed
+/// by the async library and will be freed automatically when the call 
+/// completes.
+/// </summary>
+/// <param name='asyncBlock'>A pointer to the XAsyncBlock that holds data for the call.</param>
+/// <param name='identity'>An optional arbitrary pointer that can be used to identify this call.</param>
+/// <param name='identityName'>An optional string that names the async call.  This is typically the __FUNCTION__ compiler macro.</param>
+/// <param name='provider'>The function callback to invoke to implement the async call.</param>
+/// <param name='contextSize'>The size, in bytes, of additional context memory to allocate.</param>
+/// <param name='parameterBlockSize'>The size of a parameter block to copy into the allocated context.</param>
+/// <param name='parameterBlock'>The parameter block to copy.  This will be copied into the allocated context.</param>
+STDAPI XAsyncBeginAlloc(
+    _Inout_ XAsyncBlock* asyncBlock,
+    _In_opt_ const void* identity,
+    _In_opt_ const char* identityName,
+    _In_ XAsyncProvider* provider,
+    _In_ size_t contextSize,
+    _In_ size_t parameterBlockSize,
+    _In_opt_ void* parameterBlock
+    ) noexcept;

--- a/Source/Task/XTaskQueuePriv.h
+++ b/Source/Task/XTaskQueuePriv.h
@@ -15,3 +15,12 @@
 STDAPI_(bool) XTaskQueueIsEmpty(
     _In_ XTaskQueueHandle queue,
     _In_ XTaskQueuePort port);
+
+/// <summary>
+/// Returns TRUE if this task queue is terminated or 
+/// is in the process of being terminated. There
+/// is no guarantee new callback submissions will succeed.
+/// </summary>
+/// <param name='queue'>The queue to check.</param>
+STDAPI_(bool) XTaskQueueIsTerminated(
+    _In_ XTaskQueueHandle queue);

--- a/Source/Task/XTaskQueuePriv.h
+++ b/Source/Task/XTaskQueuePriv.h
@@ -14,13 +14,23 @@
 /// <param name='port'>The port to check.</param>
 STDAPI_(bool) XTaskQueueIsEmpty(
     _In_ XTaskQueueHandle queue,
-    _In_ XTaskQueuePort port);
+    _In_ XTaskQueuePort port
+    ) noexcept;
 
 /// <summary>
-/// Returns TRUE if this task queue is terminated or 
-/// is in the process of being terminated. There
-/// is no guarantee new callback submissions will succeed.
+/// Suspends terminations on the task queue.  May return an error if
+/// the queue is already terminated.
 /// </summary>
-/// <param name='queue'>The queue to check.</param>
-STDAPI_(bool) XTaskQueueIsTerminated(
-    _In_ XTaskQueueHandle queue);
+/// <param name='queue'>The queue to suspend terminations.</param>
+STDAPI XTaskQueueSuspendTermination(
+    _In_ XTaskQueueHandle queue
+    ) noexcept;
+
+/// <summary>
+/// Resumes the ability to terminate the task queue. If a termination was
+/// attempted it will be continued.
+/// </summary>
+/// <param name='queue'>The queue resume terminations.</param>
+STDAPI_(void) XTaskQueueResumeTermination(
+    _In_ XTaskQueueHandle queue
+    ) noexcept;

--- a/Tests/UnitTests/Tests/AsyncBlockTests.cpp
+++ b/Tests/UnitTests/Tests/AsyncBlockTests.cpp
@@ -219,6 +219,33 @@ private:
         return S_OK;
     }
 
+    static HRESULT CALLBACK FactorialWorkerDistributedWithSchedule(XAsyncOp opCode, const XAsyncProviderData* data)
+    {
+        if (opCode == XAsyncOp::Begin)
+        {
+            FactorialCallData* d = (FactorialCallData*)data->context;
+            d->value = *(static_cast<DWORD*>(data->initContext));
+
+            // leak a ref on this guy so we don't try to free it. We need
+            // to do two addrefs because a new object starts with refcount
+            // of zero.  The factorial async process will addref/release so
+            // we need two to "leak" it (not really leaked; the memory is
+            // owned by the async logic)
+
+            d->AddRef();
+            d->AddRef();
+        }
+
+        HRESULT hr =  FactorialWorkerDistributed(opCode, data);
+
+        if (SUCCEEDED(hr) && opCode == XAsyncOp::Begin)
+        {
+            hr = XAsyncSchedule(data->async, 0);
+        }
+
+        return hr;
+    }
+
     static HRESULT FactorialAsync(FactorialCallData* data, XAsyncBlock* async)
     {
         HRESULT hr = XAsyncBegin(async, data, FactorialAsync, __FUNCTION__, FactorialWorkerSimple);
@@ -242,22 +269,7 @@ private:
     static HRESULT FactorialAllocateAsync(DWORD value, XAsyncBlock* async)
     {
         void* context;
-        HRESULT hr = XAsyncBeginAlloc(async, FactorialAsync, __FUNCTION__, FactorialWorkerDistributed, sizeof(FactorialCallData), &context);
-        if (SUCCEEDED(hr))
-        {
-            FactorialCallData* data = new (context) FactorialCallData;
-            data->value = value;
-
-            // leak a ref on this guy so we don't try to free it. We need
-            // to do two addrefs because a new object starts with refcount
-            // of zero.  The factorial async process will addref/release so
-            // we need two to "leak" it (not really leaked; the memory is
-            // owned by the async logic)
-            
-            data->AddRef();
-            data->AddRef();
-            hr = XAsyncSchedule(async, 0);
-        }
+        HRESULT hr = XAsyncBeginAlloc(async, FactorialAsync, __FUNCTION__, FactorialWorkerDistributedWithSchedule, &value, sizeof(FactorialCallData), &context);
         return hr;
     }
 
@@ -986,5 +998,83 @@ public:
         VERIFY_SUCCEEDED(XAsyncBegin(&async, nullptr, nullptr, nullptr, provider));
         VERIFY_SUCCEEDED(XAsyncGetStatus(&async, true));
         VERIFY_ARE_EQUAL((DWORD)WAIT_OBJECT_0, WaitForSingleObject(context.evt, 2500));
+    }
+
+    DEFINE_TEST_CASE(VerifyBeginAfterTerminate)
+    {
+        XAsyncBlock async{};
+        VERIFY_SUCCEEDED(XTaskQueueCreate(XTaskQueueDispatchMode::ThreadPool, XTaskQueueDispatchMode::ThreadPool, &async.queue));
+
+        async.callback = [](XAsyncBlock* async)
+        {
+            (*(bool*)async->context) = true;
+        };
+
+        auto provider = [](XAsyncOp op, const XAsyncProviderData* data)
+        {
+            switch(op)
+            {
+                case XAsyncOp::Begin:
+                    return XAsyncSchedule(data->async, 0);
+
+                case XAsyncOp::Cleanup:
+                    break;
+
+                default:
+                    VERIFY_FAIL();
+                    break;
+            }
+            return S_OK;
+        };
+
+        // Terminate the queue
+        XTaskQueueTerminate(async.queue, true, nullptr, nullptr);
+
+        bool callbackCalled = false;
+        async.context = &callbackCalled;
+
+        // XAsyncBegin should succeed.  The callback should have been called anyway, even
+        // without the queue.
+        VERIFY_SUCCEEDED(XAsyncBegin(&async, nullptr, nullptr, nullptr, provider));
+        VERIFY_IS_TRUE(callbackCalled);
+
+        VERIFY_ARE_EQUAL(E_ABORT, XAsyncGetStatus(&async, true));
+
+        XTaskQueueCloseHandle(async.queue);
+    }
+
+    DEFINE_TEST_CASE(VerifyFailureInDoWork)
+    {
+        XAsyncBlock async{};
+        VERIFY_SUCCEEDED(XTaskQueueCreate(XTaskQueueDispatchMode::ThreadPool, XTaskQueueDispatchMode::ThreadPool, &async.queue));
+
+        constexpr static HRESULT hrSpecial = 0x8009ABCD;
+
+        auto provider = [](XAsyncOp op, const XAsyncProviderData* data)
+        {
+            switch(op)
+            {
+                case XAsyncOp::Begin:
+                    return XAsyncSchedule(data->async, 0);
+
+                case XAsyncOp::Cleanup:
+                    break;
+
+                case XAsyncOp::DoWork:
+                    return hrSpecial;
+
+                default:
+                    VERIFY_FAIL();
+                    break;
+            }
+            return S_OK;
+        };
+
+        // Ensure that the call runs through and correctly reports our special 
+        // error.
+        VERIFY_SUCCEEDED(XAsyncBegin(&async, nullptr, nullptr, nullptr, provider));
+        VERIFY_ARE_EQUAL(hrSpecial, XAsyncGetStatus(&async, true));
+
+        XTaskQueueCloseHandle(async.queue);
     }
 };

--- a/Tests/UnitTests/Tests/AsyncBlockTests.cpp
+++ b/Tests/UnitTests/Tests/AsyncBlockTests.cpp
@@ -353,6 +353,7 @@ public:
     AsyncBlockTests::~AsyncBlockTests()
     {
         VERIFY_ARE_EQUAL(s_AsyncLibGlobalStateCount, (DWORD)0);
+        XTaskQueueTerminate(queue, true, nullptr, nullptr);
         XTaskQueueCloseHandle(queue);
     }
 

--- a/Tests/UnitTests/Tests/TaskQueueTests.cpp
+++ b/Tests/UnitTests/Tests/TaskQueueTests.cpp
@@ -110,6 +110,11 @@ public:
 
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
+        //
+        // Note: this is a global refcount for tracking
+        // leaks in the task queue.  If any other tests fail
+        // this may also fail, as those tests could have leaked.
+        //
         uint32_t gr = ApiDiag::g_globalApiRefs;
         VERIFY_ARE_EQUAL(0u, gr);
         return true;

--- a/Utilities/CMake/CMakeLists.txt
+++ b/Utilities/CMake/CMakeLists.txt
@@ -107,6 +107,7 @@ set(Task_Source_Files
     ../../../Source/Task/ThreadPool.h
     ../../../Source/Task/WaitTimer.h
     ../../../Source/Task/XTaskQueuePriv.h
+    ../../../Source/Task/XAsyncProviderPriv.h
     )
 
 set(Task_Windows_Source_Files


### PR DESCRIPTION
This change fixes a corner case where we could orphan a call if an async call was started after a queue was terminated.  It also fixes an API signature problem with XAsyncBeginAlloc -- the recommended way to use these apis is to call XAsyncSchedule in your provider during XAsyncOp::Begin, but you can't do that if you were never able to initialize your context object with the call parameters. This adds an initContext parameter to both the XAsyncBeginAlloc call and to the provider data.