### PR TITLE
Expose async cleanup

### DIFF
--- a/Include/httpClient/httpClient.h
+++ b/Include/httpClient/httpClient.h
@@ -136,8 +136,17 @@ STDAPI HCInitialize(_In_opt_ HCInitArgs* args) noexcept;
 /// Immediately reclaims all resources associated with the library.
 /// If you called HCMemSetFunctions(), call this before shutting down your app's memory manager.
 /// </summary>
+/// <remarks>
+/// Deprecated, Use HCCleanupAsync instead which allows control of which queue is running the cleanup work and does not potentially deadlock.
+/// </remarks>
 /// <returns></returns>
 STDAPI_(void) HCCleanup() noexcept;
+
+/// <summary>
+/// Reclaims all resources associated with the library.
+/// If you called HCMemSetFunctions(), call this before shutting down your app's memory manager.
+/// </summary>
+/// <returns></returns>
 STDAPI HCCleanupAsync(XAsyncBlock* async) noexcept;
 
 /// <summary>

--- a/Include/httpClient/httpClient.h
+++ b/Include/httpClient/httpClient.h
@@ -138,6 +138,7 @@ STDAPI HCInitialize(_In_opt_ HCInitArgs* args) noexcept;
 /// </summary>
 /// <returns></returns>
 STDAPI_(void) HCCleanup() noexcept;
+STDAPI HCCleanupAsync(XAsyncBlock* async) noexcept;
 
 /// <summary>
 /// Returns the version of the library

--- a/Source/Global/global_publics.cpp
+++ b/Source/Global/global_publics.cpp
@@ -8,8 +8,6 @@
 
 using namespace xbox::httpclient;
 
-XTaskQueueHandle g_HcCleanupHackQueueHandle = nullptr;
-
 STDAPI
 HCGetLibVersion(_Outptr_ const char** version) noexcept
 try

--- a/Source/Global/global_publics.cpp
+++ b/Source/Global/global_publics.cpp
@@ -5,9 +5,10 @@
 #include "../HTTP/httpcall.h"
 #include "buildver.h"
 #include "global.h"
-#include "../Logger/trace_internal.h"
 
 using namespace xbox::httpclient;
+
+XTaskQueueHandle g_HcCleanupHackQueueHandle = nullptr;
 
 STDAPI
 HCGetLibVersion(_Outptr_ const char** version) noexcept
@@ -27,7 +28,6 @@ STDAPI
 HCInitialize(_In_opt_ HCInitArgs* args) noexcept
 try
 {
-    HCTraceImplInit();
     return http_singleton::create(args);
 }
 CATCH_RETURN()
@@ -36,15 +36,20 @@ STDAPI_(void) HCCleanup() noexcept
 try
 {
     XAsyncBlock async{};
-    HRESULT hr = http_singleton::cleanup_async(&async);
+    HRESULT hr = HCCleanupAsync(&async);
     if (SUCCEEDED(hr))
     {
         XAsyncGetStatus(&async, true);
     }
-
-    HCTraceImplCleanup();
 }
 CATCH_RETURN_WITH(;)
+
+STDAPI HCCleanupAsync(XAsyncBlock* async) noexcept
+try
+{
+    return http_singleton::cleanup_async(async);
+}
+CATCH_RETURN()
 
 STDAPI
 HCSetGlobalProxy(_In_ const char* proxyUri) noexcept


### PR DESCRIPTION
The current blocking version of HCCleanup has 3 major flaws:
- It always uses the system task queue, which may be undesirable by some clients
- It blocks waiting for the internal work to complete, which could cause a deadlock
- It does not expose a result so in the case of multiple libHttpClient initializations it is impossible to tell if the memory hooks are safe to remove

This change simply exposes the internal asynchronous cleanup functionality allowing the caller control to bypass all these issues