### PR TITLE
Make the common Android config generic to which Android plugin is applied

### DIFF
--- a/Build/libHttpClient.Android.Workspace/build.gradle
+++ b/Build/libHttpClient.Android.Workspace/build.gradle
@@ -26,5 +26,6 @@ allprojects {
 }
 
 subprojects {
-    apply from: new File("common_buildtypes_and_flavors.gradle").getAbsolutePath()
+    apply plugin: "com.android.library"
+    apply from: new File("common_android_config.gradle").getAbsolutePath()
 }

--- a/Build/libHttpClient.Android.Workspace/common_android_config.gradle
+++ b/Build/libHttpClient.Android.Workspace/common_android_config.gradle
@@ -1,4 +1,6 @@
-apply plugin: "com.android.library"
+if (!pluginManager.hasPlugin("com.android.base")) {
+    throw new GradleException("An Android plugin must be applied to use this script")
+}
 
 android {
     compileSdkVersion 27
@@ -53,4 +55,4 @@ android {
     }
 }
 
-project.ext."libhc_common_config_applied" = true
+project.ext."libhc_common_android_config_applied" = true

--- a/Build/libHttpClient.Android/build.gradle
+++ b/Build/libHttpClient.Android/build.gradle
@@ -1,4 +1,4 @@
-if (!project.ext."libhc_common_config_applied") {
+if (!project.ext."libhc_common_android_config_applied") {
     throw new GradleException("Expected common configuration not applied")
 }
 

--- a/Build/libcrypto.Android/build.gradle
+++ b/Build/libcrypto.Android/build.gradle
@@ -1,4 +1,4 @@
-if (!project.ext."libhc_common_config_applied") {
+if (!project.ext."libhc_common_android_config_applied") {
     throw new GradleException("Expected common configuration not applied")
 }
 

--- a/Build/libssl.Android/build.gradle
+++ b/Build/libssl.Android/build.gradle
@@ -1,4 +1,4 @@
-if (!project.ext."libhc_common_config_applied") {
+if (!project.ext."libhc_common_android_config_applied") {
     throw new GradleException("Expected common configuration not applied")
 }
 


### PR DESCRIPTION
The common Android config currently hard-codes that it applies the "com.android.library" Android plugin. This means that application projects (like our test app) cannot apply it.

This PR:
- Renames the common Android config file.
- Requires that _an_ Android plugin has been applied to use the common config, but does not specify which one.
- Applies "com.android.library" to the subprojects here explicitly, in `libHttpClient.Android.Workspace`.