### PR TITLE
Update targetSDKVersion, Gradle version, and Android Gradle Plug-in version

### DIFF
--- a/Build/libHttpClient.Android.Workspace/build.gradle
+++ b/Build/libHttpClient.Android.Workspace/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.1.2'
     }
 }
 

--- a/Build/libHttpClient.Android.Workspace/gradle/wrapper/gradle-wrapper.properties
+++ b/Build/libHttpClient.Android.Workspace/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Feb 24 12:42:14 PST 2021
+#Fri Mar 05 15:37:21 CST 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/Build/libHttpClient.Android/build.gradle
+++ b/Build/libHttpClient.Android/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: "com.android.library"
 
 android {
-    compileSdkVersion 27
-    ndkVersion "22.0.7026061"
+    compileSdkVersion 30
+    ndkVersion '22.0.7026061'
 
     defaultConfig {
-        targetSdkVersion 21
+        targetSdkVersion 30
         minSdkVersion 21
 
         externalNativeBuild {

--- a/Build/libHttpClient.Android/build.gradle
+++ b/Build/libHttpClient.Android/build.gradle
@@ -2,7 +2,7 @@ apply plugin: "com.android.library"
 
 android {
     compileSdkVersion 30
-    ndkVersion '22.0.7026061'
+    ndkVersion "22.0.7026061"
 
     defaultConfig {
         targetSdkVersion 30

--- a/Build/libcrypto.Android/build.gradle
+++ b/Build/libcrypto.Android/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: "com.android.library"
 
 android {
-    compileSdkVersion 27
-    ndkVersion "22.0.7026061"
+    compileSdkVersion 30
+    ndkVersion '22.0.7026061'
 
     defaultConfig {
-        targetSdkVersion 21
+        targetSdkVersion 30
         minSdkVersion 21
 
         externalNativeBuild {

--- a/Build/libcrypto.Android/build.gradle
+++ b/Build/libcrypto.Android/build.gradle
@@ -2,7 +2,7 @@ apply plugin: "com.android.library"
 
 android {
     compileSdkVersion 30
-    ndkVersion '22.0.7026061'
+    ndkVersion "22.0.7026061"
 
     defaultConfig {
         targetSdkVersion 30

--- a/Build/libssl.Android/build.gradle
+++ b/Build/libssl.Android/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: "com.android.library"
 
 android {
-    compileSdkVersion 27
-    ndkVersion "22.0.7026061"
+    compileSdkVersion 30
+    ndkVersion '22.0.7026061'
 
     defaultConfig {
-        targetSdkVersion 21
+        targetSdkVersion 30
         minSdkVersion 21
 
         externalNativeBuild {

--- a/Build/libssl.Android/build.gradle
+++ b/Build/libssl.Android/build.gradle
@@ -2,7 +2,7 @@ apply plugin: "com.android.library"
 
 android {
     compileSdkVersion 30
-    ndkVersion '22.0.7026061'
+    ndkVersion "22.0.7026061"
 
     defaultConfig {
         targetSdkVersion 30


### PR DESCRIPTION
This PR targets libHttpClient builds for Android Studio.
- Updating targetSDKVersion and compileSDKVersion to 30. [Android has asked that developers target API Level 30 by Nov 2021.](https://developer.android.com/distribute/best-practices/develop/target-sdk)
- Updating to Gradle 6.5
- Updating to Android Gradle Plug-in 4.1.2