### PR TITLE
Fix Android build dir path

### DIFF
--- a/Build/libHttpClient.Android.Workspace/build.gradle
+++ b/Build/libHttpClient.Android.Workspace/build.gradle
@@ -27,6 +27,6 @@ allprojects {
 
 subprojects.each { prj ->
     // Put all the Gradle build files under the /Binaries directory
-    def binariesDir = new File("../../Binaries/Android/${prj.name}").getAbsolutePath()
+    def binariesDir = project.file("../../Binaries/Android/${prj.name}").getAbsolutePath()
     prj.buildDir = new File(binariesDir)
 }


### PR DESCRIPTION
The `new File(...)` Gradle API gets a path relative to the working directory of the running process, which is not what we want since we want the path relative to our own projects.