### PR TITLE
Minor sync of libhttpclient to the Windows OS tree

### DIFF
--- a/Source/Task/TaskQueue.cpp
+++ b/Source/Task/TaskQueue.cpp
@@ -1299,6 +1299,9 @@ TaskQueueImpl::TaskQueueImpl() :
 
 TaskQueueImpl::~TaskQueueImpl()
 {
+    // Zero the header so we get an early warning of using
+    // a released object.
+    m_header = {};
 }
 
 HRESULT TaskQueueImpl::Initialize(


### PR DESCRIPTION
There was a minor bug fix in the Windows OS tree to clear the header data of a task queue before it is deleted so if someone tried to use a released task queue handle we could catch it early.  If you reused right after releasing the un-allocated memory could still look like a valid task queue and this will cause crashes later on.