### PR TITLE
Add missing method to Apple Framework exports

### DIFF
--- a/Utilities/FrameworkResources/exports.exp
+++ b/Utilities/FrameworkResources/exports.exp
@@ -92,6 +92,7 @@ _HCMockCallCreate
 _HCMockAddMock
 _HCMockClearMocks
 _HCMockRemoveMock
+_HCMockSetMockMatchedCallback
 _HCMockResponseSetResponseBodyBytes
 _HCMockResponseSetStatusCode
 _HCMockResponseSetNetworkErrorCode

--- a/Utilities/FrameworkResources/exports_NOWEBSOCKETS.exp
+++ b/Utilities/FrameworkResources/exports_NOWEBSOCKETS.exp
@@ -72,6 +72,7 @@ _HCMockCallCreate
 _HCMockAddMock
 _HCMockClearMocks
 _HCMockRemoveMock
+_HCMockSetMockMatchedCallback
 _HCMockResponseSetResponseBodyBytes
 _HCMockResponseSetStatusCode
 _HCMockResponseSetNetworkErrorCode


### PR DESCRIPTION
The Apple framework export files are missing `HCMockSetMockMatchedCallback`. This PR adds them.