### PR TITLE
Support the streaming callbacks in the mocks

### DIFF
--- a/Source/Mock/lhc_mock.cpp
+++ b/Source/Mock/lhc_mock.cpp
@@ -141,9 +141,14 @@ HRESULT Mock_Internal_ReadRequestBodyIntoMemory(
     while (offset < bodySize)
     {
         size_t bytesWritten = 0;
-        RETURN_IF_FAILED(
-            readFunction(originalCall, offset, bodySize - offset, context, tempBodyBytes.data() + offset, &bytesWritten)
-        );
+        RETURN_IF_FAILED(readFunction(
+            originalCall,
+            offset,
+            bodySize - offset,
+            context,
+            tempBodyBytes.data() + offset,
+            &bytesWritten
+        ));
 
         offset += bytesWritten;
     }

--- a/Source/Mock/lhc_mock.cpp
+++ b/Source/Mock/lhc_mock.cpp
@@ -130,29 +130,21 @@ HRESULT Mock_Internal_ReadRequestBodyIntoMemory(
     _Out_ http_internal_vector<uint8_t>* bodyBytes
     )
 {
-    HCHttpCallRequestBodyReadFunction readFunction;
-    size_t bodySize;
-    void* context;
-    RETURN_IF_FAILED(
-        HCHttpCallRequestGetRequestBodyReadFunction(originalCall, &readFunction, &bodySize, &context)
-    );
+    HCHttpCallRequestBodyReadFunction readFunction = nullptr;
+    size_t bodySize = 0;
+    void* context = nullptr;
+    RETURN_IF_FAILED(HCHttpCallRequestGetRequestBodyReadFunction(originalCall, &readFunction, &bodySize, &context));
 
     http_internal_vector<uint8_t> tempBodyBytes(bodySize);
 
     size_t offset = 0;
-    size_t bytesWritten;
     while (offset < bodySize)
     {
+        size_t bytesWritten = 0;
         RETURN_IF_FAILED(
-            readFunction(
-                originalCall,
-                offset,
-                bodySize - offset,
-                context,
-                tempBodyBytes.data() + offset,
-                &bytesWritten
-            )
+            readFunction(originalCall, offset, bodySize - offset, context, tempBodyBytes.data() + offset, &bytesWritten)
         );
+
         offset += bytesWritten;
     }
 

--- a/Source/Mock/lhc_mock.h
+++ b/Source/Mock/lhc_mock.h
@@ -11,3 +11,4 @@ struct HC_MOCK_CALL : public HC_CALL
 };
 
 bool Mock_Internal_HCHttpCallPerformAsync(_In_ HCCallHandle originalCall);
+HRESULT Mock_Internal_ReadRequestBodyIntoMemory(_In_ HCCallHandle originalCall, _Out_ http_internal_vector<uint8_t>* bodyBytes);


### PR DESCRIPTION
Currently, the mocks do not use the `readBody` and `writeBody` callbacks added in #577. This PR adds support for reading from/writing to `HC_CALL`s that have a non-default read/write callback configured. Mock calls will still only support reading/writing the entire response body at once.