### PR TITLE
Update min iOS version to 11.0

### DIFF
--- a/Build/libHttpClient.Apple.C/libHttpClient.xcodeproj/project.pbxproj
+++ b/Build/libHttpClient.Apple.C/libHttpClient.xcodeproj/project.pbxproj
@@ -1004,6 +1004,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 58722D05209AD61900B071F7;
 			productRefGroup = 58722D0F209AD61900B071F7 /* Products */;

--- a/Build/libHttpClient.Apple.C/libHttpClient.xcodeproj/project.pbxproj
+++ b/Build/libHttpClient.Apple.C/libHttpClient.xcodeproj/project.pbxproj
@@ -1412,7 +1412,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1471,7 +1471,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = "-fembed-bitcode";
@@ -1602,7 +1602,6 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1629,7 +1628,6 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1713,7 +1711,6 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1741,7 +1738,6 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Utilities/XcodeBuildScripts/openssl.bash
+++ b/Utilities/XcodeBuildScripts/openssl.bash
@@ -92,7 +92,6 @@ for BUILD_ARCH in $BUILD_ARCHS; do
     #
     # - x86_64, i386: Mac
     # - arm64: Might be an M1 Mac or a physical iOS device
-    # - armv7: Very old phyiscal iOS device
 
     if [ "$BUILD_ARCH" == "x86_64" ]; then
         ./Configure darwin64-x86_64-cc shared enable-ec_nistp_64_gcc_128 no-ssl2 no-ssl3 no-comp no-async --prefix="$OPENSSL_TMP/" --openssldir="$OPENSSL_TMP/"
@@ -102,8 +101,6 @@ for BUILD_ARCH in $BUILD_ARCHS; do
         elif [ "$PLATFORM_NAME" == "iphoneos" ]; then
             ./Configure ios64-cross no-shared no-dso no-hw no-engine no-async -fembed-bitcode enable-ec_nistp_64_gcc_128 --prefix="$OPENSSL_TMP/" --openssldir="$OPENSSL_TMP/"
         fi
-    elif [ "$BUILD_ARCH" == "armv7" ]; then
-        ./Configure ios-cross no-shared no-dso no-hw no-engine no-async -fembed-bitcode --prefix="$OPENSSL_TMP/" --openssldir="$OPENSSL_TMP/"
     else
         log "Unexpected architecture: $BUILD_ARCH"
         exit 1


### PR DESCRIPTION
Main change:

* Updates the iOS deployment targets to 11.0 across all libHttpClient targets. This drops armv7 architectures, which are only supported below iOS 11.0.

Ancillary changes:

* Enables "base internationalization" to silence a warning. (No meaningful impact as libHttpClient includes no strings.)