### PR TITLE
Fix small race in task queue termination

### DIFF
--- a/Source/Task/TaskQueue.cpp
+++ b/Source/Task/TaskQueue.cpp
@@ -532,8 +532,10 @@ void __stdcall TaskQueuePortImpl::Terminate(
         term->node = 0;
     }
 
-    // Balance our add
-    cxt->RemoveSuspend();
+    // Balance our add.  Note we must use ResumeTermination
+    // here so we schedule the termination if this is the
+    // last remove.
+    ResumeTermination(cxt.get());
 }
 
 HRESULT __stdcall TaskQueuePortImpl::Attach(


### PR DESCRIPTION
This is a small race window, but it's there. In TaskQueuePortImpl::Terminate we add a suspend reference and if it wasn't the first, we pend the termination for later and the remove the reference we added. But, if an async call completed before we removed the reference nothing will ever process the pending termination list.

The fix for this is a one line change. From this:

cxt->RemoveSuspend();

To this:

ResumeTermination(cxt.get());

I had to modify the timing of task queue to reliably reproduce this, but I was able to verify this fixes it. ResumeTermination does just a RemoveSuspend if it's not the last suspend reference. If it is (this race), it processes the pending terminations.