### PR TITLE
Fix link error on Win32 when building with HC_NOWEBSOCKETS set

### DIFF
--- a/Source/HTTP/WinHttp/winhttp_provider.cpp
+++ b/Source/HTTP/WinHttp/winhttp_provider.cpp
@@ -81,7 +81,6 @@ void CALLBACK WinHttpProvider::HttpCallPerformAsyncHandler(
     }
 }
 
-#if !HC_NOWEBSOCKETS
 WinHttpWebSocketExports GetWinHttpWebSocketExportsHelper()
 {
     WinHttpWebSocketExports exports;
@@ -104,6 +103,7 @@ WinHttpWebSocketExports WinHttpProvider::GetWinHttpWebSocketExports()
     return s_exports;
 }
 
+#if !HC_NOWEBSOCKETS
 HRESULT CALLBACK WinHttpProvider::WebSocketConnectAsyncHandler(
     const char* uri,
     const char* subprotocol,


### PR DESCRIPTION
WinHttpWebSocketExports will be unused when HC_NOWEBSOCKETS is set.  Still define these methods to avoid link error.