### PR TITLE
Add error log line for WINHTTP_CALLBACK_STATUS_SECURE_FAILURE

### DIFF
--- a/Source/HTTP/WinHttp/winhttp_http_task.cpp
+++ b/Source/HTTP/WinHttp/winhttp_http_task.cpp
@@ -757,7 +757,7 @@ void winhttp_http_task::callback_status_read_complete(
 }
 
 void winhttp_http_task::callback_status_secure_failure(
-    _In_ HINTERNET hRequestHandle,
+    _In_ HINTERNET /*hRequestHandle*/,
     _In_ winhttp_http_task* pRequestContext,
     _In_ void* statusInfo)
 {

--- a/Source/HTTP/WinHttp/winhttp_http_task.cpp
+++ b/Source/HTTP/WinHttp/winhttp_http_task.cpp
@@ -756,6 +756,17 @@ void winhttp_http_task::callback_status_read_complete(
     }
 }
 
+void winhttp_http_task::callback_status_secure_failure(
+    _In_ HINTERNET hRequestHandle,
+    _In_ winhttp_http_task* pRequestContext,
+    _In_ void* statusInfo)
+{
+    // Status information contains pointer to DWORD containing a bitwise-OR combination of one or more error flags.
+    DWORD statusFlags = *(PDWORD)statusInfo;
+
+    HC_TRACE_ERROR(HTTPCLIENT, "HCHttpCallPerform [ID %llu] [TID %ul] WINHTTP_CALLBACK_STATUS_SECURE_FAILURE statusFlags=%d", TO_ULL(HCHttpCallGetId(pRequestContext->m_call)), GetCurrentThreadId(), statusFlags);
+}
+
 void CALLBACK winhttp_http_task::completion_callback(
     HINTERNET hRequestHandle,
     DWORD_PTR context,
@@ -873,6 +884,12 @@ void CALLBACK winhttp_http_task::completion_callback(
 
                 pRequestContext->on_websocket_disconnected(closeReason);
 #endif
+                break;
+            }
+
+            case WINHTTP_CALLBACK_STATUS_SECURE_FAILURE:
+            {
+                callback_status_secure_failure(hRequestHandle, pRequestContext, statusInfo);
                 break;
             }
         }

--- a/Source/HTTP/WinHttp/winhttp_http_task.cpp
+++ b/Source/HTTP/WinHttp/winhttp_http_task.cpp
@@ -327,7 +327,7 @@ void winhttp_http_task::complete_task(_In_ HRESULT translatedHR, uint32_t platfo
 
     if (m_hRequest != nullptr && !m_isWebSocket)
     {
-        WinHttpSetStatusCallback(m_hRequest, nullptr, WINHTTP_CALLBACK_FLAG_ALL_NOTIFICATIONS, NULL);
+        WinHttpSetStatusCallback(m_hRequest, nullptr, WINHTTP_CALLBACK_FLAG_ALL_NOTIFICATIONS | WINHTTP_CALLBACK_FLAG_SECURE_FAILURE, NULL);
         shared_ptr_cache::remove(this);
     }
 }
@@ -1487,7 +1487,7 @@ HRESULT winhttp_http_task::on_websocket_disconnected(_In_ USHORT closeReason)
     m_socketState = WinHttpWebsockState::Closed;
 
     // Handlers will be setup again upon connect
-    WinHttpSetStatusCallback(m_hRequest, nullptr, WINHTTP_CALLBACK_FLAG_ALL_NOTIFICATIONS, NULL); 
+    WinHttpSetStatusCallback(m_hRequest, nullptr, WINHTTP_CALLBACK_FLAG_ALL_NOTIFICATIONS | WINHTTP_CALLBACK_FLAG_SECURE_FAILURE, NULL);
 
     HCWebSocketCloseEventFunction disconnectFunc = nullptr;
     void* functionContext = nullptr;

--- a/Source/HTTP/WinHttp/winhttp_http_task.h
+++ b/Source/HTTP/WinHttp/winhttp_http_task.h
@@ -246,6 +246,11 @@ private:
         _In_ winhttp_http_task* pRequestContext,
         _In_ DWORD statusInfoLength);
 
+    static void callback_status_secure_failure(
+        _In_ HINTERNET hRequestHandle,
+        _In_ winhttp_http_task* pRequestContext,
+        _In_ void* statusInfo);
+
     static void callback_websocket_status_headers_available(
         _In_ HINTERNET hRequestHandle,
         _In_ winhttp_http_task* pRequestContext);


### PR DESCRIPTION
I noticed we don't have any log error message in the status callback for WINHTTP_CALLBACK_STATUS_SECURE_FAILURE.
See also #516 