### PR TITLE
Fix 32-bit Windows build

### DIFF
--- a/Source/HTTP/WinHttp/winhttp_http_task.cpp
+++ b/Source/HTTP/WinHttp/winhttp_http_task.cpp
@@ -336,8 +336,8 @@ void winhttp_http_task::read_next_response_chunk(_In_ winhttp_http_task* pReques
 
 void winhttp_http_task::_multiple_segment_write_data(_In_ winhttp_http_task* pRequestContext)
 {
-    const uint64_t defaultChunkSize = 64 * 1024;
-    uint64_t safeSize = std::min(pRequestContext->m_requestBodyRemainingToWrite, defaultChunkSize);
+    const size_t defaultChunkSize = 64 * 1024;
+    size_t safeSize = std::min(pRequestContext->m_requestBodyRemainingToWrite, defaultChunkSize);
 
     HCHttpCallRequestBodyReadFunction readFunction = nullptr;
     size_t bodySize = 0;


### PR DESCRIPTION
Use a `size_t` for a var to make 32-bit build work.