### PR TITLE
Address lint warnings in the Android Java code

### DIFF
--- a/Build/libHttpClient.141.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.141.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -1,8 +1,6 @@
 package com.xbox.httpclient;
 
-import android.content.Context;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 
@@ -15,10 +13,9 @@ import okhttp3.Response;
 import okhttp3.RequestBody;
 
 public class HttpClientRequest {
-    private static OkHttpClient OK_CLIENT;
+    private static final OkHttpClient OK_CLIENT;
     private static final byte[] NO_BODY = new byte[0];
 
-    private Request okHttpRequest;
     private Request.Builder requestBuilder;
 
     static {
@@ -31,45 +28,51 @@ public class HttpClientRequest {
         requestBuilder = new Request.Builder();
     }
 
+    @SuppressWarnings("unused")
     public static boolean isNetworkAvailable(Context context) {
         ConnectivityManager connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
         NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
         return activeNetworkInfo != null && activeNetworkInfo.isConnected();
     }
 
+    @SuppressWarnings("unused")
     public static HttpClientRequest createClientRequest() {
         return new HttpClientRequest();
     }
 
+    @SuppressWarnings("unused")
     public void setHttpUrl(String url) {
         this.requestBuilder = this.requestBuilder.url(url);
     }
 
+    @SuppressWarnings("unused")
     public void setHttpMethodAndBody(String method, String contentType, byte[] body) {
         if (body == null || body.length == 0) {
             if ("POST".equals(method) || "PUT".equals(method)) {
-                this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(null, NO_BODY));
+                this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(NO_BODY, null));
             } else {
                 this.requestBuilder = this.requestBuilder.method(method, null);
             }
         } else {
-            this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(MediaType.parse(contentType), body));
+            this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(body, MediaType.parse(contentType)));
         }
     }
 
+    @SuppressWarnings("unused")
     public void setHttpHeader(String name, String value) {
         this.requestBuilder = requestBuilder.addHeader(name, value);
     }
 
+    @SuppressWarnings("unused")
     public void doRequestAsync(final long sourceCall) {
         OK_CLIENT.newCall(this.requestBuilder.build()).enqueue(new Callback() {
             @Override
-            public void onFailure(final Call call, IOException e) {
+            public void onFailure(@NotNull final Call call, @NotNull IOException e) {
                 OnRequestFailed(sourceCall, e.getClass().getCanonicalName());
             }
 
             @Override
-            public void onResponse(Call call, final Response response) throws IOException {
+            public void onResponse(@NotNull Call call, @NotNull final Response response) {
                 OnRequestCompleted(sourceCall, new HttpClientResponse(response));
             }
         });

--- a/Build/libHttpClient.141.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.141.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -51,12 +51,12 @@ public class HttpClientRequest {
     public void setHttpMethodAndBody(String method, String contentType, byte[] body) {
         if (body == null || body.length == 0) {
             if ("POST".equals(method) || "PUT".equals(method)) {
-                this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(NO_BODY, null));
+                this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(null, NO_BODY));
             } else {
                 this.requestBuilder = this.requestBuilder.method(method, null);
             }
         } else {
-            this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(body, MediaType.parse(contentType)));
+            this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(MediaType.parse(contentType), body));
         }
     }
 

--- a/Build/libHttpClient.141.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.141.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -1,6 +1,8 @@
 package com.xbox.httpclient;
 
-import org.jetbrains.annotations.NotNull;
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 
 import java.io.IOException;
 
@@ -67,12 +69,12 @@ public class HttpClientRequest {
     public void doRequestAsync(final long sourceCall) {
         OK_CLIENT.newCall(this.requestBuilder.build()).enqueue(new Callback() {
             @Override
-            public void onFailure(@NotNull final Call call, @NotNull IOException e) {
+            public void onFailure(final Call call, IOException e) {
                 OnRequestFailed(sourceCall, e.getClass().getCanonicalName());
             }
 
             @Override
-            public void onResponse(@NotNull Call call, @NotNull final Response response) {
+            public void onResponse(Call call, final Response response) {
                 OnRequestCompleted(sourceCall, new HttpClientResponse(response));
             }
         });

--- a/Build/libHttpClient.141.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.141.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -38,11 +38,6 @@ public class HttpClientRequest {
     }
 
     @SuppressWarnings("unused")
-    public static HttpClientRequest createClientRequest() {
-        return new HttpClientRequest();
-    }
-
-    @SuppressWarnings("unused")
     public void setHttpUrl(String url) {
         this.requestBuilder = this.requestBuilder.url(url);
     }

--- a/Build/libHttpClient.141.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientResponse.java
+++ b/Build/libHttpClient.141.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientResponse.java
@@ -1,23 +1,22 @@
-
 package com.xbox.httpclient;
-
-import android.util.Log;
 
 import java.io.IOException;
 import okhttp3.Response;
 
 class HttpClientResponse
 {
-    private Response response;
+    private final Response response;
 
     public HttpClientResponse(Response sourceResponse) {
         this.response = sourceResponse;
     }
 
+    @SuppressWarnings("unused")
     public int getNumHeaders() {
         return this.response.headers().size();
     }
 
+    @SuppressWarnings("unused")
     public String getHeaderNameAtIndex(int index) {
         if (index >= 0 && index < this.response.headers().size()) {
             return this.response.headers().name(index);
@@ -26,6 +25,7 @@ class HttpClientResponse
         }
     }
 
+    @SuppressWarnings("unused")
     public String getHeaderValueAtIndex(int index) {
         if (index >= 0 && index < this.response.headers().size()) {
             return this.response.headers().value(index);
@@ -34,6 +34,7 @@ class HttpClientResponse
         }
     }
 
+    @SuppressWarnings("unused")
     public byte[] getResponseBodyBytes() {
         try {
             byte[] responseBodyBytes = this.response.body().bytes();
@@ -43,6 +44,7 @@ class HttpClientResponse
         }
     }
 
+    @SuppressWarnings("unused")
     public int getResponseCode() {
         return response.code();
     }

--- a/Build/libHttpClient.142.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.142.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -1,8 +1,6 @@
 package com.xbox.httpclient;
 
-import android.content.Context;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 
@@ -15,10 +13,9 @@ import okhttp3.Response;
 import okhttp3.RequestBody;
 
 public class HttpClientRequest {
-    private static OkHttpClient OK_CLIENT;
+    private static final OkHttpClient OK_CLIENT;
     private static final byte[] NO_BODY = new byte[0];
 
-    private Request okHttpRequest;
     private Request.Builder requestBuilder;
 
     static {
@@ -31,45 +28,51 @@ public class HttpClientRequest {
         requestBuilder = new Request.Builder();
     }
 
+    @SuppressWarnings("unused")
     public static boolean isNetworkAvailable(Context context) {
         ConnectivityManager connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
         NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
         return activeNetworkInfo != null && activeNetworkInfo.isConnected();
     }
 
+    @SuppressWarnings("unused")
     public static HttpClientRequest createClientRequest() {
         return new HttpClientRequest();
     }
 
+    @SuppressWarnings("unused")
     public void setHttpUrl(String url) {
         this.requestBuilder = this.requestBuilder.url(url);
     }
 
+    @SuppressWarnings("unused")
     public void setHttpMethodAndBody(String method, String contentType, byte[] body) {
         if (body == null || body.length == 0) {
             if ("POST".equals(method) || "PUT".equals(method)) {
-                this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(null, NO_BODY));
+                this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(NO_BODY, null));
             } else {
                 this.requestBuilder = this.requestBuilder.method(method, null);
             }
         } else {
-            this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(MediaType.parse(contentType), body));
+            this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(body, MediaType.parse(contentType)));
         }
     }
 
+    @SuppressWarnings("unused")
     public void setHttpHeader(String name, String value) {
         this.requestBuilder = requestBuilder.addHeader(name, value);
     }
 
+    @SuppressWarnings("unused")
     public void doRequestAsync(final long sourceCall) {
         OK_CLIENT.newCall(this.requestBuilder.build()).enqueue(new Callback() {
             @Override
-            public void onFailure(final Call call, IOException e) {
+            public void onFailure(@NotNull final Call call, @NotNull IOException e) {
                 OnRequestFailed(sourceCall, e.getClass().getCanonicalName());
             }
 
             @Override
-            public void onResponse(Call call, final Response response) throws IOException {
+            public void onResponse(@NotNull Call call, @NotNull final Response response) {
                 OnRequestCompleted(sourceCall, new HttpClientResponse(response));
             }
         });

--- a/Build/libHttpClient.142.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.142.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -51,12 +51,12 @@ public class HttpClientRequest {
     public void setHttpMethodAndBody(String method, String contentType, byte[] body) {
         if (body == null || body.length == 0) {
             if ("POST".equals(method) || "PUT".equals(method)) {
-                this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(NO_BODY, null));
+                this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(null, NO_BODY));
             } else {
                 this.requestBuilder = this.requestBuilder.method(method, null);
             }
         } else {
-            this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(body, MediaType.parse(contentType)));
+            this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(MediaType.parse(contentType), body));
         }
     }
 

--- a/Build/libHttpClient.142.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.142.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -1,6 +1,8 @@
 package com.xbox.httpclient;
 
-import org.jetbrains.annotations.NotNull;
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 
 import java.io.IOException;
 
@@ -67,12 +69,12 @@ public class HttpClientRequest {
     public void doRequestAsync(final long sourceCall) {
         OK_CLIENT.newCall(this.requestBuilder.build()).enqueue(new Callback() {
             @Override
-            public void onFailure(@NotNull final Call call, @NotNull IOException e) {
+            public void onFailure(final Call call, IOException e) {
                 OnRequestFailed(sourceCall, e.getClass().getCanonicalName());
             }
 
             @Override
-            public void onResponse(@NotNull Call call, @NotNull final Response response) {
+            public void onResponse(Call call, final Response response) {
                 OnRequestCompleted(sourceCall, new HttpClientResponse(response));
             }
         });

--- a/Build/libHttpClient.142.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.142.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -38,11 +38,6 @@ public class HttpClientRequest {
     }
 
     @SuppressWarnings("unused")
-    public static HttpClientRequest createClientRequest() {
-        return new HttpClientRequest();
-    }
-
-    @SuppressWarnings("unused")
     public void setHttpUrl(String url) {
         this.requestBuilder = this.requestBuilder.url(url);
     }

--- a/Build/libHttpClient.142.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientResponse.java
+++ b/Build/libHttpClient.142.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientResponse.java
@@ -1,23 +1,22 @@
-
 package com.xbox.httpclient;
-
-import android.util.Log;
 
 import java.io.IOException;
 import okhttp3.Response;
 
 class HttpClientResponse
 {
-    private Response response;
+    private final Response response;
 
     public HttpClientResponse(Response sourceResponse) {
         this.response = sourceResponse;
     }
 
+    @SuppressWarnings("unused")
     public int getNumHeaders() {
         return this.response.headers().size();
     }
 
+    @SuppressWarnings("unused")
     public String getHeaderNameAtIndex(int index) {
         if (index >= 0 && index < this.response.headers().size()) {
             return this.response.headers().name(index);
@@ -26,6 +25,7 @@ class HttpClientResponse
         }
     }
 
+    @SuppressWarnings("unused")
     public String getHeaderValueAtIndex(int index) {
         if (index >= 0 && index < this.response.headers().size()) {
             return this.response.headers().value(index);
@@ -34,6 +34,7 @@ class HttpClientResponse
         }
     }
 
+    @SuppressWarnings("unused")
     public byte[] getResponseBodyBytes() {
         try {
             byte[] responseBodyBytes = this.response.body().bytes();
@@ -43,6 +44,7 @@ class HttpClientResponse
         }
     }
 
+    @SuppressWarnings("unused")
     public int getResponseCode() {
         return response.code();
     }

--- a/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -1,8 +1,6 @@
 package com.xbox.httpclient;
 
-import android.content.Context;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 
@@ -15,10 +13,9 @@ import okhttp3.Response;
 import okhttp3.RequestBody;
 
 public class HttpClientRequest {
-    private static OkHttpClient OK_CLIENT;
+    private static final OkHttpClient OK_CLIENT;
     private static final byte[] NO_BODY = new byte[0];
 
-    private Request okHttpRequest;
     private Request.Builder requestBuilder;
 
     static {
@@ -31,45 +28,51 @@ public class HttpClientRequest {
         requestBuilder = new Request.Builder();
     }
 
+    @SuppressWarnings("unused")
     public static boolean isNetworkAvailable(Context context) {
         ConnectivityManager connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
         NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
         return activeNetworkInfo != null && activeNetworkInfo.isConnected();
     }
 
+    @SuppressWarnings("unused")
     public static HttpClientRequest createClientRequest() {
         return new HttpClientRequest();
     }
 
+    @SuppressWarnings("unused")
     public void setHttpUrl(String url) {
         this.requestBuilder = this.requestBuilder.url(url);
     }
 
+    @SuppressWarnings("unused")
     public void setHttpMethodAndBody(String method, String contentType, byte[] body) {
         if (body == null || body.length == 0) {
             if ("POST".equals(method) || "PUT".equals(method)) {
-                this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(null, NO_BODY));
+                this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(NO_BODY, null));
             } else {
                 this.requestBuilder = this.requestBuilder.method(method, null);
             }
         } else {
-            this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(MediaType.parse(contentType), body));
+            this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(body, MediaType.parse(contentType)));
         }
     }
 
+    @SuppressWarnings("unused")
     public void setHttpHeader(String name, String value) {
         this.requestBuilder = requestBuilder.addHeader(name, value);
     }
 
+    @SuppressWarnings("unused")
     public void doRequestAsync(final long sourceCall) {
         OK_CLIENT.newCall(this.requestBuilder.build()).enqueue(new Callback() {
             @Override
-            public void onFailure(final Call call, IOException e) {
+            public void onFailure(@NotNull final Call call, @NotNull IOException e) {
                 OnRequestFailed(sourceCall, e.getClass().getCanonicalName());
             }
 
             @Override
-            public void onResponse(Call call, final Response response) throws IOException {
+            public void onResponse(@NotNull Call call, @NotNull final Response response) {
                 OnRequestCompleted(sourceCall, new HttpClientResponse(response));
             }
         });

--- a/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -51,12 +51,12 @@ public class HttpClientRequest {
     public void setHttpMethodAndBody(String method, String contentType, byte[] body) {
         if (body == null || body.length == 0) {
             if ("POST".equals(method) || "PUT".equals(method)) {
-                this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(NO_BODY, null));
+                this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(null, NO_BODY));
             } else {
                 this.requestBuilder = this.requestBuilder.method(method, null);
             }
         } else {
-            this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(body, MediaType.parse(contentType)));
+            this.requestBuilder = this.requestBuilder.method(method, RequestBody.create(MediaType.parse(contentType), body));
         }
     }
 

--- a/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -1,6 +1,8 @@
 package com.xbox.httpclient;
 
-import org.jetbrains.annotations.NotNull;
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 
 import java.io.IOException;
 
@@ -67,12 +69,12 @@ public class HttpClientRequest {
     public void doRequestAsync(final long sourceCall) {
         OK_CLIENT.newCall(this.requestBuilder.build()).enqueue(new Callback() {
             @Override
-            public void onFailure(@NotNull final Call call, @NotNull IOException e) {
+            public void onFailure(final Call call, IOException e) {
                 OnRequestFailed(sourceCall, e.getClass().getCanonicalName());
             }
 
             @Override
-            public void onResponse(@NotNull Call call, @NotNull final Response response) {
+            public void onResponse(Call call, final Response response) {
                 OnRequestCompleted(sourceCall, new HttpClientResponse(response));
             }
         });

--- a/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -38,11 +38,6 @@ public class HttpClientRequest {
     }
 
     @SuppressWarnings("unused")
-    public static HttpClientRequest createClientRequest() {
-        return new HttpClientRequest();
-    }
-
-    @SuppressWarnings("unused")
     public void setHttpUrl(String url) {
         this.requestBuilder = this.requestBuilder.url(url);
     }

--- a/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientResponse.java
+++ b/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientResponse.java
@@ -1,22 +1,22 @@
 package com.xbox.httpclient;
 
-import android.util.Log;
-
 import java.io.IOException;
 import okhttp3.Response;
 
 class HttpClientResponse
 {
-    private Response response;
+    private final Response response;
 
     public HttpClientResponse(Response sourceResponse) {
         this.response = sourceResponse;
     }
 
+    @SuppressWarnings("unused")
     public int getNumHeaders() {
         return this.response.headers().size();
     }
 
+    @SuppressWarnings("unused")
     public String getHeaderNameAtIndex(int index) {
         if (index >= 0 && index < this.response.headers().size()) {
             return this.response.headers().name(index);
@@ -25,6 +25,7 @@ class HttpClientResponse
         }
     }
 
+    @SuppressWarnings("unused")
     public String getHeaderValueAtIndex(int index) {
         if (index >= 0 && index < this.response.headers().size()) {
             return this.response.headers().value(index);
@@ -33,6 +34,7 @@ class HttpClientResponse
         }
     }
 
+    @SuppressWarnings("unused")
     public byte[] getResponseBodyBytes() {
         try {
             byte[] responseBodyBytes = this.response.body().bytes();
@@ -42,6 +44,7 @@ class HttpClientResponse
         }
     }
 
+    @SuppressWarnings("unused")
     public int getResponseCode() {
         return response.code();
     }


### PR DESCRIPTION
Addresses a number of lint warnings in the Android Java code.

- Remove unused methods/members
- Add `final` where appropriate
- Suppress "unused" warnings for methods called via JNI
- Remove unnecessary `throws`
- Remove unused import