### PR TITLE
Fix bug in WinHttp WebSocket

### DIFF
--- a/Source/HTTP/WinHttp/winhttp_connection.cpp
+++ b/Source/HTTP/WinHttp/winhttp_connection.cpp
@@ -396,6 +396,11 @@ HRESULT WinHttpConnection::Close(ConnectionClosedCallback callback)
             m_state = ConnectionState::WebSocketClosing;
             break;
         }
+        case ConnectionState::WebSocketClosing:
+        {
+            // Nothing to do. WinHttpClose will happen after websocket close completes
+            return S_OK;
+        }
         case ConnectionState::WinHttpClosing:
         {
             // Nothing to do 

--- a/Source/HTTP/WinHttp/winhttp_provider.cpp
+++ b/Source/HTTP/WinHttp/winhttp_provider.cpp
@@ -242,6 +242,8 @@ HRESULT WinHttpProvider::WebSocketConnectAsync(const char* uri, const char* /*su
     m_connections.push_back(connection);
     RETURN_IF_FAILED(connection->WebSocketConnectAsync(async));
 
+    websocketHandle->impl = std::move(connection);
+
     return S_OK;
 }
 #endif


### PR DESCRIPTION
- Partial revert change previous change that broke WinHttp WebSocket Send (HC_WEBSOCKET::impl needs to be set to WinHttpConnection object)
- Add cleanup case for ConnectionState::WebSocketClosing.  By design once HC_WEBSOCKET::Disconnect is called, the HC_WEBSOCKET object waits for a disconnect callback from the provider before cleaning up.  WinHttp provider shutdown hard terminates the connection with WinHttpWebSocketClose (even if a disconnect was in progress) so that the disconnect even is never fired.  This new case will wait for the disconnect to complete before calling WinHttpWebSocketClose.