### PR TITLE
Move the Android build to a Windows agent

### DIFF
--- a/Utilities/Pipelines/Tasks/android-build.yml
+++ b/Utilities/Pipelines/Tasks/android-build.yml
@@ -1,13 +1,20 @@
+parameters:
+  - name: configuration
+    type: string
+
 steps:
   - template: checkout.yml
 
-  - bash: ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;22.0.7026061"
-    displayName: 'Install the required Android NDK'
+  - task: CmdLine@2
+    displayName: "Install the required Android NDK"
+    inputs:
+      targetType: inline
+      script: '%ANDROID_HOME%\tools\bin\sdkmanager --install "ndk;22.0.7026061"'
 
   - task: Gradle@2
-    displayName: 'Build libHttpClient.Android.Workspace'
+    displayName: "Build libHttpClient.Android.Workspace"
     inputs:
       gradleWrapperFile: Build/libHttpClient.Android.Workspace/gradlew
       workingDirectory: Build/libHttpClient.Android.Workspace
-      tasks: 'assemble'
+      tasks: assemble${{ parameters.configuration }}
       publishJUnitResults: false

--- a/Utilities/Pipelines/libHttpClient.CI.yml
+++ b/Utilities/Pipelines/libHttpClient.CI.yml
@@ -2,7 +2,7 @@
 trigger:
   branches:
     include:
-    - main
+      - main
 
 # Nightly trigger. Builds on the specified schedule.
 # Refs:
@@ -25,7 +25,6 @@ schedules:
 name: $(Build.DefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 
 jobs:
-
   ####################
   # Visual Studio 2017
   ####################
@@ -91,11 +90,17 @@ jobs:
   - job: AndroidBuild
     displayName: libHttpClient Android Build
     pool:
-      vmImage: internal-macos-10.15
+      vmImage: windows-2019
     timeoutInMinutes: 180
+    strategy:
+      matrix:
+        Debug:
+          Configuration: Debug
+        Release:
+          Configuration: Release
     steps:
       - template: Tasks/android-build.yml
-    
+
   ####################
   # iOS
   ####################
@@ -115,13 +120,13 @@ jobs:
       - template: Tasks/ios-build.yml
         parameters:
           configuration: $(Configuration)
-    
+
   ####################
   # XDK
   ####################
 
   - job: XDKBuild
-    displayName: libHttpClient XDK Build    
+    displayName: libHttpClient XDK Build
     pool:
       name: xbl-1es-vs2017-xdk
     timeoutInMinutes: 180

--- a/Utilities/Pipelines/libHttpClient.CI.yml
+++ b/Utilities/Pipelines/libHttpClient.CI.yml
@@ -1,5 +1,13 @@
-# Ref: https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/azure-repos-git#opting-out-of-ci
+# Build on merges to `main`
+# Ref: https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github#ci-triggers
 trigger:
+  branches:
+    include:
+      - main
+
+# Build for opened PRs to `main`
+# Ref: https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github#pr-triggers
+pr:
   branches:
     include:
       - main


### PR DESCRIPTION
Moves the Android build from a MacOS to Windows agent (which has increased capacity in Azure, so should reduce agent wait time). Also adds a debug/release split for the Android build.