### PR TITLE
improve multi mock behavior

### DIFF
--- a/Source/Mock/lhc_mock.cpp
+++ b/Source/Mock/lhc_mock.cpp
@@ -107,7 +107,7 @@ bool Mock_Internal_HCHttpCallPerformAsync(
     }
 
     // If this is not the only mock that matches, remove it from the list of mocks so that multiple can be used in sequence
-    auto countMatching = std::count_if(mocks.rbegin(), mocks.rend(), [originalCall](auto m) 
+    auto countMatching = std::count_if(mocks.begin(), mocks.end(), [originalCall](auto m) 
         {
             return DoesMockCallMatch(m, originalCall); 
         }


### PR DESCRIPTION
This PR updates the mocking behavior to match what's advertised by the doc header above `HCMockAddMock`:
```
/// You can set multiple active mock responses by calling HCMockAddMock() multiple 
/// times with a set of mock responses. If the HTTP call matches against a set mock responses, 
/// they will be executed in order for each subsequent call to HCHttpCallPerformAsync(). When the 
/// last matching mock response is hit, the last matching mock response will be repeated on 
/// each subsequent call to HCHttpCallPerformAsync().
```
Previously, the last-set mock for a particular URL was the only one that would ever return.  Now the behavior matches the comment: Each matching mock is used and consumed in order they were created, with the last mock repeated forever.