### PR TITLE
Update to Gradle 6.6

### DIFF
--- a/Build/libHttpClient.Android.Workspace/gradle/wrapper/gradle-wrapper.properties
+++ b/Build/libHttpClient.Android.Workspace/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip


### PR DESCRIPTION
Updates the `libHttpClient.Android.Workspace` umbrella build to use Gradle 6.6.

Gradle 6.6 includes logic for retrying downloads if connections timeout/are reset, which will help prevent spurious failures during CI builds if the build is (for whatever reason) having trouble connecting to repositories like Maven.

See:
- CI build failures due to connection reset: https://github.com/actions/virtual-environments/issues/2715
- Gradle retry on connection reset: https://github.com/gradle/gradle/issues/8264