### PR TITLE
WinHttp Cleanup race condition

### DIFF
--- a/Source/HTTP/Curl/CurlMulti.h
+++ b/Source/HTTP/Curl/CurlMulti.h
@@ -33,6 +33,7 @@ private:
     void FailAllRequests(HRESULT hr) noexcept;
 
     static HRESULT CALLBACK CleanupAsyncProvider(XAsyncOp op, const XAsyncProviderData* data);
+    static void CALLBACK TaskQueueTerminated(void* context);
 
     CURLM* m_curlMultiHandle{ nullptr };
     XTaskQueueHandle m_queue{ nullptr };

--- a/Source/HTTP/WinHttp/winhttp_connection.cpp
+++ b/Source/HTTP/WinHttp/winhttp_connection.cpp
@@ -432,7 +432,7 @@ HRESULT WinHttpConnection::Close(ConnectionClosedCallback callback)
     }
     else if (closeComplete)
     {
-        callback();
+        m_connectionClosedCallback();
     }
  
     return S_OK;

--- a/Source/HTTP/WinHttp/winhttp_connection.cpp
+++ b/Source/HTTP/WinHttp/winhttp_connection.cpp
@@ -376,6 +376,7 @@ HRESULT WinHttpConnection::Close(ConnectionClosedCallback callback)
 {
     bool doWebSocketClose = false;
     bool doWinHttpClose = false;
+    bool closeComplete = false;
 
     {
         win32_cs_autolock autoCriticalSection(&m_lock);
@@ -406,6 +407,11 @@ HRESULT WinHttpConnection::Close(ConnectionClosedCallback callback)
             // Nothing to do 
             return S_OK;
         }
+        case ConnectionState::Closed:
+        {
+            closeComplete = true;
+            break;
+        }
         default:
         {
             doWinHttpClose = true;
@@ -423,6 +429,10 @@ HRESULT WinHttpConnection::Close(ConnectionClosedCallback callback)
     else if (doWinHttpClose)
     {
         return StartWinHttpClose();
+    }
+    else if (closeComplete)
+    {
+        callback();
     }
  
     return S_OK;
@@ -1103,8 +1113,14 @@ void CALLBACK WinHttpConnection::completion_callback(
                     // WinHttp Shutdown complete. WinHttp guarantees we will get no more callbacks for this request so we can safely cleanup context.
                     // Ensure WinHttpCallbackContext is cleaned before invoking callback in case this is happening during HCCleanup
                     HC_UNIQUE_PTR<WinHttpCallbackContext> reclaim{ callbackContext };
-                    pRequestContext->m_hRequest = nullptr;
-                    auto connectionClosedCallback = std::move(pRequestContext->m_connectionClosedCallback);
+
+                    ConnectionClosedCallback connectionClosedCallback{};
+                    {
+                        win32_cs_autolock cs{ &pRequestContext->m_lock };
+                        pRequestContext->m_hRequest = nullptr;
+                        connectionClosedCallback = std::move(pRequestContext->m_connectionClosedCallback);
+                        pRequestContext->m_state = ConnectionState::Closed;
+                    }
                     reclaim.reset();
 
                     if (connectionClosedCallback)

--- a/Source/HTTP/WinHttp/winhttp_connection.h
+++ b/Source/HTTP/WinHttp/winhttp_connection.h
@@ -165,7 +165,8 @@ enum class ConnectionState : uint32_t
     WinHttpRunning,
     WebSocketConnected,
     WebSocketClosing,
-    WinHttpClosing
+    WinHttpClosing,
+    Closed
 };
 
 using WinHttpWebSocketCompleteUpgradeExport = HINTERNET(WINAPI *)(HINTERNET, DWORD_PTR);


### PR DESCRIPTION
Fixes a race condition be HCCleanupAsync and a WinHttpClose call by adding a final "Closed" state to connection.