### PR TITLE
Expose tracing init/cleanup separately from overall libHttpClient init

### DIFF
--- a/Include/httpClient/trace.h
+++ b/Include/httpClient/trace.h
@@ -145,6 +145,16 @@ enum class HCTraceLevel : uint32_t
 };
 
 /// <summary>
+/// Initialize tracing for the library.
+/// </summary>
+void HCTraceInit() noexcept;
+
+/// <summary>
+/// Clean up tracing for the library.
+/// </summary>
+void HCTraceCleanup() noexcept;
+
+/// <summary>
 /// Sets the trace level for the library.  Traces are sent the debug output.
 /// </summary>
 /// <param name="traceLevel">Trace level.</param>

--- a/Include/httpClient/trace.h
+++ b/Include/httpClient/trace.h
@@ -147,11 +147,20 @@ enum class HCTraceLevel : uint32_t
 /// <summary>
 /// Initialize tracing for the library.
 /// </summary>
+/// <remarks>
+/// This function is implicitly called during HCInitialize. Initialization is reference counted, and
+/// multiple calls to HCTraceInit and HCTraceCleanup will not interfere with each other as long as
+/// each call to HCTraceInit is paired with exactly one call to HCTraceCleanup.
+/// </remarks>
 void HCTraceInit() noexcept;
 
 /// <summary>
 /// Clean up tracing for the library.
 /// </summary>
+/// <remarks>
+/// This function is implicitly called during HCCleanup. See HCTraceInit for remarks on reference
+/// counting and multiple calls to these functions.
+/// </remarks>
 void HCTraceCleanup() noexcept;
 
 /// <summary>

--- a/Source/Global/global.cpp
+++ b/Source/Global/global.cpp
@@ -34,7 +34,7 @@ HRESULT http_singleton::singleton_access(
         // Create the singleton only for the first client calling create
         if (!s_useCount)
         {
-            HCTraceImplInit();
+            HCTraceInit();
 
             PerformEnv performEnv;
             RETURN_IF_FAILED(Internal_InitializeHttpPlatform(createArgs, performEnv));
@@ -180,7 +180,7 @@ HRESULT http_singleton::cleanup_async(
             self.reset();
 
             // cleanup tracing now that we are done
-            HCTraceImplCleanup();
+            HCTraceCleanup();
 
             XAsyncComplete(data->async, S_OK, 0);
             return S_OK;

--- a/Source/Logger/trace.cpp
+++ b/Source/Logger/trace.cpp
@@ -250,12 +250,12 @@ TraceState& GetTraceState() noexcept
     return state;
 }
 
-void HCTraceImplInit() noexcept
+void HCTraceInit() noexcept
 {
     GetTraceState().Init();
 }
 
-void HCTraceImplCleanup() noexcept
+void HCTraceCleanup() noexcept
 {
     GetTraceState().Cleanup();
 }

--- a/Source/Logger/trace_internal.h
+++ b/Source/Logger/trace_internal.h
@@ -27,9 +27,6 @@ private:
 
 TraceState& GetTraceState() noexcept;
 
-void HCTraceImplInit() noexcept;
-void HCTraceImplCleanup() noexcept;
-
 struct ThreadIdInfo
 {
     HCTracePlatformThisThreadIdCallback* callback;

--- a/Utilities/FrameworkResources/exports.exp
+++ b/Utilities/FrameworkResources/exports.exp
@@ -101,6 +101,8 @@ _HCMockResponseSetHeader
 #
 # trace.h
 #
+_HCTraceInit
+_HCTraceCleanup
 _HCSettingsSetTraceLevel
 _HCSettingsGetTraceLevel
 _HCTraceSetClientCallback

--- a/Utilities/FrameworkResources/exports_NOWEBSOCKETS.exp
+++ b/Utilities/FrameworkResources/exports_NOWEBSOCKETS.exp
@@ -81,6 +81,8 @@ _HCMockResponseSetHeader
 #
 # trace.h
 #
+_HCTraceInit
+_HCTraceCleanup
 _HCSettingsSetTraceLevel
 _HCSettingsGetTraceLevel
 _HCTraceSetClientCallback


### PR DESCRIPTION
Expose `HCTraceInit()` and `HCTraceCleanup()` as public functions separate from just an `HCInitialize()` call. This allows tracing to happen before/after libHttpClient itself has been initialized/cleaned up.