### PR TITLE
Upgrade OkHttp version

### DIFF
--- a/Build/libHttpClient.141.Android.Java/app/build.gradle
+++ b/Build/libHttpClient.141.Android.Java/app/build.gradle
@@ -55,6 +55,6 @@ repositories {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.squareup.okhttp3:okhttp:3.10.0'
+    compile 'com.squareup.okhttp3:okhttp:4.9.1'
     
 }

--- a/Build/libHttpClient.141.Android.Java/app/build.gradle.template
+++ b/Build/libHttpClient.141.Android.Java/app/build.gradle.template
@@ -55,6 +55,6 @@ repositories {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.squareup.okhttp3:okhttp:3.10.0'
+    compile 'com.squareup.okhttp3:okhttp:4.9.1'
     $(AarDependencies)
 }

--- a/Build/libHttpClient.141.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.141.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -48,12 +48,12 @@ public class HttpClientRequest {
     public void setHttpMethodAndBody(String method, String contentType, byte[] body) {
         if (body == null || body.length == 0) {
             if ("POST".equals(method) || "PUT".equals(method)) {
-                this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(null, NO_BODY));
+                this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(NO_BODY, null));
             } else {
                 this.requestBuilder = this.requestBuilder.method(method, null);
             }
         } else {
-            this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(MediaType.parse(contentType), body));
+            this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(body, MediaType.parse(contentType)));
         }
     }
 

--- a/Build/libHttpClient.142.Android.Java/app/build.gradle
+++ b/Build/libHttpClient.142.Android.Java/app/build.gradle
@@ -52,6 +52,6 @@ repositories {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.squareup.okhttp3:okhttp:3.10.0'
+    compile 'com.squareup.okhttp3:okhttp:4.9.1'
     
 }

--- a/Build/libHttpClient.142.Android.Java/app/build.gradle.template
+++ b/Build/libHttpClient.142.Android.Java/app/build.gradle.template
@@ -53,6 +53,6 @@ repositories {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.squareup.okhttp3:okhttp:3.10.0'
+    compile 'com.squareup.okhttp3:okhttp:4.9.1'
     $(AarDependencies)
 }

--- a/Build/libHttpClient.142.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.142.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -48,12 +48,12 @@ public class HttpClientRequest {
     public void setHttpMethodAndBody(String method, String contentType, byte[] body) {
         if (body == null || body.length == 0) {
             if ("POST".equals(method) || "PUT".equals(method)) {
-                this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(null, NO_BODY));
+                this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(NO_BODY, null));
             } else {
                 this.requestBuilder = this.requestBuilder.method(method, null);
             }
         } else {
-            this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(MediaType.parse(contentType), body));
+            this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(body, MediaType.parse(contentType)));
         }
     }
 

--- a/Build/libHttpClient.Android/build.gradle
+++ b/Build/libHttpClient.Android/build.gradle
@@ -48,5 +48,5 @@ android {
 }
 
 dependencies {
-    implementation "com.squareup.okhttp3:okhttp:3.10.0"
+    implementation "com.squareup.okhttp3:okhttp:4.9.1"
 }

--- a/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -48,12 +48,12 @@ public class HttpClientRequest {
     public void setHttpMethodAndBody(String method, String contentType, byte[] body) {
         if (body == null || body.length == 0) {
             if ("POST".equals(method) || "PUT".equals(method)) {
-                this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(null, NO_BODY));
+                this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(NO_BODY, null));
             } else {
                 this.requestBuilder = this.requestBuilder.method(method, null);
             }
         } else {
-            this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(MediaType.parse(contentType), body));
+            this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(body, MediaType.parse(contentType)));
         }
     }
 


### PR DESCRIPTION
Upgrades the Android OkHttp version from 3.10.0 to 4.9.1. Swaps the order of arguments to `RequestBody.create` to use a non-deprecated overload.