### PR TITLE
Partial Revert of #608, Updating Min Target to Ensure 8.1 Backcompat

### DIFF
--- a/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj
+++ b/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj
@@ -43,7 +43,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>8.1</WindowsTargetPlatformMinVersion>
     <HCLibPlatformType>Win32</HCLibPlatformType>
     <HCLibImpl>true</HCLibImpl>
   </PropertyGroup>

--- a/Build/libHttpClient.142.Win32.C/libHttpClient.142.Win32.C.vcxproj
+++ b/Build/libHttpClient.142.Win32.C/libHttpClient.142.Win32.C.vcxproj
@@ -43,7 +43,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>8.1</WindowsTargetPlatformMinVersion>
     <HCLibPlatformType>Win32</HCLibPlatformType>
     <HCLibImpl>true</HCLibImpl>
   </PropertyGroup>

--- a/Build/libHttpClient.Android/build.gradle
+++ b/Build/libHttpClient.Android/build.gradle
@@ -2,7 +2,7 @@ apply plugin: "com.android.library"
 
 android {
     compileSdkVersion 30
-    ndkVersion "22.0.7026061"
+    ndkVersion "22.1.7171670"
 
     defaultConfig {
         targetSdkVersion 30

--- a/Build/libcrypto.141.Win32/libcrypto.141.Win32.vcxproj
+++ b/Build/libcrypto.141.Win32/libcrypto.141.Win32.vcxproj
@@ -36,7 +36,8 @@
     <CharacterSet>Unicode</CharacterSet>
     <LinkIncremental>true</LinkIncremental>
     <HCLibPlatformType>Win32</HCLibPlatformType>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>8.1</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets">

--- a/Build/libcrypto.142.Win32/libcrypto.142.Win32.vcxproj
+++ b/Build/libcrypto.142.Win32/libcrypto.142.Win32.vcxproj
@@ -36,7 +36,8 @@
     <CharacterSet>Unicode</CharacterSet>
     <LinkIncremental>true</LinkIncremental>
     <HCLibPlatformType>Win32</HCLibPlatformType>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>8.1</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets">

--- a/Build/libcrypto.Android/build.gradle
+++ b/Build/libcrypto.Android/build.gradle
@@ -2,7 +2,7 @@ apply plugin: "com.android.library"
 
 android {
     compileSdkVersion 30
-    ndkVersion "22.0.7026061"
+    ndkVersion "22.1.7171670"
 
     defaultConfig {
         targetSdkVersion 30

--- a/Build/libssl.141.Win32/libssl.141.Win32.vcxproj
+++ b/Build/libssl.141.Win32/libssl.141.Win32.vcxproj
@@ -36,7 +36,8 @@
     <CharacterSet>Unicode</CharacterSet>
     <LinkIncremental>true</LinkIncremental>
     <HCLibPlatformType>Win32</HCLibPlatformType>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>8.1</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets">

--- a/Build/libssl.142.Win32/libssl.142.Win32.vcxproj
+++ b/Build/libssl.142.Win32/libssl.142.Win32.vcxproj
@@ -36,7 +36,8 @@
     <CharacterSet>Unicode</CharacterSet>
     <LinkIncremental>true</LinkIncremental>
     <HCLibPlatformType>Win32</HCLibPlatformType>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>8.1</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets">

--- a/Build/libssl.Android/build.gradle
+++ b/Build/libssl.Android/build.gradle
@@ -2,7 +2,7 @@ apply plugin: "com.android.library"
 
 android {
     compileSdkVersion 30
-    ndkVersion "22.0.7026061"
+    ndkVersion "22.1.7171670"
 
     defaultConfig {
         targetSdkVersion 30

--- a/Utilities/CMake/template-libHttpClient.141.Win32.C.vcxproj
+++ b/Utilities/CMake/template-libHttpClient.141.Win32.C.vcxproj
@@ -43,7 +43,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>8.1</WindowsTargetPlatformMinVersion>
     <HCLibPlatformType>Win32</HCLibPlatformType>
     <HCLibImpl>true</HCLibImpl>
   </PropertyGroup>

--- a/Utilities/CMake/template-libHttpClient.142.Win32.C.vcxproj
+++ b/Utilities/CMake/template-libHttpClient.142.Win32.C.vcxproj
@@ -43,7 +43,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>8.1</WindowsTargetPlatformMinVersion>
     <HCLibPlatformType>Win32</HCLibPlatformType>
     <HCLibImpl>true</HCLibImpl>
   </PropertyGroup>

--- a/Utilities/Pipelines/Tasks/android-build.yml
+++ b/Utilities/Pipelines/Tasks/android-build.yml
@@ -9,7 +9,7 @@ steps:
     displayName: "Install the required Android NDK"
     inputs:
       targetType: inline
-      script: '%ANDROID_HOME%\tools\bin\sdkmanager --install "ndk;22.0.7026061"'
+      script: '%ANDROID_HOME%\tools\bin\sdkmanager --install "ndk;22.1.7171670"'
 
   - task: Gradle@2
     displayName: "Build libHttpClient.Android.Workspace"


### PR DESCRIPTION
#608 Changed the `WindowsTargetPlatform` to hard target Windows 8.1, so that Psychonauts 2 would be able to run on Windows 7. However, this change breaks XAL build pipelines, as our Windows2019 images don't support this scenario. We can do a partial revert and add Windows 8.1 backwards compatibility by specifying a `MinTargetVersion`