### PR TITLE
Place Android Gradle/CMake build files under `/Binaries`

### DIFF
--- a/Build/libHttpClient.Android.Workspace/build.gradle
+++ b/Build/libHttpClient.Android.Workspace/build.gradle
@@ -24,3 +24,9 @@ allprojects {
         }
     }
 }
+
+subprojects.each { prj ->
+    // Put all the Gradle build files under the /Binaries directory
+    def binariesDir = new File("../../Binaries/Android/${prj.name}").getAbsolutePath()
+    prj.buildDir = new File(binariesDir)
+}

--- a/Build/libHttpClient.Android/build.gradle
+++ b/Build/libHttpClient.Android/build.gradle
@@ -24,6 +24,7 @@ android {
     externalNativeBuild {
         cmake {
             path "../../Utilities/CMake/Android/libHttpClient/CMakeLists.txt"
+            buildStagingDirectory "${project.buildDir.getParentFile().getAbsolutePath()}/.cxx/${project.name}"
         }
     }
 

--- a/Build/libHttpClient.Android/build.gradle
+++ b/Build/libHttpClient.Android/build.gradle
@@ -38,13 +38,6 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android.txt")
         }
     }
-
-    // We want to copy the built Java `.aar` binary to the libHttpClient `Binaries` dir.
-    libraryVariants.all { variant ->
-         variant.outputs.each { output ->
-             output.outputFileName = "../../../../../Binaries/Android/java/${variant.getBuildType().getName()}/libHttpClient.aar"
-         }
-    }
 }
 
 dependencies {

--- a/Build/libcrypto.Android/build.gradle
+++ b/Build/libcrypto.Android/build.gradle
@@ -20,6 +20,7 @@ android {
     externalNativeBuild {
         cmake {
             path "../../Utilities/Cmake/Android/openssl/libcrypto/CMakeLists.txt"
+            buildStagingDirectory "${project.buildDir.getParentFile().getAbsolutePath()}/.cxx/${project.name}"
         }
     }
 }

--- a/Build/libssl.Android/build.gradle
+++ b/Build/libssl.Android/build.gradle
@@ -20,6 +20,7 @@ android {
     externalNativeBuild {
         cmake {
             path "../../Utilities/Cmake/Android/openssl/libssl/CMakeLists.txt"
+            buildStagingDirectory "${project.buildDir.getParentFile().getAbsolutePath()}/.cxx/${project.name}"
         }
     }
 }

--- a/Utilities/CMake/Android/GetLibHCBinaryOutputDir.cmake
+++ b/Utilities/CMake/Android/GetLibHCBinaryOutputDir.cmake
@@ -1,6 +1,0 @@
-cmake_minimum_required(VERSION 3.6)
-
-function(GET_LIBHC_BINARY_OUTPUT_DIR PATH_TO_ROOT OUT_BINARY_DIR)
-    string(TOLOWER "${CMAKE_BUILD_TYPE}" PATH_FLAVOR)
-    set(${OUT_BINARY_DIR} "${PATH_TO_ROOT}/Binaries/Android/${ANDROID_ABI}/${PATH_FLAVOR}" PARENT_SCOPE)
-endfunction()

--- a/Utilities/CMake/Android/libHttpClient/CMakeLists.txt
+++ b/Utilities/CMake/Android/libHttpClient/CMakeLists.txt
@@ -4,10 +4,6 @@ get_filename_component(PATH_TO_ROOT "../../../.." ABSOLUTE)
 
 project("libHttpClient.Android")
 
-include("../GetLibHCBinaryOutputDir.cmake")
-get_libhc_binary_output_dir("${PATH_TO_ROOT}" LIBHC_BINARY_DIR)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${LIBHC_BINARY_DIR}")
-
 set(CMAKE_STATIC_LIBRARY_PREFIX "")
 
 ###########################################

--- a/Utilities/CMake/Android/openssl/libcrypto/CMakeLists.txt
+++ b/Utilities/CMake/Android/openssl/libcrypto/CMakeLists.txt
@@ -4,10 +4,6 @@ get_filename_component(PATH_TO_ROOT "../../../../.." ABSOLUTE)
 
 project("libcrypto.Android")
 
-include("../../GetLibHCBinaryOutputDir.cmake")
-get_libhc_binary_output_dir("${PATH_TO_ROOT}" LIBHC_BINARY_DIR)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${LIBHC_BINARY_DIR}")
-
 set(CMAKE_STATIC_LIBRARY_PREFIX "")
 
 ###########################################

--- a/Utilities/CMake/Android/openssl/libssl/CMakeLists.txt
+++ b/Utilities/CMake/Android/openssl/libssl/CMakeLists.txt
@@ -4,10 +4,6 @@ get_filename_component(PATH_TO_ROOT "../../../../.." ABSOLUTE)
 
 project("libssl.Android")
 
-include("../../GetLibHCBinaryOutputDir.cmake")
-get_libhc_binary_output_dir("${PATH_TO_ROOT}" LIBHC_BINARY_DIR)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${LIBHC_BINARY_DIR}")
-
 set(CMAKE_STATIC_LIBRARY_PREFIX "")
 
 ###########################################


### PR DESCRIPTION
Currently, the libHttpClient Gradle+CMake Android build uses the default "build directory" location, which puts a "build" and ".cxx" directory inside each Gradle project (I.e., inside `/Build/[libHttpClient.Android|libssl.Android|libcrypto.Android]`. This is contrary to the VS build, which places all build files under `/Binaries`.

This change uses built-in Gradle configuration options to use `/Binaries/Android/<project name>` as the Gradle build directory for each project, and `/Binaries/Android/.cxx/<project name>` as the CMake build directory for each project. (It is a configuration error for the CMake build directory to be nested under the Gradle build directory - see documentation [here](https://developer.android.com/reference/tools/gradle-api/4.2/com/android/build/api/dsl/Cmake#buildstagingdirectory)).

This allows us to do a "hard clean" of the Android build by deleting `/Binaries`, as well as centralizes the intermediate and output build files for distribution.