### PR TITLE
Fixing Android network error retry

### DIFF
--- a/Source/HTTP/Android/http_android.cpp
+++ b/Source/HTTP/Android/http_android.cpp
@@ -40,7 +40,7 @@ JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientRequest_OnRequestFaile
     const char* nativeErrorString = env->GetStringUTFChars(errorMessage, nullptr);
     HCHttpCallResponseSetPlatformNetworkErrorMessage(sourceCall, nativeErrorString);
     env->ReleaseStringUTFChars(errorMessage, nativeErrorString);
-    
+
     XAsyncComplete(sourceRequest->GetAsyncBlock(), S_OK, 0);
 }
 

--- a/Source/HTTP/Android/http_android.cpp
+++ b/Source/HTTP/Android/http_android.cpp
@@ -40,6 +40,7 @@ JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientRequest_OnRequestFaile
     const char* nativeErrorString = env->GetStringUTFChars(errorMessage, nullptr);
     HCHttpCallResponseSetPlatformNetworkErrorMessage(sourceCall, nativeErrorString);
     env->ReleaseStringUTFChars(errorMessage, nativeErrorString);
+    
     XAsyncComplete(sourceRequest->GetAsyncBlock(), S_OK, 0);
 }
 

--- a/Source/HTTP/Android/http_android.cpp
+++ b/Source/HTTP/Android/http_android.cpp
@@ -40,8 +40,7 @@ JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientRequest_OnRequestFaile
     const char* nativeErrorString = env->GetStringUTFChars(errorMessage, nullptr);
     HCHttpCallResponseSetPlatformNetworkErrorMessage(sourceCall, nativeErrorString);
     env->ReleaseStringUTFChars(errorMessage, nativeErrorString);
-
-    XAsyncComplete(sourceRequest->GetAsyncBlock(), E_FAIL, 0);
+    XAsyncComplete(sourceRequest->GetAsyncBlock(), S_OK, 0);
 }
 
 }


### PR DESCRIPTION
On Android if a network request failed due to network issues, the Android code set a failure on both the network call object as well as the async call. Because the async call was indicating a failure as well, the retry logic was never kicking in.