### PR TITLE
Proper handling of large incoming messages for WinHttp WebSockets 

### DIFF
--- a/Include/httpClient/httpClient.h
+++ b/Include/httpClient/httpClient.h
@@ -989,6 +989,21 @@ STDAPI HCWebSocketDisconnect(
     _In_ HCWebsocketHandle websocket
     ) noexcept;
 
+#if HC_PLATFORM == HC_PLATFORM_WIN32 || HC_PLATFORM == HC_PLATFORM_GDK
+/// <summary>
+/// Configures how large the WebSocket receive buffer is allowed to grow before passing messages to clients. If a single message
+/// exceeds the maximum buffer size, the message will be broken down and passed to clients via multiple calls to the HCWebSocketMessageFunction.
+/// The default value is 20kb.
+/// </summary>
+/// <param name="websocket">The handle of the WebSocket</param>
+/// <param name="bufferSizeInBytes">Maximum size (in bytes) for the WebSocket receive buffer.</param>
+/// <returns>Result code for this API operation.  Possible values are S_OK, E_INVALIDARG, or E_FAIL.</returns>
+STDAPI HCWebSocketSetMaxReceiveBufferSize(
+    _In_ HCWebsocketHandle websocket,
+    _In_ size_t bufferSizeInBytes
+) noexcept;
+#endif
+
 /// <summary>
 /// Increments the reference count on the call object.
 /// </summary>

--- a/Include/httpClient/httpClient.h
+++ b/Include/httpClient/httpClient.h
@@ -843,6 +843,7 @@ STDAPI HCWebSocketCreate(
     _In_opt_ void* functionContext
     ) noexcept;
 
+#if HC_PLATFORM == HC_PLATFORM_WIN32 || HC_PLATFORM == HC_PLATFORM_GDK
 /// <summary>
 /// Set the binary message fragment handler. The client functionContext passed to HCWebSocketCreate will also be passed to this handler.
 /// </summary>
@@ -858,6 +859,7 @@ STDAPI HCWebSocketSetBinaryMessageFragmentEventFunction(
     _In_ HCWebsocketHandle websocket,
     _In_ HCWebSocketBinaryMessageFragmentFunction binaryMessageFragmentFunc
 ) noexcept;
+#endif
 
 /// <summary>
 /// Set the proxy URI for the WebSocket.
@@ -917,6 +919,7 @@ STDAPI HCWebSocketGetEventFunctions(
     _Out_ void** functionContext
     ) noexcept;
 
+#if HC_PLATFORM == HC_PLATFORM_WIN32 || HC_PLATFORM == HC_PLATFORM_GDK
 /// <summary>
 /// Gets the WebSocket binary message fragment handler.
 /// </summary>
@@ -929,6 +932,7 @@ STDAPI HCWebSocketGetBinaryMessageFragmentEventFunction(
     _Out_ HCWebSocketBinaryMessageFragmentFunction* binaryMessageFragmentFunc,
     _Out_ void** functionContext
 ) noexcept;
+#endif
 
 /// <summary>
 /// Used by HCWebSocketConnectAsync() and HCWebSocketSendMessageAsync().

--- a/Samples/WebSocketEchoServer/WebSocketEchoServer.cpp
+++ b/Samples/WebSocketEchoServer/WebSocketEchoServer.cpp
@@ -1,0 +1,85 @@
+#define _WEBSOCKETPP_CPP11_SYSTEM_ERROR_
+
+#pragma warning( push )
+#pragma warning( disable : 4100 4127 4512 4996 4701 4267 )
+#define _WEBSOCKETPP_CPP11_STL_
+#define _WEBSOCKETPP_CONSTEXPR_TOKEN_
+#define _SCL_SECURE_NO_WARNINGS
+#if (_MSC_VER >= 1900)
+#define ASIO_ERROR_CATEGORY_NOEXCEPT noexcept(true)
+#endif // (_MSC_VER >= 1900)
+
+#include <websocketpp/config/asio_no_tls.hpp>
+#include <websocketpp/server.hpp>
+#include <iostream>
+
+typedef websocketpp::server<websocketpp::config::asio> server;
+
+using websocketpp::lib::placeholders::_1;
+using websocketpp::lib::placeholders::_2;
+using websocketpp::lib::bind;
+
+// pull out the type of messages sent by our config
+typedef server::message_ptr message_ptr;
+
+// Define a callback to handle incoming messages
+void on_message(server* s, websocketpp::connection_hdl hdl, message_ptr msg)
+{
+    std::cout << "on_message called with hdl: " << hdl.lock().get()
+        << " and message: " << msg->get_payload()
+        << std::endl;
+
+    // check for a special command to instruct the server to stop listening so
+    // it can be cleanly exited.
+    if (msg->get_payload() == "stop-listening")
+    {
+        s->stop_listening();
+        return;
+    }
+
+    try 
+    {
+        s->send(hdl, msg->get_payload(), msg->get_opcode());
+    }
+    catch (websocketpp::exception const& e)
+    {
+        std::cout << "Echo failed because: "
+            << "(" << e.what() << ")" << std::endl;
+    }
+}
+
+int main()
+{
+    // Create a server endpoint
+    server echo_server;
+
+    try 
+    {
+        // Set logging settings
+        echo_server.set_access_channels(websocketpp::log::alevel::all);
+        echo_server.clear_access_channels(websocketpp::log::alevel::frame_payload);
+
+        // Initialize Asio
+        echo_server.init_asio();
+
+        // Register our message handler
+        echo_server.set_message_handler(bind(&on_message, &echo_server, ::_1, ::_2));
+
+        // Listen on port 9002
+        echo_server.listen(9002);
+
+        // Start the server accept loop
+        echo_server.start_accept();
+
+        // Start the ASIO io_service run loop
+        echo_server.run();
+    }
+    catch (websocketpp::exception const& e)
+    {
+        std::cout << e.what() << std::endl;
+    }
+    catch (...)
+    {
+        std::cout << "other exception" << std::endl;
+    }
+}

--- a/Samples/WebSocketEchoServer/WebSocketEchoServer.vcxproj
+++ b/Samples/WebSocketEchoServer/WebSocketEchoServer.vcxproj
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>WebSocketEchoServer</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <HCBuildRoot Condition="'$(HCBuildRoot)'==''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.root))\</HCBuildRoot>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;ASIO_STANDALONE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(HCBuildRoot)\External\asio\asio\include;$(HCBuildRoot)\External\websocketpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;ASIO_STANDALONE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(HCBuildRoot)\External\asio\asio\include;$(HCBuildRoot)\External\websocketpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;ASIO_STANDALONE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(HCBuildRoot)\External\asio\asio\include;$(HCBuildRoot)\External\websocketpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;ASIO_STANDALONE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(HCBuildRoot)\External\asio\asio\include;$(HCBuildRoot)\External\websocketpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="WebSocketEchoServer.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Samples/WebSocketEchoServer/WebSocketEchoServer.vcxproj.filters
+++ b/Samples/WebSocketEchoServer/WebSocketEchoServer.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="WebSocketEchoServer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/Samples/Win32WebSocket/main.cpp
+++ b/Samples/Win32WebSocket/main.cpp
@@ -200,6 +200,7 @@ int main()
     HCWebsocketHandle websocket;
 
     HRESULT hr = HCWebSocketCreate(&websocket, message_received, binary_message_received, websocket_closed, nullptr);
+    HCWebSocketSetMaxReceiveBufferSize(websocket, 160000);
 
     for (int iConnectAttempt = 0; iConnectAttempt < 10; iConnectAttempt++)
     {
@@ -221,11 +222,16 @@ int main()
         hr = HCWebSocketConnectAsync(url.data(), "", websocket, asyncBlock);
         WaitForSingleObject(g_eventHandle, INFINITE);
 
-        uint32_t numberOfMessagesToSend = 100;
+        uint32_t numberOfMessagesToSend = 1;
         for (uint32_t i = 1; i <= numberOfMessagesToSend; i++)
         {
-            char webMsg[100];
-            snprintf(webMsg, sizeof(webMsg), "Message #%d should be echoed!", i);
+            char webMsg[150000];
+            for (uint32_t j = 0; j < sizeof(webMsg); ++j)
+            {
+                webMsg[j] = 'X';
+            }
+            webMsg[sizeof(webMsg) - 1] = '\0';
+            //snprintf(webMsg, sizeof(webMsg), "Message #%d should be echoed!", i);
 
             asyncBlock = new XAsyncBlock{};
             asyncBlock->queue = g_queue;

--- a/Samples/Win32WebSocket/main.cpp
+++ b/Samples/Win32WebSocket/main.cpp
@@ -174,6 +174,22 @@ void CALLBACK binary_message_received(
     SetEvent(g_eventHandle);
 }
 
+void CALLBACK binary_message_fragment_received(
+    _In_ HCWebsocketHandle websocket,
+    _In_reads_bytes_(payloadSize) const uint8_t* payloadBytes,
+    _In_ uint32_t payloadSize,
+    _In_ bool isFinalFragment,
+    _In_ void* functionContext
+)
+{
+    printf("Received websocket binary message fragment\r\n");
+    if (isFinalFragment)
+    {
+        g_numberMessagesReceieved++;
+    }
+    SetEvent(g_eventHandle);
+}
+
 void CALLBACK websocket_closed(
     _In_ HCWebsocketHandle websocket,
     _In_ HCWebSocketCloseStatus closeStatus,
@@ -200,7 +216,7 @@ int main()
     HCWebsocketHandle websocket;
 
     HRESULT hr = HCWebSocketCreate(&websocket, message_received, binary_message_received, websocket_closed, nullptr);
-    HCWebSocketSetMaxReceiveBufferSize(websocket, 160000);
+    HCWebSocketSetBinaryMessageFragmentEventFunction(websocket, binary_message_fragment_received);
 
     for (int iConnectAttempt = 0; iConnectAttempt < 10; iConnectAttempt++)
     {

--- a/Samples/Win32WebSocket/main.cpp
+++ b/Samples/Win32WebSocket/main.cpp
@@ -195,7 +195,7 @@ int main()
     XTaskQueueRegisterMonitor(g_queue, nullptr, HandleAsyncQueueCallback, &g_callbackToken);
     StartBackgroundThread();
 
-    std::string url = "wss://echo.websocket.org";
+    std::string url = "wss://localhost";
 
     HCWebsocketHandle websocket;
 

--- a/Samples/Win32WebSocket/main.cpp
+++ b/Samples/Win32WebSocket/main.cpp
@@ -195,7 +195,7 @@ int main()
     XTaskQueueRegisterMonitor(g_queue, nullptr, HandleAsyncQueueCallback, &g_callbackToken);
     StartBackgroundThread();
 
-    std::string url = "wss://localhost";
+    std::string url = "ws://localhost:9002";
 
     HCWebsocketHandle websocket;
 

--- a/Source/HTTP/WinHttp/winhttp_connection.cpp
+++ b/Source/HTTP/WinHttp/winhttp_connection.cpp
@@ -1337,7 +1337,7 @@ void WinHttpConnection::callback_websocket_status_read_complete(
         {
             win32_cs_autolock autoCriticalSection(&pRequestContext->m_lock);
 
-            // WinHttp doesn't report the chunk of a fragmented message as a fragment, but LHC will
+            // WinHttp doesn't report the final chunk of a fragmented message as a fragment, but LHC will
             pRequestContext->m_websocketReceivingMessageFragments = true;
             pRequestContext->m_websocketReceiveBuffer.FinishWriteData(wsStatus->dwBytesTransferred);
             

--- a/Source/HTTP/WinHttp/winhttp_connection.cpp
+++ b/Source/HTTP/WinHttp/winhttp_connection.cpp
@@ -18,8 +18,7 @@
 using namespace xbox::httpclient;
 
 #define CRLF L"\r\n"
-#define WINHTTP_WEBSOCKET_RECVBUFFER_SIZE (1024 * 4)
-#define WINHTTP_WEBSOCKET_RECVBUFFER_MAXSIZE (1024 * 20)
+#define WINHTTP_WEBSOCKET_RECVBUFFER_INITIAL_SIZE (1024 * 4)
 
 #ifndef WINHTTP_OPTION_UPGRADE_TO_WEB_SOCKET
 #define WINHTTP_OPTION_UPGRADE_TO_WEB_SOCKET 114
@@ -1334,73 +1333,26 @@ void WinHttpConnection::callback_websocket_status_read_complete(
     }
     else if (wsStatus->eBufferType == WINHTTP_WEB_SOCKET_UTF8_FRAGMENT_BUFFER_TYPE || wsStatus->eBufferType == WINHTTP_WEB_SOCKET_BINARY_FRAGMENT_BUFFER_TYPE)
     {
-        win32_cs_autolock autoCriticalSection(&pRequestContext->m_lock);
+        bool readComplete{ false };
+        {
+            win32_cs_autolock autoCriticalSection(&pRequestContext->m_lock);
+            pRequestContext->m_websocketReceiveBuffer.FinishWriteData(wsStatus->dwBytesTransferred);
+            
+            // If the receive buffer is full & at max size, invoke client callbacks with partial message
+            readComplete = pRequestContext->m_websocketReceiveBuffer.GetBufferByteCount() >= pRequestContext->m_websocketHandle->MaxReceiveBufferSize();
+        }
 
-        pRequestContext->m_websocketResponseBuffer.FinishWriteData(wsStatus->dwBytesTransferred);
-        pRequestContext->websocket_read_message();
+        if (readComplete)
+        {
+            pRequestContext->WebSocketReadComplete(true);
+        }
+
+        pRequestContext->WebSocketReadAsync();
     }
-    else if (wsStatus->eBufferType == WINHTTP_WEB_SOCKET_UTF8_MESSAGE_BUFFER_TYPE)
+    else if (wsStatus->eBufferType == WINHTTP_WEB_SOCKET_UTF8_MESSAGE_BUFFER_TYPE || wsStatus->eBufferType == WINHTTP_WEB_SOCKET_BINARY_MESSAGE_BUFFER_TYPE)
     {
-        websocket_message_buffer responseBuffer;
-        HCWebSocketMessageFunction messageFunc = nullptr;
-        void* functionContext = nullptr;
-
-        {
-            win32_cs_autolock autoCriticalSection(&pRequestContext->m_lock);
-
-            pRequestContext->m_websocketResponseBuffer.FinishWriteData(wsStatus->dwBytesTransferred);
-            pRequestContext->m_websocketResponseBuffer.TransferBuffer(&responseBuffer);
-            HCWebSocketGetEventFunctions(pRequestContext->m_websocketHandle, &messageFunc, nullptr, nullptr, &functionContext);
-        }
-
-        if (messageFunc)
-        {
-            try
-            {
-                char* buffer = reinterpret_cast<char*>(responseBuffer.GetBuffer());
-                uint32_t bufferLength = responseBuffer.GetBufferByteCount();
-                buffer[bufferLength] = 0;
-
-                messageFunc(pRequestContext->m_websocketHandle, buffer, functionContext);
-            }
-            catch (...)
-            {
-            }
-        }
-
-        {
-            win32_cs_autolock autoCriticalSection(&pRequestContext->m_lock);
-            pRequestContext->websocket_start_listening();
-        }
-    }
-    else if (wsStatus->eBufferType == WINHTTP_WEB_SOCKET_BINARY_MESSAGE_BUFFER_TYPE)
-    {
-        websocket_message_buffer responseBuffer;
-        HCWebSocketBinaryMessageFunction messageFunc = nullptr;
-        void* functionContext = nullptr;
-        {
-            win32_cs_autolock autoCriticalSection(&pRequestContext->m_lock);
-
-            pRequestContext->m_websocketResponseBuffer.FinishWriteData(wsStatus->dwBytesTransferred);
-            pRequestContext->m_websocketResponseBuffer.TransferBuffer(&responseBuffer);
-            HCWebSocketGetEventFunctions(pRequestContext->m_websocketHandle, nullptr, &messageFunc, nullptr, &functionContext);
-        }
-
-        if (messageFunc)
-        {
-            try
-            {
-                messageFunc(pRequestContext->m_websocketHandle, responseBuffer.GetBuffer(), responseBuffer.GetBufferByteCount(), functionContext);
-            }
-            catch (...)
-            {
-            }
-        }
-
-        {
-            win32_cs_autolock autoCriticalSection(&pRequestContext->m_lock);
-            pRequestContext->websocket_start_listening();
-        }
+        pRequestContext->WebSocketReadComplete(wsStatus->eBufferType == WINHTTP_WEB_SOCKET_BINARY_MESSAGE_BUFFER_TYPE);
+        pRequestContext->WebSocketReadAsync();
     }
 #else
     UNREFERENCED_PARAMETER(statusInfo);
@@ -1409,57 +1361,76 @@ void WinHttpConnection::callback_websocket_status_read_complete(
 #endif
 }
 
-HRESULT WinHttpConnection::websocket_start_listening()
+HRESULT WinHttpConnection::WebSocketReadAsync()
 {
-    HC_TRACE_VERBOSE(HTTPCLIENT, "WINHTTP_WEB_SOCKET_UTF8 [ID %llu] [TID %ul] listening", TO_ULL(HCHttpCallGetId(m_call)), GetCurrentThreadId());
-    HRESULT hr = m_websocketResponseBuffer.Resize(WINHTTP_WEBSOCKET_RECVBUFFER_SIZE);
-    if (SUCCEEDED(hr))
+    win32_cs_autolock autoCriticalSection(&m_lock);
+
+    if (m_websocketReceiveBuffer.GetBuffer() == nullptr)
     {
-        hr = websocket_read_message();
+        // Initialize buffer with default size of WINHTTP_WEBSOCKET_RECVBUFFER_SIZE
+        RETURN_IF_FAILED(m_websocketReceiveBuffer.Resize(WINHTTP_WEBSOCKET_RECVBUFFER_INITIAL_SIZE));
+    }
+    else if (m_websocketReceiveBuffer.GetRemainingCapacity() == 0)
+    {
+        // Expand buffer
+        size_t newSize = (size_t)m_websocketReceiveBuffer.GetBufferByteCount() * 2;
+        if (newSize > m_websocketHandle->MaxReceiveBufferSize())
+        {
+            newSize = m_websocketHandle->MaxReceiveBufferSize();
+        }
+
+        RETURN_IF_FAILED(m_websocketReceiveBuffer.Resize((uint32_t)newSize));
     }
 
-    return hr;
+    assert(m_winHttpWebSocketExports.receive);
+
+    uint8_t* bufferPtr = m_websocketReceiveBuffer.GetNextWriteLocation();
+    uint64_t bufferSize = m_websocketReceiveBuffer.GetRemainingCapacity();
+    DWORD dwError = ERROR_SUCCESS;
+    DWORD bytesRead{ 0 }; // not used but required.  bytes read comes from FinishWriteData(wsStatus->dwBytesTransferred)
+    UINT bufType{};
+    dwError = m_winHttpWebSocketExports.receive(m_hRequest, bufferPtr, (DWORD)bufferSize, &bytesRead, &bufType);
+    if (dwError)
+    {
+        HC_TRACE_ERROR(HTTPCLIENT, "[WinHttp] websocket_read_message [ID %llu] [TID %ul] errorcode %d", TO_ULL(HCHttpCallGetId(m_call)), GetCurrentThreadId(), dwError);
+    }
+
+    return S_OK;
 }
 
-HRESULT WinHttpConnection::websocket_read_message()
+HRESULT WinHttpConnection::WebSocketReadComplete(bool binaryMessage)
 {
-    HRESULT hr = S_OK;
+    websocket_message_buffer messageBuffer;
+    HCWebSocketMessageFunction messageFunc = nullptr;
+    HCWebSocketBinaryMessageFunction binaryMessageFunc = nullptr;
+    void* functionContext = nullptr;
 
-    if (m_websocketResponseBuffer.GetRemainingCapacity() == 0)
     {
-        if (m_websocketResponseBuffer.GetBufferByteCount() < WINHTTP_WEBSOCKET_RECVBUFFER_MAXSIZE)
-        {
-            uint32_t newSize = m_websocketResponseBuffer.GetBufferByteCount() * 2;
-            if (newSize > WINHTTP_WEBSOCKET_RECVBUFFER_MAXSIZE)
-            {
-                newSize = WINHTTP_WEBSOCKET_RECVBUFFER_MAXSIZE;
-            }
-
-            hr = m_websocketResponseBuffer.Resize(newSize);
-        }
-        else
-        {
-            hr = E_ABORT;
-        }
+        win32_cs_autolock autoCriticalSection(&m_lock);
+        HCWebSocketGetEventFunctions(m_websocketHandle, &messageFunc, &binaryMessageFunc, nullptr, &functionContext);
+        m_websocketReceiveBuffer.TransferBuffer(&messageBuffer);
     }
 
-    if (SUCCEEDED(hr))
+    try
     {
-        assert(m_winHttpWebSocketExports.receive);
-
-        uint8_t* bufferPtr = m_websocketResponseBuffer.GetNextWriteLocation();
-        uint64_t bufferSize = m_websocketResponseBuffer.GetRemainingCapacity();
-        DWORD dwError = ERROR_SUCCESS;
-        DWORD bytesRead{ 0 }; // not used by required.  bytes read comes from FinishWriteData(wsStatus->dwBytesTransferred)
-        UINT bufType{};
-        dwError = m_winHttpWebSocketExports.receive(m_hRequest, bufferPtr, (DWORD)bufferSize, &bytesRead, &bufType);
-        if (dwError)
+        if (binaryMessage && binaryMessageFunc)
         {
-            HC_TRACE_ERROR(HTTPCLIENT, "[WinHttp] websocket_read_message [ID %llu] [TID %ul] errorcode %d", TO_ULL(HCHttpCallGetId(m_call)), GetCurrentThreadId(), dwError);
+            binaryMessageFunc(m_websocketHandle, messageBuffer.GetBuffer(), messageBuffer.GetBufferByteCount(), functionContext);
+        }
+        else if (!binaryMessage && messageFunc)
+        {
+            char* buffer = reinterpret_cast<char*>(messageBuffer.GetBuffer());
+            uint32_t bufferLength = messageBuffer.GetBufferByteCount();
+            buffer[bufferLength] = 0;
+
+            messageFunc(m_websocketHandle, buffer, functionContext);
         }
     }
-
-    return hr;
+    catch (...)
+    {
+        HC_TRACE_ERROR(HTTPCLIENT, "[WinHttp] Caught unhandled exception from client message handler");
+    }
+    return S_OK;
 }
 
 void WinHttpConnection::callback_websocket_status_headers_available(
@@ -1486,7 +1457,6 @@ void WinHttpConnection::callback_websocket_status_headers_available(
         return;
     }
 
-    winHttpConnection->websocket_start_listening();
     winHttpConnection->m_state = ConnectionState::WebSocketConnected;
 
     WinHttpCloseHandle(hRequestHandle); // The old request handle is not needed anymore.  We're using pRequestContext->m_hRequest now
@@ -1494,6 +1464,9 @@ void WinHttpConnection::callback_websocket_status_headers_available(
 
     // This will now complete the WebSocket Connect operation
     winHttpConnection->complete_task(S_OK, S_OK);
+
+    // Begin listening for messages
+    winHttpConnection->WebSocketReadAsync();
 }
 
 #if !HC_NOWEBSOCKETS

--- a/Source/HTTP/WinHttp/winhttp_connection.h
+++ b/Source/HTTP/WinHttp/winhttp_connection.h
@@ -337,7 +337,7 @@ private:
     void WebSocketSendMessage(const WebSocketSendContext& sendContext);
     void WebSocketCompleteEntireSendQueueWithError(HRESULT error);
     HRESULT WebSocketReadAsync();
-    HRESULT WebSocketReadComplete(bool binaryMessage);
+    HRESULT WebSocketReadComplete(bool binaryMessage, bool isFragment, bool isFinalFragment);
     void on_websocket_disconnected(_In_ USHORT closeReason);
 
     static HRESULT CALLBACK WebSocketConnectProvider(XAsyncOp op, const XAsyncProviderData* data);
@@ -349,6 +349,7 @@ private:
     std::recursive_mutex m_websocketSendMutex; // controls access to m_websocketSendQueue
     http_internal_queue<WebSocketSendContext*> m_websocketSendQueue{};
     websocket_message_buffer m_websocketReceiveBuffer;
+    bool m_websocketReceivingMessageFragments{ false };
 };
 
 NAMESPACE_XBOX_HTTP_CLIENT_END

--- a/Source/HTTP/WinHttp/winhttp_connection.h
+++ b/Source/HTTP/WinHttp/winhttp_connection.h
@@ -54,37 +54,19 @@ private:
 class websocket_message_buffer
 {
 public:
+    websocket_message_buffer() = default;
+    ~websocket_message_buffer()
+    {
+        if (m_buffer != nullptr)
+        {
+            http_memory::mem_free(m_buffer);
+        }
+    }
+
     inline uint8_t* GetBuffer() { return m_buffer; }
     inline uint8_t* GetNextWriteLocation() { return m_buffer + m_bufferByteCount; }
     inline uint32_t GetBufferByteCount() { return m_bufferByteCount; }
     inline uint32_t GetRemainingCapacity() { return m_bufferByteCapacity - m_bufferByteCount; }
-
-    HRESULT InitializeBuffer(_In_ uint32_t dataByteCount)
-    {
-        assert(m_buffer == nullptr);
-
-        HRESULT hr = S_OK;
-        if (dataByteCount > 0)
-        {
-            m_buffer = static_cast<uint8_t*>(http_memory::mem_alloc(dataByteCount));
-            if (m_buffer != nullptr)
-            {
-                m_bufferByteCapacity = dataByteCount;
-            }
-            else
-            {
-                hr = E_OUTOFMEMORY;
-            }
-        }
-        else
-        {
-            m_buffer = nullptr;
-            m_bufferByteCount = 0;
-            m_bufferByteCapacity = 0;
-        }
-
-        return hr;
-    }
 
     void FinishWriteData(_In_ uint32_t dataByteCount)
     {
@@ -114,9 +96,12 @@ public:
             newBuffer = static_cast<uint8_t*>(http_memory::mem_alloc(dataByteCount));
             if (newBuffer != nullptr)
             {
-                // Copy the contents of the old buffer
-                CopyMemory(newBuffer, m_buffer, m_bufferByteCount);
-                http_memory::mem_free(m_buffer);
+                if (m_buffer != nullptr)
+                {
+                    // Copy the contents of the old buffer
+                    CopyMemory(newBuffer, m_buffer, m_bufferByteCount);
+                    http_memory::mem_free(m_buffer);
+                }
                 m_buffer = newBuffer;
                 m_bufferByteCapacity = dataByteCount;
             }
@@ -127,14 +112,6 @@ public:
         }
 
         return hr;
-    }
-
-    ~websocket_message_buffer()
-    {
-        if (m_buffer != nullptr)
-        {
-            http_memory::mem_free(m_buffer);
-        }
     }
 
 private:
@@ -359,8 +336,8 @@ private:
     // WinHttp WebSocket methods
     void WebSocketSendMessage(const WebSocketSendContext& sendContext);
     void WebSocketCompleteEntireSendQueueWithError(HRESULT error);
-    HRESULT websocket_start_listening();
-    HRESULT websocket_read_message();
+    HRESULT WebSocketReadAsync();
+    HRESULT WebSocketReadComplete(bool binaryMessage);
     void on_websocket_disconnected(_In_ USHORT closeReason);
 
     static HRESULT CALLBACK WebSocketConnectProvider(XAsyncOp op, const XAsyncProviderData* data);
@@ -371,7 +348,7 @@ private:
     HCCallHandle m_websocketCall{ nullptr };
     std::recursive_mutex m_websocketSendMutex; // controls access to m_websocketSendQueue
     http_internal_queue<WebSocketSendContext*> m_websocketSendQueue{};
-    websocket_message_buffer m_websocketResponseBuffer;
+    websocket_message_buffer m_websocketReceiveBuffer;
 };
 
 NAMESPACE_XBOX_HTTP_CLIENT_END

--- a/Source/WebSocket/hcwebsocket.cpp
+++ b/Source/WebSocket/hcwebsocket.cpp
@@ -519,7 +519,7 @@ void HC_WEBSOCKET::BinaryMessageFragmentFunc(
             lock.unlock();
 
             if (websocket->m_clientBinaryMessageFragmentFunc)
-            {           
+            {
                 websocket->m_clientBinaryMessageFragmentFunc(websocket, bytes, payloadSize, isLastFragment, websocket->m_clientContext);
             }
             else if (websocket->m_clientBinaryMessageFunc)

--- a/Source/WebSocket/hcwebsocket.cpp
+++ b/Source/WebSocket/hcwebsocket.cpp
@@ -9,6 +9,8 @@
 
 using namespace xbox::httpclient;
 
+#define WEBSOCKET_RECVBUFFER_MAXSIZE_DEFAULT (1024 * 20)
+
 HC_WEBSOCKET::HC_WEBSOCKET(
     _In_ uint64_t _id,
     _In_opt_ HCWebSocketMessageFunction messageFunc,
@@ -20,7 +22,8 @@ HC_WEBSOCKET::HC_WEBSOCKET(
     m_clientMessageFunc{ messageFunc },
     m_clientBinaryMessageFunc{ binaryMessageFunc },
     m_clientCloseEventFunc{ closeFunc },
-    m_clientContext{ functionContext }
+    m_clientContext{ functionContext },
+    m_maxReceiveBufferSize{ WEBSOCKET_RECVBUFFER_MAXSIZE_DEFAULT }
 {
 }
 
@@ -335,6 +338,11 @@ const http_internal_string& HC_WEBSOCKET::SubProtocol() const noexcept
     return m_subProtocol;
 }
 
+size_t HC_WEBSOCKET::MaxReceiveBufferSize() const noexcept
+{
+    return m_maxReceiveBufferSize;
+}
+
 HRESULT HC_WEBSOCKET::SetProxyUri(
     http_internal_string&& proxyUri
 ) noexcept
@@ -370,6 +378,12 @@ HRESULT HC_WEBSOCKET::SetHeader(
         return E_HC_CONNECT_ALREADY_CALLED;
     }
     m_connectHeaders[headerName] = headerValue;
+    return S_OK;
+}
+
+HRESULT HC_WEBSOCKET::SetMaxReceiveBufferSize(size_t maxReceiveBufferSizeBytes) noexcept
+{
+    m_maxReceiveBufferSize = maxReceiveBufferSizeBytes;
     return S_OK;
 }
 
@@ -680,6 +694,17 @@ try
         return E_INVALIDARG;
     }
     return websocket->Disconnect();
+}
+CATCH_RETURN()
+
+STDAPI HCWebSocketSetMaxReceiveBufferSize(
+    _In_ HCWebsocketHandle websocket,
+    _In_ size_t bufferSizeInBytes
+) noexcept
+try
+{
+    RETURN_HR_IF(E_INVALIDARG, !websocket);
+    return websocket->SetMaxReceiveBufferSize(bufferSizeInBytes);
 }
 CATCH_RETURN()
 

--- a/Source/WebSocket/hcwebsocket.cpp
+++ b/Source/WebSocket/hcwebsocket.cpp
@@ -343,6 +343,13 @@ size_t HC_WEBSOCKET::MaxReceiveBufferSize() const noexcept
     return m_maxReceiveBufferSize;
 }
 
+HRESULT HC_WEBSOCKET::SetBinaryMessageFragmentFunc(HCWebSocketBinaryMessageFragmentFunction func) noexcept
+{
+    std::lock_guard<std::recursive_mutex> lock{ m_mutex };
+    m_clientBinaryMessageFragmentFunc = func;
+    return S_OK;
+}
+
 HRESULT HC_WEBSOCKET::SetProxyUri(
     http_internal_string&& proxyUri
 ) noexcept
@@ -494,6 +501,40 @@ void HC_WEBSOCKET::BinaryMessageFunc(
     }
 }
 
+void HC_WEBSOCKET::BinaryMessageFragmentFunc(
+    HC_WEBSOCKET* websocket,
+    const uint8_t* bytes,
+    uint32_t payloadSize,
+    bool isLastFragment,
+    void* /*context*/
+)
+{
+    std::unique_lock<std::recursive_mutex> lock{ websocket->m_mutex };
+    if (websocket->m_clientRefCount > 0)
+    {
+        try
+        {
+            auto httpSingleton = get_http_singleton();
+            notify_websocket_routed_handlers(httpSingleton, websocket, true, nullptr, bytes, payloadSize);
+            lock.unlock();
+
+            if (websocket->m_clientBinaryMessageFragmentFunc)
+            {           
+                websocket->m_clientBinaryMessageFragmentFunc(websocket, bytes, payloadSize, isLastFragment, websocket->m_clientContext);
+            }
+            else if (websocket->m_clientBinaryMessageFunc)
+            {
+                HC_TRACE_INFORMATION(WEBSOCKET, "Received binary message fragment but no client handler has been set. Invoking HCWebSocketBinaryMessageFunction instead.");
+                websocket->m_clientBinaryMessageFunc(websocket, bytes, payloadSize, websocket->m_clientContext);
+            }
+        }
+        catch (...)
+        {
+            HC_TRACE_WARNING(WEBSOCKET, "Caught exception in client HCWebSocketBinaryMessageFragmentFunction");
+        }
+    }
+}
+
 void HC_WEBSOCKET::CloseFunc(
     HC_WEBSOCKET* websocket,
     HCWebSocketCloseStatus status,
@@ -584,6 +625,17 @@ try
     socket->AddClientRef();
     *websocket = socket.get();
     return S_OK;
+}
+CATCH_RETURN()
+
+STDAPI HCWebSocketSetBinaryMessageFragmentEventFunction(
+    _In_ HCWebsocketHandle websocket,
+    _In_ HCWebSocketBinaryMessageFragmentFunction binaryMessageFragmentFunc
+) noexcept
+try
+{
+    RETURN_HR_IF(E_INVALIDARG, !websocket);
+    return websocket->SetBinaryMessageFragmentFunc(binaryMessageFragmentFunc);
 }
 CATCH_RETURN()
 
@@ -941,6 +993,22 @@ try
     return S_OK;
 }
 CATCH_RETURN()
+
+STDAPI HCWebSocketGetBinaryMessageFragmentEventFunction(
+    _In_ HCWebsocketHandle websocket,
+    _Out_ HCWebSocketBinaryMessageFragmentFunction* binaryMessageFragmentFunc,
+    _Out_ void** context
+) noexcept
+try
+{
+    RETURN_HR_IF(E_INVALIDARG, !websocket || !binaryMessageFragmentFunc || !context);
+
+    *binaryMessageFragmentFunc = HC_WEBSOCKET::BinaryMessageFragmentFunc;
+    *context = nullptr;
+    return S_OK;
+}
+CATCH_RETURN()
+
 
 STDAPI
 HCGetWebSocketConnectResult(

--- a/Source/WebSocket/hcwebsocket.h
+++ b/Source/WebSocket/hcwebsocket.h
@@ -55,6 +55,7 @@ public:
     const http_internal_string& SubProtocol() const noexcept;
     size_t MaxReceiveBufferSize() const noexcept;
 
+    HRESULT SetBinaryMessageFragmentFunc(HCWebSocketBinaryMessageFragmentFunction func) noexcept;
     HRESULT SetProxyUri(http_internal_string&& proxyUri) noexcept;
     HRESULT SetProxyDecryptsHttps(bool allowProxyToDecryptHttps) noexcept;
     HRESULT SetHeader(http_internal_string&& headerName, http_internal_string&& headerValue) noexcept;
@@ -67,6 +68,7 @@ public:
 
     static void CALLBACK MessageFunc(HC_WEBSOCKET* websocket, const char* message, void* context);
     static void CALLBACK BinaryMessageFunc(HC_WEBSOCKET* websocket, const uint8_t* bytes, uint32_t payloadSize, void* context);
+    static void CALLBACK BinaryMessageFragmentFunc(HC_WEBSOCKET* websocket, const uint8_t* payloadBytes, uint32_t payloadSize, bool isLastFragment, void* functionContext);
     static void CALLBACK CloseFunc(HC_WEBSOCKET* websocket, HCWebSocketCloseStatus status, void* context);
 
     std::shared_ptr<hc_websocket_impl> impl;
@@ -92,10 +94,11 @@ private:
     http_internal_string m_subProtocol;
     size_t m_maxReceiveBufferSize;
 
-    HCWebSocketMessageFunction const m_clientMessageFunc;
-    HCWebSocketBinaryMessageFunction const m_clientBinaryMessageFunc;
-    HCWebSocketCloseEventFunction const m_clientCloseEventFunc;
-    void* m_clientContext;
+    HCWebSocketMessageFunction const m_clientMessageFunc{ nullptr };
+    HCWebSocketBinaryMessageFunction const m_clientBinaryMessageFunc{ nullptr };
+    HCWebSocketBinaryMessageFragmentFunction m_clientBinaryMessageFragmentFunc{ nullptr };
+    HCWebSocketCloseEventFunction const m_clientCloseEventFunc{ nullptr };
+    void* m_clientContext{ nullptr };
 
     std::recursive_mutex m_mutex;
     std::atomic<int> m_clientRefCount{ 0 };

--- a/Source/WebSocket/hcwebsocket.h
+++ b/Source/WebSocket/hcwebsocket.h
@@ -92,7 +92,7 @@ private:
     http_internal_string m_proxyUri;
     http_internal_string m_uri;
     http_internal_string m_subProtocol;
-    size_t m_maxReceiveBufferSize;
+    size_t m_maxReceiveBufferSize{ 0 };
 
     HCWebSocketMessageFunction const m_clientMessageFunc{ nullptr };
     HCWebSocketBinaryMessageFunction const m_clientBinaryMessageFunc{ nullptr };

--- a/Source/WebSocket/hcwebsocket.h
+++ b/Source/WebSocket/hcwebsocket.h
@@ -53,10 +53,12 @@ public:
     const bool ProxyDecryptsHttps() const noexcept;
     const http_internal_string& Uri() const noexcept;
     const http_internal_string& SubProtocol() const noexcept;
+    size_t MaxReceiveBufferSize() const noexcept;
 
     HRESULT SetProxyUri(http_internal_string&& proxyUri) noexcept;
     HRESULT SetProxyDecryptsHttps(bool allowProxyToDecryptHttps) noexcept;
     HRESULT SetHeader(http_internal_string&& headerName, http_internal_string&& headerValue) noexcept;
+    HRESULT SetMaxReceiveBufferSize(size_t maxReceiveBufferSizeBytes) noexcept;
 
     void AddClientRef();
     void DecClientRef();
@@ -88,6 +90,7 @@ private:
     http_internal_string m_proxyUri;
     http_internal_string m_uri;
     http_internal_string m_subProtocol;
+    size_t m_maxReceiveBufferSize;
 
     HCWebSocketMessageFunction const m_clientMessageFunc;
     HCWebSocketBinaryMessageFunction const m_clientBinaryMessageFunc;

--- a/libHttpClient.vs2019.sln
+++ b/libHttpClient.vs2019.sln
@@ -17,7 +17,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{A7CDB1FA
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libHttpClient.142.UnitTest.TE", "Build\libHttpClient.142.UnitTest.TE\libHttpClient.142.UnitTest.TE.vcxproj", "{9DD2BA60-6505-493A-8C41-8085C44E9F1F}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libHttpClient.142.UnitTest.TAEF", "Build\libHttpClient.142.UnitTest.TAEF\libHttpClient.142.UnitTest.TAEF.vcxproj", "{E885BB30-F51E-4BAB-9300-4B303144BB49}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libHttpClient.UnitTest.142.TAEF", "Build\libHttpClient.142.UnitTest.TAEF\libHttpClient.142.UnitTest.TAEF.vcxproj", "{E885BB30-F51E-4BAB-9300-4B303144BB49}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{CADB9561-440F-4B5F-BC40-4D569EBF1903}"
 EndProject
@@ -39,7 +39,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libHttpClient.142.XDK.C", "
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GDK", "GDK", "{9C8A0D94-F592-46D7-9491-1E464C6A8166}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libHttpClient.142.GDK.C", "Build\libHttpClient.142.GDK.C\libHttpClient.142.GDK.C.vcxproj", "{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libHttpClient.142.GDK.C", "Build\libHttpClient.142.GDK.C\libHttpClient.142.GDK.C.vcxproj", "{80D8061D-BBEF-414D-8F08-4D8B52C02E85}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WebSocketEchoServer", "Samples\WebSocketEchoServer\WebSocketEchoServer.vcxproj", "{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}"
 EndProject
@@ -429,36 +429,68 @@ Global
 		{9E0EB8C2-40CD-448F-9B98-DAF9830EF9AD}.Release|Gaming.Desktop.x64.ActiveCfg = Release|Durango
 		{9E0EB8C2-40CD-448F-9B98-DAF9830EF9AD}.Release|x64.ActiveCfg = Release|Durango
 		{9E0EB8C2-40CD-448F-9B98-DAF9830EF9AD}.Release|x86.ActiveCfg = Release|Durango
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Debug|Any CPU.ActiveCfg = Debug|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Debug|ARM.ActiveCfg = Debug|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Debug|ARM64.ActiveCfg = Debug|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Debug|Durango.ActiveCfg = Debug|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Debug|Gaming.Desktop.x64.ActiveCfg = Debug|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Debug|Gaming.Desktop.x64.Build.0 = Debug|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Debug|x64.ActiveCfg = Debug|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Debug|x86.ActiveCfg = Debug|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Profile|Any CPU.ActiveCfg = Debug|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Profile|Any CPU.Build.0 = Debug|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Profile|ARM.ActiveCfg = Debug|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Profile|ARM.Build.0 = Debug|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Profile|ARM64.ActiveCfg = Debug|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Profile|ARM64.Build.0 = Debug|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Profile|Durango.ActiveCfg = Debug|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Profile|Durango.Build.0 = Debug|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Profile|Gaming.Desktop.x64.ActiveCfg = Debug|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Profile|Gaming.Desktop.x64.Build.0 = Debug|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Profile|x64.ActiveCfg = Debug|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Profile|x64.Build.0 = Debug|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Profile|x86.ActiveCfg = Debug|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Profile|x86.Build.0 = Debug|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Release|Any CPU.ActiveCfg = Release|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Release|ARM.ActiveCfg = Release|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Release|ARM64.ActiveCfg = Release|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Release|Durango.ActiveCfg = Release|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Release|Gaming.Desktop.x64.ActiveCfg = Release|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Release|Gaming.Desktop.x64.Build.0 = Release|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Release|x64.ActiveCfg = Release|Gaming.Desktop.x64
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}.Release|x86.ActiveCfg = Release|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Debug|Any CPU.ActiveCfg = Debug|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Debug|ARM.ActiveCfg = Debug|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Debug|ARM64.ActiveCfg = Debug|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Debug|Durango.ActiveCfg = Debug|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Debug|Gaming.Desktop.x64.ActiveCfg = Debug|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Debug|Gaming.Desktop.x64.Build.0 = Debug|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Debug|x64.ActiveCfg = Debug|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Debug|x86.ActiveCfg = Debug|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Profile|Any CPU.ActiveCfg = Debug|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Profile|Any CPU.Build.0 = Debug|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Profile|ARM.ActiveCfg = Debug|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Profile|ARM.Build.0 = Debug|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Profile|ARM64.ActiveCfg = Debug|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Profile|ARM64.Build.0 = Debug|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Profile|Durango.ActiveCfg = Debug|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Profile|Durango.Build.0 = Debug|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Profile|Gaming.Desktop.x64.ActiveCfg = Debug|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Profile|Gaming.Desktop.x64.Build.0 = Debug|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Profile|x64.ActiveCfg = Debug|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Profile|x64.Build.0 = Debug|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Profile|x86.ActiveCfg = Debug|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Profile|x86.Build.0 = Debug|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Release|Any CPU.ActiveCfg = Release|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Release|ARM.ActiveCfg = Release|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Release|ARM64.ActiveCfg = Release|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Release|Durango.ActiveCfg = Release|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Release|Gaming.Desktop.x64.ActiveCfg = Release|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Release|Gaming.Desktop.x64.Build.0 = Release|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Release|x64.ActiveCfg = Release|Gaming.Desktop.x64
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85}.Release|x86.ActiveCfg = Release|Gaming.Desktop.x64
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Debug|ARM.ActiveCfg = Debug|Win32
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Debug|ARM64.ActiveCfg = Debug|Win32
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Debug|Durango.ActiveCfg = Debug|Win32
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Debug|Gaming.Desktop.x64.ActiveCfg = Debug|Win32
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Debug|x64.ActiveCfg = Debug|x64
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Debug|x64.Build.0 = Debug|x64
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Debug|x86.ActiveCfg = Debug|Win32
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Debug|x86.Build.0 = Debug|Win32
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Profile|Any CPU.ActiveCfg = Release|x64
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Profile|Any CPU.Build.0 = Release|x64
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Profile|ARM.ActiveCfg = Release|x64
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Profile|ARM.Build.0 = Release|x64
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Profile|ARM64.ActiveCfg = Release|x64
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Profile|ARM64.Build.0 = Release|x64
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Profile|Durango.ActiveCfg = Release|x64
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Profile|Durango.Build.0 = Release|x64
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Profile|Gaming.Desktop.x64.ActiveCfg = Release|x64
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Profile|Gaming.Desktop.x64.Build.0 = Release|x64
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Profile|x64.ActiveCfg = Release|x64
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Profile|x64.Build.0 = Release|x64
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Profile|x86.ActiveCfg = Release|Win32
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Profile|x86.Build.0 = Release|Win32
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Release|Any CPU.ActiveCfg = Release|Win32
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Release|ARM.ActiveCfg = Release|Win32
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Release|ARM64.ActiveCfg = Release|Win32
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Release|Durango.ActiveCfg = Release|Win32
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Release|Gaming.Desktop.x64.ActiveCfg = Release|Win32
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Release|x64.ActiveCfg = Release|x64
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Release|x64.Build.0 = Release|x64
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Release|x86.ActiveCfg = Release|Win32
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -477,7 +509,8 @@ Global
 		{13457617-8476-4708-A601-AF998F6EDF21} = {0AA3F7FD-BB7C-4386-8435-F6BABE5EBED3}
 		{9A461116-4B40-40F0-8AE0-81DD294BB92E} = {CADB9561-440F-4B5F-BC40-4D569EBF1903}
 		{9E0EB8C2-40CD-448F-9B98-DAF9830EF9AD} = {888A3A17-4FE5-4768-B67E-B4B2B59CF895}
-		{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C} = {9C8A0D94-F592-46D7-9491-1E464C6A8166}
+		{80D8061D-BBEF-414D-8F08-4D8B52C02E85} = {9C8A0D94-F592-46D7-9491-1E464C6A8166}
+		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB} = {CADB9561-440F-4B5F-BC40-4D569EBF1903}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {973E1528-6B80-4A7E-9534-56E9481AF63A}

--- a/libHttpClient.vs2019.sln
+++ b/libHttpClient.vs2019.sln
@@ -41,6 +41,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GDK", "GDK", "{9C8A0D94-F59
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libHttpClient.142.GDK.C", "Build\libHttpClient.142.GDK.C\libHttpClient.142.GDK.C.vcxproj", "{DA74F6C1-9B77-4135-9C23-AA348AB0DC9C}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WebSocketEchoServer", "Samples\WebSocketEchoServer\WebSocketEchoServer.vcxproj", "{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
* Fixes bug where messages that exceeded the hardcoded receive buffer size were never delivered to clients
* Added public API to set a message fragment handler. When messages are broken down at the platform level and exceed the configured receive buffer size, they will be passed to clients in fragments.
* Adds public API to configure maximum WebSocket receive buffer size.  When receive buffer is full, partial messages are passed to client. 
* Adds public API to configure the maximum receive buffer size (WinHttp only).  If large messages are expected, this can be changed so that full messages are delivered all at once rather than in chunks.  Setting this buffer size to large values does mean that the entire message will be stored in LHC memory until it is passed along to clients so memory performance may be affected.