### PR TITLE
Bump Android NDK version to r22

### DIFF
--- a/Build/libHttpClient.Android.Workspace/common_android_config.gradle
+++ b/Build/libHttpClient.Android.Workspace/common_android_config.gradle
@@ -5,7 +5,7 @@ if (!pluginManager.hasPlugin("com.android.base")) {
 android {
     compileSdkVersion 27
     defaultConfig.targetSdkVersion 21
-    ndkVersion "21.3.6528147"
+    ndkVersion "22.0.7026061"
 
     flavorDimensions "default"
 


### PR DESCRIPTION
Per the GH issue here: https://github.com/actions/virtual-environments/issues/2420, the Mac images that ADO/GH-actions CI uses have removed Android NDK r21d (our currently pinned version) in favor of r22.

This PR bumps our version to r22.