### PR TITLE
Fix various missing #include and required namespace qualifiers

### DIFF
--- a/Source/Common/pch_common.h
+++ b/Source/Common/pch_common.h
@@ -36,12 +36,15 @@
 #endif
 
 // STL includes
+#include <algorithm>
 #include <atomic>
 #include <cassert>
 #include <chrono>
+#include <cmath>
 #include <codecvt>
 #include <condition_variable>
 #include <cstdint>
+#include <cstring>
 #include <functional>
 #include <iomanip>
 #include <list>

--- a/Source/Task/AsyncLib.cpp
+++ b/Source/Task/AsyncLib.cpp
@@ -164,11 +164,11 @@ public:
     {
         return m_state;
     }
-    bool operator==(nullptr_t) const noexcept
+    bool operator==(std::nullptr_t) const noexcept
     {
         return m_state == nullptr;
     }
-    bool operator!=(nullptr_t) const noexcept
+    bool operator!=(std::nullptr_t) const noexcept
     {
         return m_state != nullptr;
     }

--- a/Source/Task/referenced_ptr.h
+++ b/Source/Task/referenced_ptr.h
@@ -96,13 +96,13 @@ private:
 };
 
 template <typename TInterface>
-bool operator==(referenced_ptr<TInterface>& p, nullptr_t)
+bool operator==(referenced_ptr<TInterface>& p, std::nullptr_t)
 {
     return p.get() == nullptr;
 }
 
 template <typename TInterface>
-bool operator!=(referenced_ptr<TInterface>& p, nullptr_t)
+bool operator!=(referenced_ptr<TInterface>& p, std::nullptr_t)
 {
     return p.get() != nullptr;
 }

--- a/Utilities/CMake/CMakeLists.txt
+++ b/Utilities/CMake/CMakeLists.txt
@@ -76,8 +76,8 @@ include_directories(
     $(ProjectDir)../../../Source/Common
     $(ProjectDir)../../../Source/HTTP
     $(ProjectDir)../../../Source/Logger
-    $(ProjectDir)../../../include
-    $(ProjectDir)../../../include/httpClient
+    $(ProjectDir)../../../Include
+    $(ProjectDir)../../../Include/httpClient
     )
 
 set(CMAKE_SUPPRESS_REGENERATION true)

--- a/Utilities/CMake/GetCommonHCSourceFiles.cmake
+++ b/Utilities/CMake/GetCommonHCSourceFiles.cmake
@@ -13,16 +13,16 @@ function(GET_COMMON_HC_SOURCE_FILES
          )
 
     set(${OUT_PUBLIC_SOURCE_FILES}
-        "${PATH_TO_ROOT}/include/httpClient/config.h"
-        "${PATH_TO_ROOT}/include/httpClient/httpClient.h"
-        "${PATH_TO_ROOT}/include/httpClient/httpProvider.h"
-        "${PATH_TO_ROOT}/include/httpClient/mock.h"
-        "${PATH_TO_ROOT}/include/xasync.h"
-        "${PATH_TO_ROOT}/include/xasyncProvider.h"
-        "${PATH_TO_ROOT}/include/xtaskQueue.h"
-        "${PATH_TO_ROOT}/include/httpClient/trace.h"
-        "${PATH_TO_ROOT}/include/httpClient/pal.h"
-        "${PATH_TO_ROOT}/include/httpClient/async.h"
+        "${PATH_TO_ROOT}/Include/httpClient/config.h"
+        "${PATH_TO_ROOT}/Include/httpClient/httpClient.h"
+        "${PATH_TO_ROOT}/Include/httpClient/httpProvider.h"
+        "${PATH_TO_ROOT}/Include/httpClient/mock.h"
+        "${PATH_TO_ROOT}/Include/XAsync.h"
+        "${PATH_TO_ROOT}/Include/XAsyncProvider.h"
+        "${PATH_TO_ROOT}/Include/XTaskQueue.h"
+        "${PATH_TO_ROOT}/Include/httpClient/trace.h"
+        "${PATH_TO_ROOT}/Include/httpClient/pal.h"
+        "${PATH_TO_ROOT}/Include/httpClient/async.h"
         PARENT_SCOPE
         )
 


### PR DESCRIPTION
This patchset fixes a number of trivial compilation issues that were found when attempting to add Linux support to `libHttpClient`. 

I have not tested these on all platforms, or attempted to understand why the current incorrect forms work, but they are harmless changes AFAICT.