### PR TITLE
Fix to Curl provider for custom HTTP requests

### DIFF
--- a/Source/HTTP/Curl/CurlEasyRequest.cpp
+++ b/Source/HTTP/Curl/CurlEasyRequest.cpp
@@ -60,6 +60,8 @@ Result<HC_UNIQUE_PTR<CurlEasyRequest>> CurlEasyRequest::Initialize(HCCallHandle 
     RETURN_IF_FAILED(MethodStringToOpt(method, opt));
     if (opt == CURLOPT_CUSTOMREQUEST)
     {
+        // Set PUT and then override as custom request. If we don't do this we Curl defaults to "GET" behavior which doesn't allow request body
+        RETURN_IF_FAILED(easyRequest->SetOpt<long>(CURLOPT_UPLOAD, 1));
         RETURN_IF_FAILED(easyRequest->SetOpt<char const*>(opt, method));
     }
     else


### PR DESCRIPTION
Some Curl implantations may not allow request body for custom requests by default (despite setting CURLOPT_INFILESIZE).  There is a workaround to first set CURLOPT_UPLOAD to force the call to have "PUT" semantics and then override the method using CURLOPT_CUSTOMREQUEST. 