### PR TITLE
Fix unreferenced parameter build break in release

### DIFF
--- a/Source/Common/pch_common.h
+++ b/Source/Common/pch_common.h
@@ -62,6 +62,8 @@
 #define UNREFERENCED_PARAMETER(args) (void)(args);
 #endif
 
+#define UNREFERENCED_LOCAL(args) (void)(args);
+
 #ifndef ASIO_STANDALONE
 #define ASIO_STANDALONE
 #endif

--- a/Source/HTTP/WinHttp/winhttp_http_task.cpp
+++ b/Source/HTTP/WinHttp/winhttp_http_task.cpp
@@ -429,6 +429,7 @@ void winhttp_http_task::callback_status_write_complete(
 
         DWORD bytesWritten = *((DWORD *)statusInfo);
         HC_TRACE_INFORMATION(HTTPCLIENT, "HCHttpCallPerform [ID %llu] [TID %ul] WINHTTP_CALLBACK_STATUS_WRITE_COMPLETE bytesWritten=%d", TO_ULL(HCHttpCallGetId(pRequestContext->m_call)), GetCurrentThreadId(), bytesWritten);
+        UNREFERENCED_LOCAL(bytesWritten);
 
         if (pRequestContext->m_requestBodyType == content_length_chunked)
         {

--- a/Source/WebSocket/WinRT/winrt_websocket.cpp
+++ b/Source/WebSocket/WinRT/winrt_websocket.cpp
@@ -478,6 +478,8 @@ try
         auto msg = sendMsgContext->nextMessage;
         HC_TRACE_INFORMATION(WEBSOCKET, "Websocket [ID %llu]: Message [ID %llu] [%s]", TO_ULL(websocket->id), TO_ULL(msg->m_id), msg->m_message.c_str());
 
+        UNREFERENCED_LOCAL(websocket);
+
         if (!msg->m_message.empty())
         {
             websocketTask->m_messageWebSocket->Control->MessageType = SocketMessageType::Utf8;


### PR DESCRIPTION
Adds an `UNREFERENCED_LOCAL` macro and uses it to address two unreferenced parameters in release builds.