### PR TITLE
Short-circuit request body read if no more data

### DIFF
--- a/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequestBody.java
+++ b/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequestBody.java
@@ -49,6 +49,7 @@ public final class HttpClientRequestBody extends RequestBody
 
             int bytesRead = nativeRead(this.callHandle, this.offset, destination, destinationOffset, length);
             if (bytesRead == -1) {
+                // Tell the OS that we are done reading
                 return -1;
             }
 

--- a/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequestBody.java
+++ b/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequestBody.java
@@ -48,7 +48,7 @@ public final class HttpClientRequestBody extends RequestBody
             }
 
             int bytesRead = nativeRead(this.callHandle, this.offset, destination, destinationOffset, length);
-            if (bytesRead == 0) {
+            if (bytesRead == -1) {
                 return -1;
             }
 

--- a/Source/HTTP/Android/http_android.cpp
+++ b/Source/HTTP/Android/http_android.cpp
@@ -73,7 +73,8 @@ JNIEXPORT jint JNICALL Java_com_xbox_httpclient_HttpClientRequestBody_00024Nativ
 
     if (srcOffset >= bodySize)
     {
-        return 0;
+        // Signal to Java-land that we are done reading
+        return -1;
     }
 
     // perform read

--- a/Source/HTTP/Android/http_android.cpp
+++ b/Source/HTTP/Android/http_android.cpp
@@ -71,6 +71,11 @@ JNIEXPORT jint JNICALL Java_com_xbox_httpclient_HttpClientRequestBody_00024Nativ
         return ThrowIOException(env, "Failed to get read function");
     }
 
+    if (srcOffset >= bodySize)
+    {
+        return 0;
+    }
+
     // perform read
     size_t bytesWritten = 0;
     {

--- a/Source/HTTP/Apple/request_body_stream.mm
+++ b/Source/HTTP/Apple/request_body_stream.mm
@@ -52,6 +52,11 @@
         return 0;
     }
 
+    if (_offset >= requestBodySize)
+    {
+        return 0;
+    }
+
     size_t bytesWritten = 0;
     try
     {

--- a/Source/HTTP/Apple/request_body_stream.mm
+++ b/Source/HTTP/Apple/request_body_stream.mm
@@ -54,6 +54,7 @@
 
     if (_offset >= requestBodySize)
     {
+        // Tell the OS that we are done reading
         return 0;
     }
 


### PR DESCRIPTION
On Win32, during request body reading we tell the OS how large the request body will be. The OS then does not ask for more bytes when the `offset` has reached the `requestBodySize`.

On iOS and Android, however, we aren't able to tell the OS the request body size ahead of time, and so it will call us even when the `offset` is equal to the `requestBodySize`.

This PR adds a short-circuit check for iOS and Android to not call the "request body read" callback if we know that we've already provided the entire request body, and to instead signal the OS that we are done.