### PR TITLE
Prevent request body read to continue reading if no more data on XMLHttp

### DIFF
--- a/Source/HTTP/XMLHttp/http_request_stream.cpp
+++ b/Source/HTTP/XMLHttp/http_request_stream.cpp
@@ -51,6 +51,11 @@ HRESULT STDMETHODCALLTYPE http_request_stream::Read(
     _Out_ ULONG *pcbRead
     )
 {
+    if (pv == nullptr || pcbRead == nullptr)
+    {
+        return STG_E_INVALIDPOINTER;
+    }
+
     HCHttpCallRequestBodyReadFunction readFunction = nullptr;
     size_t bodySize = 0;
     void* context = nullptr;
@@ -58,6 +63,13 @@ HRESULT STDMETHODCALLTYPE http_request_stream::Read(
     if (FAILED(hr) || readFunction == nullptr)
     {
         return STG_E_READFAULT;
+    }
+
+    if (m_startIndex == bodySize)
+    {
+        // Reached end of buffer
+        *pcbRead = 0;
+        return S_FALSE;
     }
 
     size_t bytesWritten = 0;
@@ -79,6 +91,11 @@ HRESULT STDMETHODCALLTYPE http_request_stream::Read(
     if (pcbRead != nullptr)
     {
         *pcbRead = static_cast<DWORD>(bytesWritten);
+        if (bytesWritten < cb)
+        {
+            // Reached end of buffer
+            return S_FALSE;
+        }
     }
 
     return S_OK;

--- a/Source/HTTP/XMLHttp/http_response_stream.cpp
+++ b/Source/HTTP/XMLHttp/http_response_stream.cpp
@@ -40,10 +40,19 @@ HRESULT STDMETHODCALLTYPE http_response_stream::Write(
     try
     {
         hr = writeFunction(httpTask->call(), static_cast<const uint8_t*>(pv), cb, context);
-        if (FAILED(hr))
+        if (hr == E_OUTOFMEMORY)
+        {
+            return STG_E_MEDIUMFULL;
+        }
+        else if (FAILED(hr))
         {
             return STG_E_CANTSAVE;
         }
+    }
+    catch (std::bad_alloc /*e*/)
+    {
+        httpTask->set_exception(std::current_exception());
+        return STG_E_MEDIUMFULL;
     }
     catch (...)
     {


### PR DESCRIPTION
On UWP, per [ISequentialStream::Read](https://docs.microsoft.com/en-us/windows/win32/api/objidl/nf-objidl-isequentialstream-read) documentation, the Read method should return S_FALSE if the value returned in pcbRead is less than the number of bytes requested in cb (end of the stream has been reached).

This PR also adds a couple of extra checks to return a more appropriate error code for some failure scenarios.