### PR TITLE
Tweak binary dir for libHttpClient Java

### DIFF
--- a/Build/libHttpClient.Android/app/build.gradle
+++ b/Build/libHttpClient.Android/app/build.gradle
@@ -57,7 +57,7 @@ android {
 
     libraryVariants.all { variant ->
         variant.outputs.each { output ->
-            output.outputFileName = "../../../../../../Binaries/Android/java/libHttpClient-${variant.name}.aar"
+            output.outputFileName = "../../../../../../Binaries/Android/java/${variant.getFlavorName()}/libHttpClient-${variant.getBuildType().getName()}.aar"
         }
     }
 }

--- a/Build/libHttpClient.Android/app/build.gradle
+++ b/Build/libHttpClient.Android/app/build.gradle
@@ -56,8 +56,20 @@ android {
     }
 
     libraryVariants.all { variant ->
+        def variantFlavor = variant.getFlavorName()
+        def variantAbi = "unknown"
+        if (variantFlavor == "arm7") {
+            variantAbi = "armeabi-v7a"
+        } else if (variantFlavor == "arm64") {
+            variantAbi = "arm64-v8a"
+        } else if (variantFlavor == "x86") {
+            variantAbi = "x86"
+        } else if (variantFlavor == "x86_64") {
+            variantAbi = "x86_64"
+        }
+        
         variant.outputs.each { output ->
-            output.outputFileName = "../../../../../../Binaries/Android/java/${variant.getFlavorName()}/libHttpClient-${variant.getBuildType().getName()}.aar"
+            output.outputFileName = "../../../../../../Binaries/Android/${variantAbi}/${variant.getBuildType().getName()}/libHttpClient.aar"
         }
     }
 }

--- a/Utilities/CMake/Android/GetLibHCBinaryOutputDir.cmake
+++ b/Utilities/CMake/Android/GetLibHCBinaryOutputDir.cmake
@@ -2,5 +2,5 @@ cmake_minimum_required(VERSION 3.6)
 
 function(GET_LIBHC_BINARY_OUTPUT_DIR PATH_TO_ROOT OUT_BINARY_DIR)
     string(TOLOWER "${CMAKE_BUILD_TYPE}" PATH_FLAVOR)
-    set(${OUT_BINARY_DIR} "${PATH_TO_ROOT}/Binaries/Android/native/${PATH_FLAVOR}/${ANDROID_ABI}" PARENT_SCOPE)
+    set(${OUT_BINARY_DIR} "${PATH_TO_ROOT}/Binaries/Android/${ANDROID_ABI}/${PATH_FLAVOR}" PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
Since product flavors are only used to separate native lib ABIs, no need to put the product flavor in the built Java binary name.