### PR TITLE
When hitting an Android network failure, pass through and log the stack trace

### DIFF
--- a/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -1,6 +1,8 @@
 package com.xbox.httpclient;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.UnknownHostException;
 
 import okhttp3.Call;
@@ -10,8 +12,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.RequestBody;
-
-import com.xbox.httpclient.HttpClientRequestBody;
 
 public class HttpClientRequest {
     private static final OkHttpClient OK_CLIENT;
@@ -59,7 +59,12 @@ public class HttpClientRequest {
             @Override
             public void onFailure(final Call call, IOException e) {
                 boolean isNoNetworkFailure = e instanceof UnknownHostException;
-                OnRequestFailed(sourceCall, e.getClass().getCanonicalName(), isNoNetworkFailure);
+
+                StringWriter sw = new StringWriter();
+                PrintWriter pw = new PrintWriter(sw);
+                e.printStackTrace(pw);
+
+                OnRequestFailed(sourceCall, e.getClass().getCanonicalName(), sw.toString(), isNoNetworkFailure);
             }
 
             @Override
@@ -70,5 +75,5 @@ public class HttpClientRequest {
     }
 
     private native void OnRequestCompleted(long call, HttpClientResponse response);
-    private native void OnRequestFailed(long call, String errorMessage, boolean isNoNetwork);
+    private native void OnRequestFailed(long call, String errorMessage, String stackTrace, boolean isNoNetwork);
 }

--- a/Source/HTTP/Android/http_android.cpp
+++ b/Source/HTTP/Android/http_android.cpp
@@ -38,8 +38,8 @@ extern "C"
 {
 
 JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientRequest_OnRequestCompleted(
-    JNIEnv* /*env*/,
-    jobject /*instance*/,
+    JNIEnv* /* env */,
+    jobject /* instance */,
     jlong call,
     jobject response
 )
@@ -63,7 +63,7 @@ JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientRequest_OnRequestCompl
 
 JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientRequest_OnRequestFailed(
     JNIEnv* env,
-    jobject /*instance*/,
+    jobject /* instance */,
     jlong call,
     jstring errorMessage,
     jstring stackTrace,
@@ -156,7 +156,7 @@ JNIEXPORT jint JNICALL Java_com_xbox_httpclient_HttpClientRequestBody_00024Nativ
     // perform read
     size_t bytesWritten = 0;
     {
-        ByteArray destination = GetBytesFromJByteArray(env, dst, true);
+        ByteArray destination = GetBytesFromJByteArray(env, dst, true /* copyBack */);
 
         if (destination == nullptr)
         {
@@ -217,7 +217,7 @@ JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientResponse_00024NativeOu
 
     // perform write
     {
-        ByteArray source = GetBytesFromJByteArray(env, src, false);
+        ByteArray source = GetBytesFromJByteArray(env, src, false /* copyBack */);
 
         try
         {
@@ -243,7 +243,7 @@ JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientResponse_00024NativeOu
 void Internal_HCHttpCallPerformAsync(
     _In_ HCCallHandle call,
     _Inout_ XAsyncBlock* asyncBlock,
-    _In_opt_ void* /*context*/,
+    _In_opt_ void* /* context */,
     _In_ HCPerformEnv env
 ) noexcept
 {

--- a/Source/HTTP/Android/http_android.cpp
+++ b/Source/HTTP/Android/http_android.cpp
@@ -9,7 +9,12 @@
 extern "C"
 {
 
-JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientRequest_OnRequestCompleted(JNIEnv* env, jobject instance, jlong call, jobject response)
+JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientRequest_OnRequestCompleted(
+    JNIEnv* env,
+    jobject instance,
+    jlong call,
+    jobject response
+)
 {
     HCCallHandle sourceCall = reinterpret_cast<HCCallHandle>(call);
     HttpRequest* request = nullptr;
@@ -28,7 +33,14 @@ JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientRequest_OnRequestCompl
     }
 }
 
-JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientRequest_OnRequestFailed(JNIEnv* env, jobject instance, jlong call, jstring errorMessage, jboolean isNoNetwork)
+JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientRequest_OnRequestFailed(
+    JNIEnv* env,
+    jobject instance,
+    jlong call,
+    jstring errorMessage,
+    jstring stackTrace,
+    jboolean isNoNetwork
+)
 {
     HCCallHandle sourceCall = reinterpret_cast<HCCallHandle>(call);
     HttpRequest* request = nullptr;
@@ -41,6 +53,34 @@ JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientRequest_OnRequestFaile
     HCHttpCallResponseSetPlatformNetworkErrorMessage(sourceCall, nativeErrorString);
     env->ReleaseStringUTFChars(errorMessage, nativeErrorString);
 
+    // Log the stack trace for debugging purposes. It may be very long, so we
+    // break it on newlines.
+    auto stringLength = static_cast<uint32_t>(env->GetStringLength(stackTrace));
+    const char* nativeStackTraceString = env->GetStringUTFChars(stackTrace, nullptr);
+
+    std::string_view stackTraceStringView{ nativeStackTraceString, stringLength };
+    bool firstLine = true;
+    while (!stackTraceStringView.empty())
+    {
+        size_t nextNewline = stackTraceStringView.find('\n');
+        std::string_view line = stackTraceStringView.substr(0, nextNewline);
+
+        char const* format = firstLine ? "Network request failed, stack trace: %.*s" : "  %.*s";
+        HC_TRACE_WARNING(HTTPCLIENT, format, line.size(), line.data());
+
+        firstLine = false;
+
+        if (nextNewline == std::string::npos)
+        {
+            break;
+        }
+        else
+        {
+            stackTraceStringView = stackTraceStringView.substr(nextNewline + 1);
+        }
+    }
+    env->ReleaseStringUTFChars(stackTrace, nativeStackTraceString);
+
     XAsyncComplete(sourceRequest->GetAsyncBlock(), S_OK, 0);
 }
 
@@ -51,7 +91,15 @@ jint ThrowIOException(JNIEnv* env, char const* message) {
     return -1;
 }
 
-JNIEXPORT jint JNICALL Java_com_xbox_httpclient_HttpClientRequestBody_00024NativeInputStream_nativeRead(JNIEnv* env, jobject /* instance */, jlong callHandle, jlong srcOffset, jbyteArray dst, jlong dstOffset, jlong bytesAvailable)
+JNIEXPORT jint JNICALL Java_com_xbox_httpclient_HttpClientRequestBody_00024NativeInputStream_nativeRead(
+    JNIEnv* env,
+    jobject /* instance */,
+    jlong callHandle,
+    jlong srcOffset,
+    jbyteArray dst,
+    jlong dstOffset,
+    jlong bytesAvailable
+)
 {
     // convert call handle
     HCCallHandle call = reinterpret_cast<HCCallHandle>(callHandle);
@@ -119,7 +167,14 @@ JNIEXPORT jint JNICALL Java_com_xbox_httpclient_HttpClientRequestBody_00024Nativ
     return static_cast<jint>(bytesWritten);
 }
 
-JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientResponse_00024NativeOutputStream_nativeWrite(JNIEnv* env, jobject /* instance */, jlong callHandle, jbyteArray src, jint sourceOffset, jint sourceLength)
+JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientResponse_00024NativeOutputStream_nativeWrite(
+    JNIEnv* env,
+    jobject /* instance */,
+    jlong callHandle,
+    jbyteArray src,
+    jint sourceOffset,
+    jint sourceLength
+)
 {
     // convert handle
     auto call = reinterpret_cast<HCCallHandle>(callHandle);
@@ -183,7 +238,7 @@ JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientResponse_00024NativeOu
 void Internal_HCHttpCallPerformAsync(
     _In_ HCCallHandle call,
     _Inout_ XAsyncBlock* asyncBlock,
-    _In_opt_ void* context,
+    _In_opt_ void* /*context*/,
     _In_ HCPerformEnv env
 ) noexcept
 {

--- a/Source/HTTP/Android/http_android.cpp
+++ b/Source/HTTP/Android/http_android.cpp
@@ -10,13 +10,13 @@ extern "C"
 {
 
 JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientRequest_OnRequestCompleted(
-    JNIEnv* env,
-    jobject instance,
+    JNIEnv* /*env*/,
+    jobject /*instance*/,
     jlong call,
     jobject response
 )
 {
-    HCCallHandle sourceCall = reinterpret_cast<HCCallHandle>(call);
+    auto sourceCall = reinterpret_cast<HCCallHandle>(call);
     HttpRequest* request = nullptr;
     HCHttpCallGetContext(sourceCall, reinterpret_cast<void**>(&request));
     std::unique_ptr<HttpRequest> sourceRequest{ request };
@@ -35,14 +35,14 @@ JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientRequest_OnRequestCompl
 
 JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientRequest_OnRequestFailed(
     JNIEnv* env,
-    jobject instance,
+    jobject /*instance*/,
     jlong call,
     jstring errorMessage,
     jstring stackTrace,
     jboolean isNoNetwork
 )
 {
-    HCCallHandle sourceCall = reinterpret_cast<HCCallHandle>(call);
+    auto sourceCall = reinterpret_cast<HCCallHandle>(call);
     HttpRequest* request = nullptr;
     HCHttpCallGetContext(sourceCall, reinterpret_cast<void**>(&request));
     std::unique_ptr<HttpRequest> sourceRequest{ request };
@@ -102,7 +102,7 @@ JNIEXPORT jint JNICALL Java_com_xbox_httpclient_HttpClientRequestBody_00024Nativ
 )
 {
     // convert call handle
-    HCCallHandle call = reinterpret_cast<HCCallHandle>(callHandle);
+    auto call = reinterpret_cast<HCCallHandle>(callHandle);
     if (call == nullptr)
     {
         return ThrowIOException(env, "Invalid call handle");


### PR DESCRIPTION
- Adds logic to log the stack trace produced on network failure on Android, line-by-line (since it might be very long).
- Some minor refactoring to avoid the use of `[Get|Release]PrimitiveArrayCritical]` in both RequestBodyRead and ResponseBodyWrite.
- Some small Clang-Tidy changes.