### PR TITLE
Update the Android compileSdkVersion

### DIFF
--- a/Build/libHttpClient.Android/build.gradle
+++ b/Build/libHttpClient.Android/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: "com.android.library"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     ndkVersion "22.1.7171670"
 
     defaultConfig {

--- a/Build/libcrypto.Android/build.gradle
+++ b/Build/libcrypto.Android/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: "com.android.library"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     ndkVersion "22.1.7171670"
 
     defaultConfig {

--- a/Build/libssl.Android/build.gradle
+++ b/Build/libssl.Android/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: "com.android.library"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     ndkVersion "22.1.7171670"
 
     defaultConfig {


### PR DESCRIPTION
Updates the `compileSdkVersion` to 31 for all libHttpClient Gradle projects. Should have no effect on consumers of these modules.