### PR TITLE
Unreal Engine 4 and 5 Include fix

### DIFF
--- a/Include/httpClient/httpProvider.h
+++ b/Include/httpClient/httpProvider.h
@@ -9,6 +9,7 @@
 #include <httpClient/async.h>
 #include <httpClient/pal.h>
 #include <httpClient/trace.h>
+#include <httpClient/httpClient.h>
 
 extern "C"
 {


### PR DESCRIPTION
Include httpClient.h in httpProvider.h for HCHttpCallRequestBodyReadFunction and HCHttpCallResponseBodyWriteFunction