### PR TITLE
Remove network check during Android HTTP request initialization

### DIFF
--- a/Build/libHttpClient.141.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.141.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -5,6 +5,7 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 
 import java.io.IOException;
+import java.net.UnknownHostException;
 
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -29,12 +30,6 @@ public class HttpClientRequest {
 
     public HttpClientRequest() {
         requestBuilder = new Request.Builder();
-    }
-
-    public static boolean isNetworkAvailable(Context context) {
-        ConnectivityManager connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
-        return activeNetworkInfo != null && activeNetworkInfo.isConnected();
     }
 
     public static HttpClientRequest createClientRequest() {
@@ -65,7 +60,8 @@ public class HttpClientRequest {
         OK_CLIENT.newCall(this.requestBuilder.build()).enqueue(new Callback() {
             @Override
             public void onFailure(final Call call, IOException e) {
-                OnRequestFailed(sourceCall, e.getClass().getCanonicalName());
+                boolean isNoNetworkFailure = e instanceof UnknownHostException;
+                OnRequestFailed(sourceCall, e.getClass().getCanonicalName(), isNoNetworkFailure);
             }
 
             @Override
@@ -76,5 +72,5 @@ public class HttpClientRequest {
     }
 
     private native void OnRequestCompleted(long call, HttpClientResponse response);
-    private native void OnRequestFailed(long call, String errorMessage);
+    private native void OnRequestFailed(long call, String errorMessage, boolean isNoNetwork);
 }

--- a/Build/libHttpClient.141.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.141.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -1,9 +1,5 @@
 package com.xbox.httpclient;
 
-import android.content.Context;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
-
 import java.io.IOException;
 import java.net.UnknownHostException;
 

--- a/Build/libHttpClient.141.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientResponse.java
+++ b/Build/libHttpClient.141.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientResponse.java
@@ -1,4 +1,3 @@
-
 package com.xbox.httpclient;
 
 import android.util.Log;

--- a/Build/libHttpClient.142.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.142.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -5,6 +5,7 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 
 import java.io.IOException;
+import java.net.UnknownHostException;
 
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -29,12 +30,6 @@ public class HttpClientRequest {
 
     public HttpClientRequest() {
         requestBuilder = new Request.Builder();
-    }
-
-    public static boolean isNetworkAvailable(Context context) {
-        ConnectivityManager connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
-        return activeNetworkInfo != null && activeNetworkInfo.isConnected();
     }
 
     public static HttpClientRequest createClientRequest() {
@@ -65,7 +60,8 @@ public class HttpClientRequest {
         OK_CLIENT.newCall(this.requestBuilder.build()).enqueue(new Callback() {
             @Override
             public void onFailure(final Call call, IOException e) {
-                OnRequestFailed(sourceCall, e.getClass().getCanonicalName());
+                boolean isNoNetworkFailure = e instanceof UnknownHostException;
+                OnRequestFailed(sourceCall, e.getClass().getCanonicalName(), isNoNetworkFailure);
             }
 
             @Override
@@ -76,5 +72,5 @@ public class HttpClientRequest {
     }
 
     private native void OnRequestCompleted(long call, HttpClientResponse response);
-    private native void OnRequestFailed(long call, String errorMessage);
+    private native void OnRequestFailed(long call, String errorMessage, boolean isNoNetwork);
 }

--- a/Build/libHttpClient.142.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.142.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -1,9 +1,5 @@
 package com.xbox.httpclient;
 
-import android.content.Context;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
-
 import java.io.IOException;
 import java.net.UnknownHostException;
 

--- a/Build/libHttpClient.142.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientResponse.java
+++ b/Build/libHttpClient.142.Android.Java/app/src/main/java/com/xbox/httpclient/HttpClientResponse.java
@@ -1,4 +1,3 @@
-
 package com.xbox.httpclient;
 
 import android.util.Log;

--- a/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -5,6 +5,7 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 
 import java.io.IOException;
+import java.net.UnknownHostException;
 
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -29,12 +30,6 @@ public class HttpClientRequest {
 
     public HttpClientRequest() {
         requestBuilder = new Request.Builder();
-    }
-
-    public static boolean isNetworkAvailable(Context context) {
-        ConnectivityManager connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
-        return activeNetworkInfo != null && activeNetworkInfo.isConnected();
     }
 
     public static HttpClientRequest createClientRequest() {
@@ -65,7 +60,8 @@ public class HttpClientRequest {
         OK_CLIENT.newCall(this.requestBuilder.build()).enqueue(new Callback() {
             @Override
             public void onFailure(final Call call, IOException e) {
-                OnRequestFailed(sourceCall, e.getClass().getCanonicalName());
+                boolean isNoNetworkFailure = e instanceof UnknownHostException;
+                OnRequestFailed(sourceCall, e.getClass().getCanonicalName(), isNoNetworkFailure);
             }
 
             @Override
@@ -76,5 +72,5 @@ public class HttpClientRequest {
     }
 
     private native void OnRequestCompleted(long call, HttpClientResponse response);
-    private native void OnRequestFailed(long call, String errorMessage);
+    private native void OnRequestFailed(long call, String errorMessage, boolean isNoNetwork);
 }

--- a/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -1,9 +1,5 @@
 package com.xbox.httpclient;
 
-import android.content.Context;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
-
 import java.io.IOException;
 import java.net.UnknownHostException;
 

--- a/Source/HTTP/Android/android_http_request.cpp
+++ b/Source/HTTP/Android/android_http_request.cpp
@@ -4,11 +4,10 @@
 #include <httpClient/httpClient.h>
 #include <vector>
 
-HttpRequest::HttpRequest(XAsyncBlock* asyncBlock, JavaVM* javaVm, jobject applicationContext, jclass httpRequestClass, jclass httpResponseClass) :
+HttpRequest::HttpRequest(XAsyncBlock* asyncBlock, JavaVM* javaVm, jclass httpRequestClass, jclass httpResponseClass) :
     m_httpRequestInstance(nullptr), 
     m_asyncBlock(asyncBlock),
     m_javaVm(javaVm),
-    m_applicationContext(applicationContext),
     m_httpRequestClass(httpRequestClass),
     m_httpResponseClass(httpResponseClass)
 {
@@ -34,20 +33,6 @@ HRESULT HttpRequest::Initialize()
 
     if (SUCCEEDED(result)) 
     {
-        jmethodID networkAvailabilityFunc = jniEnv->GetStaticMethodID(m_httpRequestClass, "isNetworkAvailable", "(Landroid/content/Context;)Z");
-        if (networkAvailabilityFunc == nullptr)
-        {
-            HC_TRACE_ERROR(HTTPCLIENT, "Could not find isNetworkAvailable static method");
-            return E_FAIL;
-        }
-
-        jboolean isNetworkAvailable = jniEnv->CallStaticBooleanMethod(m_httpRequestClass, networkAvailabilityFunc, m_applicationContext);
-        if (!isNetworkAvailable)
-        {
-            HC_TRACE_ERROR(HTTPCLIENT, "Could not initialize HttpRequest - no network available");
-            return E_HC_NO_NETWORK;
-        }
-
         jmethodID httpRequestCtor = jniEnv->GetMethodID(m_httpRequestClass, "<init>", "()V");
         if (httpRequestCtor == nullptr) 
         {

--- a/Source/HTTP/Android/android_http_request.h
+++ b/Source/HTTP/Android/android_http_request.h
@@ -4,7 +4,7 @@
 
 class HttpRequest {
 public:
-    HttpRequest(XAsyncBlock* asyncBlock, JavaVM* javaVm, jobject applicationContext, jclass httpRequestClass, jclass httpResponseClass);
+    HttpRequest(XAsyncBlock* asyncBlock, JavaVM* javaVm, jclass httpRequestClass, jclass httpResponseClass);
     virtual ~HttpRequest();
 
     HRESULT Initialize();
@@ -27,7 +27,6 @@ private:
     XAsyncBlock* m_asyncBlock;
 
     JavaVM* m_javaVm;
-    jobject m_applicationContext;
     jclass m_httpRequestClass;
     jclass m_httpResponseClass;
 };

--- a/Source/HTTP/Android/http_android.cpp
+++ b/Source/HTTP/Android/http_android.cpp
@@ -28,14 +28,14 @@ JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientRequest_OnRequestCompl
     }
 }
 
-JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientRequest_OnRequestFailed(JNIEnv* env, jobject instance, jlong call, jstring errorMessage)
+JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientRequest_OnRequestFailed(JNIEnv* env, jobject instance, jlong call, jstring errorMessage, jboolean isNoNetwork)
 {
     HCCallHandle sourceCall = reinterpret_cast<HCCallHandle>(call);
     HttpRequest* request = nullptr;
     HCHttpCallGetContext(sourceCall, reinterpret_cast<void**>(&request));
     std::unique_ptr<HttpRequest> sourceRequest{ request };
 
-    HCHttpCallResponseSetNetworkErrorCode(sourceCall, E_FAIL, 0);
+    HCHttpCallResponseSetNetworkErrorCode(sourceCall, isNoNetwork ? E_HC_NO_NETWORK : E_FAIL, 0);
 
     const char* nativeErrorString = env->GetStringUTFChars(errorMessage, nullptr);
     HCHttpCallResponseSetPlatformNetworkErrorMessage(sourceCall, nativeErrorString);
@@ -65,7 +65,6 @@ void Internal_HCHttpCallPerformAsync(
         new HttpRequest(
             asyncBlock,
             env->GetJavaVm(),
-            env->GetApplicationContext(),
             env->GetHttpRequestClass(),
             env->GetHttpResponseClass()
         )


### PR DESCRIPTION
On Android, we currently query the OS while initializing an HTTP request to check if network "is available" before doing the initialization. However, the network-checking code uses deprecated APIs and given the logs from some recent bug reports in XAL we believe there is a subtle and rare bug in that code.

This PR removes the check during initialization and instead (mirroring iOS behavior) does a best-effort at detecting a "no-network" related failure when a request fails (by checking for a `java.net.UnknownHostException`), and passes that signal along in the error code on the call's handle.