### PR TITLE
debugging GlobalConfig issue

### DIFF
--- a/Utilities/Pipelines/Tasks/vs2019-build.yml
+++ b/Utilities/Pipelines/Tasks/vs2019-build.yml
@@ -7,6 +7,11 @@ parameters:
 steps:
   - template: checkout.yml
 
+  - task: PkgESWACKTests@12
+    displayName: 'Package ES - WACK Tests'
+    inputs:
+      PackageFilePath: '$(Build.SourcesDirectory)'
+
   - task: PkgESSetupBuild@12
     displayName: PkgES build setup
     inputs:


### PR DESCRIPTION
it was suggested that another Package ES task may not have the problem.  Adding WACK Test just to see if it can successfully download the global config package without error.