### PR TITLE
Fix random FAIL_FAST and async context corruption in XAsyncGetResults

### DIFF
--- a/Include/httpClient/pal.h
+++ b/Include/httpClient/pal.h
@@ -154,6 +154,7 @@ typedef void* HANDLE;
 #define E_NOT_SUFFICIENT_BUFFER                 _HRESULTYPEDEF_(0x8007007AL)
 #define E_NOINTERFACE                           _HRESULTYPEDEF_(0x80004002L)
 #define E_BOUNDS                                _HRESULTYPEDEF_(0x8000000BL)
+#define E_ILLEGAL_METHOD_CALL                   _HRESULTYPEDEF_(0x8000000EL)
 #define HTTP_E_STATUS_AMBIGUOUS                 _HRESULTYPEDEF_(0x8019012CL)
 #define HTTP_E_STATUS_BAD_GATEWAY               _HRESULTYPEDEF_(0x801901F6L)
 #define HTTP_E_STATUS_BAD_METHOD                _HRESULTYPEDEF_(0x80190195L)

--- a/Source/Task/TaskQueue.cpp
+++ b/Source/Task/TaskQueue.cpp
@@ -476,6 +476,7 @@ HRESULT __stdcall TaskQueuePortImpl::PrepareTerminate(
     _Out_ void** token)
 {
     RETURN_HR_IF(E_POINTER, token == nullptr);
+    RETURN_HR_IF(E_INVALIDARG, callback == nullptr);
 
     std::unique_ptr<TerminationEntry> term(new (std::nothrow) TerminationEntry);
     RETURN_IF_NULL_ALLOC(term);
@@ -1020,13 +1021,10 @@ void TaskQueuePortImpl::ScheduleTermination(
     // races and that the termination callback happens on the right
     // thread.
 
-    if (term->callback != nullptr)
-    {
-        // This never fails because we preallocate the
-        // list node.
-        m_terminationList->push_back(term, term->node);
-        term->node = 0; // now owned by the list
-    }
+    // This never fails because we preallocate the
+    // list node.
+    m_terminationList->push_back(term, term->node);
+    term->node = 0; // now owned by the list
 
     // We will not signal until we are marked as terminated. The queue could
     // still be moving while we are running this terminate call.
@@ -1240,7 +1238,7 @@ bool __stdcall TaskQueuePortContextImpl::RemoveSuspend()
 
         // These should always be balanced and there is no
         // valid case where this should happen, even
-        // for multiple therads racing.
+        // for multiple threads racing.
 
         if (current == 0)
         {

--- a/Source/Task/TaskQueueP.h
+++ b/Source/Task/TaskQueueP.h
@@ -86,7 +86,6 @@ enum class TaskQueuePortStatus
 {
     Active,
     Canceled,
-    Terminating,
     Terminated
 };
 


### PR DESCRIPTION
This PR fixes a random FAIL_FAST crash when completing an async call and fixes an issue where if you call XAsyncGetResults before a call is complete the async block's internal context gets corrupted.