### PR TITLE
Disable header maps for SSL targets

### DIFF
--- a/Build/libHttpClient.Apple.C/libHttpClient.xcodeproj/project.pbxproj
+++ b/Build/libHttpClient.Apple.C/libHttpClient.xcodeproj/project.pbxproj
@@ -1595,6 +1595,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
+				USE_HEADERMAP = NO;
 			};
 			name = Debug;
 		};
@@ -1619,6 +1620,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
+				USE_HEADERMAP = NO;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -1705,6 +1707,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
+				USE_HEADERMAP = NO;
 			};
 			name = Debug;
 		};
@@ -1730,6 +1733,7 @@
 				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
+				USE_HEADERMAP = NO;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;


### PR DESCRIPTION
Disable header maps for the SSL iOS/macOS targets. For mysterious reasons they cause the build to break on the first run with the error:

```log
Virtual filesystem overlay file '/Users/sasha/dev/xal/DerivedData/Xal/Build/Intermediates.noindex/libHttpClient.build/Debug-iphoneos/SSL_iOS.build/all-product-headers.yaml' not found
```

although the build succeeds on a second run. That doesn't work for CI though, unfortunately.