### PR TITLE
Cleanup redesign part 2

### DIFF
--- a/Build/libHttpClient.140.UWP.C/libHttpClient.140.UWP.C.vcxproj
+++ b/Build/libHttpClient.140.UWP.C/libHttpClient.140.UWP.C.vcxproj
@@ -184,6 +184,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\WinRT\winrt_websocket.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.h" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\async.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h" />

--- a/Build/libHttpClient.140.UWP.C/libHttpClient.140.UWP.C.vcxproj.filters
+++ b/Build/libHttpClient.140.UWP.C/libHttpClient.140.UWP.C.vcxproj.filters
@@ -82,6 +82,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp">
       <Filter>C++ Source\WebSocket</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp">
+      <Filter>C++ Source\WebSocket</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Common\EntryList.h">

--- a/Build/libHttpClient.140.Win32.C/libHttpClient.140.Win32.C.vcxproj
+++ b/Build/libHttpClient.140.Win32.C/libHttpClient.140.Win32.C.vcxproj
@@ -171,6 +171,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\Websocketpp\x509_cert_utilities.hpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.h" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\async.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h" />

--- a/Build/libHttpClient.140.Win32.C/libHttpClient.140.Win32.C.vcxproj.filters
+++ b/Build/libHttpClient.140.Win32.C/libHttpClient.140.Win32.C.vcxproj.filters
@@ -76,6 +76,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp">
       <Filter>C++ Source\WebSocket</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp">
+      <Filter>C++ Source\WebSocket</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Common\EntryList.h">

--- a/Build/libHttpClient.140.XDK.C/libHttpClient.140.XDK.C.vcxproj
+++ b/Build/libHttpClient.140.XDK.C/libHttpClient.140.XDK.C.vcxproj
@@ -139,6 +139,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\WinRT\winrt_websocket.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.h" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\async.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h" />

--- a/Build/libHttpClient.140.XDK.C/libHttpClient.140.XDK.C.vcxproj.filters
+++ b/Build/libHttpClient.140.XDK.C/libHttpClient.140.XDK.C.vcxproj.filters
@@ -82,6 +82,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp">
       <Filter>C++ Source\WebSocket</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp">
+      <Filter>C++ Source\WebSocket</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Common\EntryList.h">

--- a/Build/libHttpClient.141.GDK.C/libHttpClient.141.GDK.C.vcxproj
+++ b/Build/libHttpClient.141.GDK.C/libHttpClient.141.GDK.C.vcxproj
@@ -145,6 +145,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\mock_publics.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.h" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\async.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h" />

--- a/Build/libHttpClient.141.GDK.C/libHttpClient.141.GDK.C.vcxproj.filters
+++ b/Build/libHttpClient.141.GDK.C/libHttpClient.141.GDK.C.vcxproj.filters
@@ -70,6 +70,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp">
       <Filter>C++ Source\WebSocket</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp">
+      <Filter>C++ Source\WebSocket</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Common\EntryList.h">

--- a/Build/libHttpClient.141.UWP.C/libHttpClient.141.UWP.C.vcxproj
+++ b/Build/libHttpClient.141.UWP.C/libHttpClient.141.UWP.C.vcxproj
@@ -184,6 +184,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\WinRT\winrt_websocket.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.h" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\async.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h" />

--- a/Build/libHttpClient.141.UWP.C/libHttpClient.141.UWP.C.vcxproj.filters
+++ b/Build/libHttpClient.141.UWP.C/libHttpClient.141.UWP.C.vcxproj.filters
@@ -82,6 +82,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp">
       <Filter>C++ Source\WebSocket</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp">
+      <Filter>C++ Source\WebSocket</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Common\EntryList.h">

--- a/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj
+++ b/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj
@@ -171,6 +171,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\Websocketpp\x509_cert_utilities.hpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.h" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\async.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h" />

--- a/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj.filters
+++ b/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj.filters
@@ -76,6 +76,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp">
       <Filter>C++ Source\WebSocket</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp">
+      <Filter>C++ Source\WebSocket</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Common\EntryList.h">

--- a/Build/libHttpClient.141.XDK.C/libHttpClient.141.XDK.C.vcxproj
+++ b/Build/libHttpClient.141.XDK.C/libHttpClient.141.XDK.C.vcxproj
@@ -139,6 +139,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\WinRT\winrt_websocket.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.h" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\async.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h" />

--- a/Build/libHttpClient.141.XDK.C/libHttpClient.141.XDK.C.vcxproj.filters
+++ b/Build/libHttpClient.141.XDK.C/libHttpClient.141.XDK.C.vcxproj.filters
@@ -82,6 +82,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp">
       <Filter>C++ Source\WebSocket</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp">
+      <Filter>C++ Source\WebSocket</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Common\EntryList.h">

--- a/Build/libHttpClient.142.GDK.C/libHttpClient.142.GDK.C.vcxproj
+++ b/Build/libHttpClient.142.GDK.C/libHttpClient.142.GDK.C.vcxproj
@@ -145,6 +145,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\mock_publics.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.h" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\async.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h" />

--- a/Build/libHttpClient.142.GDK.C/libHttpClient.142.GDK.C.vcxproj.filters
+++ b/Build/libHttpClient.142.GDK.C/libHttpClient.142.GDK.C.vcxproj.filters
@@ -70,6 +70,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp">
       <Filter>C++ Source\WebSocket</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp">
+      <Filter>C++ Source\WebSocket</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Common\EntryList.h">

--- a/Build/libHttpClient.142.UWP.C/libHttpClient.142.UWP.C.vcxproj
+++ b/Build/libHttpClient.142.UWP.C/libHttpClient.142.UWP.C.vcxproj
@@ -184,6 +184,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\WinRT\winrt_websocket.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.h" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\async.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h" />

--- a/Build/libHttpClient.142.UWP.C/libHttpClient.142.UWP.C.vcxproj.filters
+++ b/Build/libHttpClient.142.UWP.C/libHttpClient.142.UWP.C.vcxproj.filters
@@ -82,6 +82,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp">
       <Filter>C++ Source\WebSocket</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp">
+      <Filter>C++ Source\WebSocket</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Common\EntryList.h">

--- a/Build/libHttpClient.142.UnitTest.TAEF/libHttpClient.142.UnitTest.TAEF.vcxproj
+++ b/Build/libHttpClient.142.UnitTest.TAEF/libHttpClient.142.UnitTest.TAEF.vcxproj
@@ -153,6 +153,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\referenced_ptr.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.h" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Tests\UnitTests\Support\DefineTestMacros.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Tests\UnitTests\Support\TAEF\UnitTestBase.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Tests\UnitTests\Support\TAEF\UnitTestBase.h" />

--- a/Build/libHttpClient.142.UnitTest.TAEF/libHttpClient.142.UnitTest.TAEF.vcxproj.filters
+++ b/Build/libHttpClient.142.UnitTest.TAEF/libHttpClient.142.UnitTest.TAEF.vcxproj.filters
@@ -67,6 +67,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp">
       <Filter>C++ Source\WebSocket</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp">
+      <Filter>C++ Source\WebSocket</Filter>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Tests\UnitTests\Support\TAEF\UnitTestBase.cpp">
       <Filter>C++ Source\UnitTests\Support</Filter>
     </ClCompile>

--- a/Build/libHttpClient.142.UnitTest.TE/libHttpClient.142.UnitTest.TE.vcxproj
+++ b/Build/libHttpClient.142.UnitTest.TE/libHttpClient.142.UnitTest.TE.vcxproj
@@ -227,6 +227,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\referenced_ptr.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.h" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Tests\UnitTests\Support\DefineTestMacros.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Tests\UnitTests\Support\TE\UnitTestHelpers.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Tests\UnitTests\Support\TE\UnitTestHelpers.h" />

--- a/Build/libHttpClient.142.UnitTest.TE/libHttpClient.142.UnitTest.TE.vcxproj.filters
+++ b/Build/libHttpClient.142.UnitTest.TE/libHttpClient.142.UnitTest.TE.vcxproj.filters
@@ -67,6 +67,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp">
       <Filter>C++ Source\WebSocket</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp">
+      <Filter>C++ Source\WebSocket</Filter>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Tests\UnitTests\Support\TE\UnitTestHelpers.cpp">
       <Filter>C++ Source\UnitTests\Support</Filter>
     </ClCompile>

--- a/Build/libHttpClient.142.Win32.C/libHttpClient.142.Win32.C.vcxproj
+++ b/Build/libHttpClient.142.Win32.C/libHttpClient.142.Win32.C.vcxproj
@@ -171,6 +171,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\Websocketpp\x509_cert_utilities.hpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.h" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\async.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h" />

--- a/Build/libHttpClient.142.Win32.C/libHttpClient.142.Win32.C.vcxproj.filters
+++ b/Build/libHttpClient.142.Win32.C/libHttpClient.142.Win32.C.vcxproj.filters
@@ -76,6 +76,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp">
       <Filter>C++ Source\WebSocket</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp">
+      <Filter>C++ Source\WebSocket</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Common\EntryList.h">

--- a/Build/libHttpClient.142.XDK.C/libHttpClient.142.XDK.C.vcxproj
+++ b/Build/libHttpClient.142.XDK.C/libHttpClient.142.XDK.C.vcxproj
@@ -139,6 +139,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\WinRT\winrt_websocket.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.h" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\async.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h" />

--- a/Build/libHttpClient.142.XDK.C/libHttpClient.142.XDK.C.vcxproj.filters
+++ b/Build/libHttpClient.142.XDK.C/libHttpClient.142.XDK.C.vcxproj.filters
@@ -82,6 +82,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp">
       <Filter>C++ Source\WebSocket</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp">
+      <Filter>C++ Source\WebSocket</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Common\EntryList.h">

--- a/Build/libHttpClient.143.GDK.C/libHttpClient.143.GDK.C.vcxproj
+++ b/Build/libHttpClient.143.GDK.C/libHttpClient.143.GDK.C.vcxproj
@@ -145,6 +145,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Mock\mock_publics.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.h" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\async.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h" />

--- a/Build/libHttpClient.143.GDK.C/libHttpClient.143.GDK.C.vcxproj.filters
+++ b/Build/libHttpClient.143.GDK.C/libHttpClient.143.GDK.C.vcxproj.filters
@@ -70,6 +70,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp">
       <Filter>C++ Source\WebSocket</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp">
+      <Filter>C++ Source\WebSocket</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Common\EntryList.h">

--- a/Build/libHttpClient.143.Win32.C/libHttpClient.143.Win32.C.vcxproj
+++ b/Build/libHttpClient.143.Win32.C/libHttpClient.143.Win32.C.vcxproj
@@ -171,6 +171,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\Websocketpp\x509_cert_utilities.hpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.h" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\async.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\config.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\httpClient.h" />

--- a/Build/libHttpClient.143.Win32.C/libHttpClient.143.Win32.C.vcxproj.filters
+++ b/Build/libHttpClient.143.Win32.C/libHttpClient.143.Win32.C.vcxproj.filters
@@ -76,6 +76,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp">
       <Filter>C++ Source\WebSocket</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp">
+      <Filter>C++ Source\WebSocket</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Common\EntryList.h">

--- a/Include/httpClient/httpClient.h
+++ b/Include/httpClient/httpClient.h
@@ -890,7 +890,7 @@ STDAPI HCWebSocketSetProxyUri(
 /// <returns>Result code for this API operation.  Possible values are S_OK, E_INVALIDARG, E_OUTOFMEMORY, or E_FAIL.</returns>
 STDAPI HCWebSocketSetProxyDecryptsHttps(
     _In_ HCWebsocketHandle websocket,
-    _In_z_ bool allowProxyToDecryptHttps
+    _In_ bool allowProxyToDecryptHttps
 ) noexcept; 
 #endif
 

--- a/Include/httpClient/pal.h
+++ b/Include/httpClient/pal.h
@@ -449,7 +449,7 @@ typedef struct _LIST_ENTRY {
 #define E_HC_INTERNAL_STILLINUSE        MAKE_E_HC(0x5008) // 0x89235008
 
 typedef uint32_t HCMemoryType;
-typedef struct HC_WEBSOCKET* HCWebsocketHandle;
+typedef struct HC_WEBSOCKET_OBSERVER* HCWebsocketHandle;
 typedef struct HC_CALL* HCCallHandle;
 typedef struct HC_MOCK_CALL* HCMockCallHandle;
 typedef struct HC_PERFORM_ENV* HCPerformEnv;

--- a/Samples/Win32WebSocket/main.cpp
+++ b/Samples/Win32WebSocket/main.cpp
@@ -3,6 +3,7 @@
 
 #include "pch.h"
 #include <atomic>
+#include <assert.h>
 
 class win32_handle
 {
@@ -225,7 +226,9 @@ int main()
     asyncBlock->callback = [](XAsyncBlock* asyncBlock)
     {
         WebSocketCompletionResult result = {};
-        HCGetWebSocketConnectResult(asyncBlock, &result);
+        HRESULT hr = HCGetWebSocketConnectResult(asyncBlock, &result);
+        assert(SUCCEEDED(hr));
+        UNREFERENCED_PARAMETER(hr);
 
         printf_s("HCWebSocketConnect complete: %d, %d\n", result.errorCode, result.platformErrorCode);
         SetEvent(g_eventHandle);
@@ -252,7 +255,9 @@ int main()
         asyncBlock->callback = [](XAsyncBlock* asyncBlock)
         {
             WebSocketCompletionResult result = {};
-            HCGetWebSocketSendMessageResult(asyncBlock, &result);
+            HRESULT hr = HCGetWebSocketSendMessageResult(asyncBlock, &result);
+            assert(SUCCEEDED(hr));
+            UNREFERENCED_PARAMETER(hr);
 
             printf_s("HCWebSocketSendMessage complete: %d, %d\n", result.errorCode, result.platformErrorCode);
             SetEvent(g_eventHandle);
@@ -267,7 +272,9 @@ int main()
         asyncBlock->callback = [](XAsyncBlock* asyncBlock)
         {
             WebSocketCompletionResult result = {};
-            HCGetWebSocketSendMessageResult(asyncBlock, &result);
+            HRESULT hr = HCGetWebSocketSendMessageResult(asyncBlock, &result);
+            assert(SUCCEEDED(hr));
+            UNREFERENCED_PARAMETER(hr);
 
             printf_s("HCWebSocketSendBinaryMessageAsync complete: %d, %d\n", result.errorCode, result.platformErrorCode);
             SetEvent(g_eventHandle);

--- a/Samples/Win32WebSocket/main.cpp
+++ b/Samples/Win32WebSocket/main.cpp
@@ -218,80 +218,77 @@ int main()
     HRESULT hr = HCWebSocketCreate(&websocket, message_received, binary_message_received, websocket_closed, nullptr);
     HCWebSocketSetBinaryMessageFragmentEventFunction(websocket, binary_message_fragment_received);
 
-    for (int iConnectAttempt = 0; iConnectAttempt < 10; iConnectAttempt++)
-    {
-        g_numberMessagesReceieved = 0;
+    g_numberMessagesReceieved = 0;
 
-        XAsyncBlock* asyncBlock = new XAsyncBlock{};
+    XAsyncBlock* asyncBlock = new XAsyncBlock{};
+    asyncBlock->queue = g_queue;
+    asyncBlock->callback = [](XAsyncBlock* asyncBlock)
+    {
+        WebSocketCompletionResult result = {};
+        HCGetWebSocketConnectResult(asyncBlock, &result);
+
+        printf_s("HCWebSocketConnect complete: %d, %d\n", result.errorCode, result.platformErrorCode);
+        SetEvent(g_eventHandle);
+        delete asyncBlock;
+    };
+
+    printf_s("Calling HCWebSocketConnect...\n");
+    hr = HCWebSocketConnectAsync(url.data(), "", websocket, asyncBlock);
+    WaitForSingleObject(g_eventHandle, INFINITE);
+
+    uint32_t numberOfMessagesToSend = 1;
+    for (uint32_t i = 1; i <= numberOfMessagesToSend; i++)
+    {
+        char webMsg[150000];
+        for (uint32_t j = 0; j < sizeof(webMsg); ++j)
+        {
+            webMsg[j] = 'X';
+        }
+        webMsg[sizeof(webMsg) - 1] = '\0';
+        snprintf(webMsg, sizeof(webMsg), "Message #%d should be echoed!", i);
+
+        asyncBlock = new XAsyncBlock{};
         asyncBlock->queue = g_queue;
         asyncBlock->callback = [](XAsyncBlock* asyncBlock)
         {
             WebSocketCompletionResult result = {};
-            HCGetWebSocketConnectResult(asyncBlock, &result);
+            HCGetWebSocketSendMessageResult(asyncBlock, &result);
 
-            printf_s("HCWebSocketConnect complete: %d, %d\n", result.errorCode, result.platformErrorCode);
+            printf_s("HCWebSocketSendMessage complete: %d, %d\n", result.errorCode, result.platformErrorCode);
             SetEvent(g_eventHandle);
             delete asyncBlock;
         };
 
-        printf_s("Calling HCWebSocketConnect...\n");
-        hr = HCWebSocketConnectAsync(url.data(), "", websocket, asyncBlock);
-        WaitForSingleObject(g_eventHandle, INFINITE);
+        printf_s("Calling HCWebSocketSend with message \"%s\" and waiting for response...\n", webMsg);
+        hr = HCWebSocketSendMessageAsync(websocket, webMsg, asyncBlock);
 
-        uint32_t numberOfMessagesToSend = 1;
-        for (uint32_t i = 1; i <= numberOfMessagesToSend; i++)
+        asyncBlock = new XAsyncBlock{};
+        asyncBlock->queue = g_queue;
+        asyncBlock->callback = [](XAsyncBlock* asyncBlock)
         {
-            char webMsg[150000];
-            for (uint32_t j = 0; j < sizeof(webMsg); ++j)
-            {
-                webMsg[j] = 'X';
-            }
-            webMsg[sizeof(webMsg) - 1] = '\0';
-            //snprintf(webMsg, sizeof(webMsg), "Message #%d should be echoed!", i);
+            WebSocketCompletionResult result = {};
+            HCGetWebSocketSendMessageResult(asyncBlock, &result);
 
-            asyncBlock = new XAsyncBlock{};
-            asyncBlock->queue = g_queue;
-            asyncBlock->callback = [](XAsyncBlock* asyncBlock)
-            {
-                WebSocketCompletionResult result = {};
-                HCGetWebSocketSendMessageResult(asyncBlock, &result);
+            printf_s("HCWebSocketSendBinaryMessageAsync complete: %d, %d\n", result.errorCode, result.platformErrorCode);
+            SetEvent(g_eventHandle);
+            delete asyncBlock;
+        };
 
-                printf_s("HCWebSocketSendMessage complete: %d, %d\n", result.errorCode, result.platformErrorCode);
-                SetEvent(g_eventHandle);
-                delete asyncBlock;
-            };
+        hr = HCWebSocketSendBinaryMessageAsync(websocket, (uint8_t*)webMsg, 100, asyncBlock);
+    }
 
-            printf_s("Calling HCWebSocketSend with message \"%s\" and waiting for response...\n", webMsg);
-            hr = HCWebSocketSendMessageAsync(websocket, webMsg, asyncBlock);
-
-            asyncBlock = new XAsyncBlock{};
-            asyncBlock->queue = g_queue;
-            asyncBlock->callback = [](XAsyncBlock* asyncBlock)
-            {
-                WebSocketCompletionResult result = {};
-                HCGetWebSocketSendMessageResult(asyncBlock, &result);
-
-                printf_s("HCWebSocketSendBinaryMessageAsync complete: %d, %d\n", result.errorCode, result.platformErrorCode);
-                SetEvent(g_eventHandle);
-                delete asyncBlock;
-            };
-
-            hr = HCWebSocketSendBinaryMessageAsync(websocket, (uint8_t*)webMsg, 100, asyncBlock);
-        }
-
-        while (g_numberMessagesReceieved < numberOfMessagesToSend * 2)
-        {
-            WaitForSingleObject(g_eventHandle, INFINITE);
-        }
-
-        printf_s("Calling HCWebSocketDisconnect...\n");
-        HCWebSocketDisconnect(websocket);
+    while (g_numberMessagesReceieved < numberOfMessagesToSend * 2)
+    {
         WaitForSingleObject(g_eventHandle, INFINITE);
     }
 
+    printf_s("Calling HCWebSocketDisconnect...\n");
+    HCWebSocketDisconnect(websocket);
+    WaitForSingleObject(g_eventHandle, INFINITE);
+
     HCWebSocketCloseHandle(websocket);
-    CloseHandle(g_eventHandle);
     HCCleanup();
+    CloseHandle(g_eventHandle);
     return 0;
 }
 

--- a/Source/Global/mem.h
+++ b/Source/Global/mem.h
@@ -5,6 +5,7 @@
 #include <new>
 #include <stddef.h>
 #include <sstream>
+#include <set>
 
 NAMESPACE_XBOX_HTTP_CLIENT_BEGIN
 
@@ -167,3 +168,6 @@ using http_internal_queue = std::queue<T, http_internal_dequeue<T>>;
 
 template<class T>
 using http_internal_list = std::list<T, http_stl_allocator<T>>;
+
+template<class T, class LESS = std::less<T>>
+using http_internal_set = std::set<T, LESS, http_stl_allocator<T>>;

--- a/Source/Global/perform_env.cpp
+++ b/Source/Global/perform_env.cpp
@@ -311,6 +311,7 @@ void CALLBACK HC_PERFORM_ENV::HttpPerformComplete(XAsyncBlock* async)
     XAsyncComplete(performContext->clientAsyncBlock, XAsyncGetStatus(async, false), 0);
 }
 
+#if !HC_NOWEBSOCKETS
 struct HC_PERFORM_ENV::WebSocketConnectContext
 {
     WebSocketConnectContext(
@@ -479,6 +480,7 @@ void CALLBACK HC_PERFORM_ENV::WebSocketClosed(HCWebsocketHandle /*websocket*/, H
         }
     }
 }
+#endif
 
 HRESULT HC_PERFORM_ENV::CleanupAsync(HC_UNIQUE_PTR<HC_PERFORM_ENV>&& env, XAsyncBlock* async) noexcept
 {
@@ -503,6 +505,7 @@ HRESULT CALLBACK HC_PERFORM_ENV::CleanupAsyncProvider(XAsyncOp op, const XAsyncP
         {
             XAsyncCancel(activeRequest);
         }
+#if !HC_NOWEBSOCKETS
         for (auto& context : env->m_connectedWebSockets)
         {
             HRESULT hr = context->websocketObserver->websocket->Disconnect();
@@ -511,6 +514,7 @@ HRESULT CALLBACK HC_PERFORM_ENV::CleanupAsyncProvider(XAsyncOp op, const XAsyncP
                 HC_TRACE_ERROR_HR(HTTPCLIENT, hr, "WebSocket::Disconnect failed during HCCleanup");
             }
         }
+#endif
         lock.unlock();
 
         if (scheduleProviderCleanup)
@@ -589,6 +593,7 @@ bool HC_PERFORM_ENV::CanScheduleProviderCleanup()
         // Pending Http Requests
         return false;
     }
+#if !HC_NOWEBSOCKETS
     else if (!m_connectingWebSockets.empty())
     {
         // Pending WebSocket Connect operations
@@ -599,5 +604,6 @@ bool HC_PERFORM_ENV::CanScheduleProviderCleanup()
         // Pending WebSocket CloseFunc callbacks
         return false;
     }
+#endif
     return true;
 }

--- a/Source/Global/perform_env.cpp
+++ b/Source/Global/perform_env.cpp
@@ -236,10 +236,10 @@ struct HC_PERFORM_ENV::HttpPerformContext : public std::enable_shared_from_this<
         }
     }
 
-    HC_PERFORM_ENV* env{};
-    HCCallHandle const callHandle{};
-    XAsyncBlock* const clientAsyncBlock{};
-    XAsyncBlock internalAsyncBlock{};
+    HC_PERFORM_ENV* const env;
+    HCCallHandle const callHandle;
+    XAsyncBlock* const clientAsyncBlock;
+    XAsyncBlock internalAsyncBlock;
 };
 
 HRESULT HC_PERFORM_ENV::HttpCallPerformAsyncShim(HCCallHandle call, XAsyncBlock* async)
@@ -261,6 +261,7 @@ HRESULT CALLBACK HC_PERFORM_ENV::HttpPerformAsyncShimProvider(XAsyncOp op, const
     case XAsyncOp::Begin:
     {
         XTaskQueuePortHandle workPort{};
+        assert(data->async->queue); // Queue should never be null here
         RETURN_IF_FAILED(XTaskQueueGetPort(data->async->queue, XTaskQueuePort::Work, &workPort));
         RETURN_IF_FAILED(XTaskQueueCreateComposite(workPort, workPort, &performContext->internalAsyncBlock.queue));
 
@@ -380,6 +381,7 @@ HRESULT CALLBACK HC_PERFORM_ENV::WebSocketConnectAsyncShimProvider(XAsyncOp op, 
     case XAsyncOp::Begin:
     {
         XTaskQueuePortHandle workPort{};
+        assert(data->async->queue); // Queue should never be null here
         RETURN_IF_FAILED(XTaskQueueGetPort(data->async->queue, XTaskQueuePort::Work, &workPort));
         RETURN_IF_FAILED(XTaskQueueCreateComposite(workPort, workPort, &context->internalAsyncBlock.queue));
 

--- a/Source/Global/perform_env.cpp
+++ b/Source/Global/perform_env.cpp
@@ -218,7 +218,7 @@ Result<HC_UNIQUE_PTR<HC_PERFORM_ENV>> HC_PERFORM_ENV::Initialize(HCInitArgs* arg
     return std::move(performEnv);
 }
 
-struct HC_PERFORM_ENV::HttpPerformContext : public std::enable_shared_from_this<HC_PERFORM_ENV::HttpPerformContext>
+struct HC_PERFORM_ENV::HttpPerformContext
 {
     HttpPerformContext(HC_PERFORM_ENV* _env, HCCallHandle _callHandle, XAsyncBlock* _clientAsyncBlock) :
         env{ _env },
@@ -581,8 +581,6 @@ void CALLBACK HC_PERFORM_ENV::ProviderCleanupComplete(XAsyncBlock* async)
 
 bool HC_PERFORM_ENV::CanScheduleProviderCleanup()
 {
-    // mutex should always be held when calling this method
-    assert(!m_mutex.try_lock());
     if (!m_cleanupAsyncBlock)
     {
         // HC_PERFORM_ENV::CleanupAsync has not yet been called

--- a/Source/Global/perform_env.cpp
+++ b/Source/Global/perform_env.cpp
@@ -1,7 +1,7 @@
 #include "pch.h"
 #include "perform_env.h"
 #include "httpcall.h"
-#include "WebSocket\hcwebsocket.h"
+#include "../WebSocket/hcwebsocket.h"
 
 #if HC_PLATFORM == HC_PLATFORM_WIN32
 #include "WebSocket/Websocketpp/websocketpp_websocket.h"

--- a/Source/Global/perform_env.cpp
+++ b/Source/Global/perform_env.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "perform_env.h"
 #include "httpcall.h"
+#include "WebSocket\hcwebsocket.h"
 
 #if HC_PLATFORM == HC_PLATFORM_WIN32
 #include "WebSocket/Websocketpp/websocketpp_websocket.h"
@@ -217,7 +218,7 @@ Result<HC_UNIQUE_PTR<HC_PERFORM_ENV>> HC_PERFORM_ENV::Initialize(HCInitArgs* arg
     return std::move(performEnv);
 }
 
-struct HC_PERFORM_ENV::HttpPerformContext
+struct HC_PERFORM_ENV::HttpPerformContext : public std::enable_shared_from_this<HC_PERFORM_ENV::HttpPerformContext>
 {
     HttpPerformContext(HC_PERFORM_ENV* _env, HCCallHandle _callHandle, XAsyncBlock* _clientAsyncBlock) :
         env{ _env },
@@ -229,23 +230,25 @@ struct HC_PERFORM_ENV::HttpPerformContext
 
     ~HttpPerformContext()
     {
-        XTaskQueueCloseHandle(internalAsyncBlock.queue);
+        if (internalAsyncBlock.queue)
+        {
+            XTaskQueueCloseHandle(internalAsyncBlock.queue);
+        }
     }
 
-    HC_PERFORM_ENV* const env;
-    HCCallHandle const callHandle;
-    XAsyncBlock* const clientAsyncBlock;
-    XAsyncBlock internalAsyncBlock;
+    HC_PERFORM_ENV* env{};
+    HCCallHandle const callHandle{};
+    XAsyncBlock* const clientAsyncBlock{};
+    XAsyncBlock internalAsyncBlock{};
 };
 
 HRESULT HC_PERFORM_ENV::HttpCallPerformAsyncShim(HCCallHandle call, XAsyncBlock* async)
 {
-    auto performContext = http_allocate_shared<HttpPerformContext>(this, call, async);
-    {
-        std::unique_lock<std::mutex> lock{ m_mutex };
-        m_activeHttpRequests[performContext->callHandle] = performContext;
-    }
-    return XAsyncBegin(async, performContext.get(), nullptr, __FUNCTION__, HttpPerformAsyncShimProvider);
+    auto performContext = http_allocate_unique<HttpPerformContext>(this, call, async);
+    RETURN_IF_FAILED(XAsyncBegin(async, performContext.get(), nullptr, __FUNCTION__, HttpPerformAsyncShimProvider));
+    performContext.release();
+
+    return S_OK;
 }
 
 HRESULT CALLBACK HC_PERFORM_ENV::HttpPerformAsyncShimProvider(XAsyncOp op, const XAsyncProviderData* data)
@@ -258,9 +261,12 @@ HRESULT CALLBACK HC_PERFORM_ENV::HttpPerformAsyncShimProvider(XAsyncOp op, const
     case XAsyncOp::Begin:
     {
         XTaskQueuePortHandle workPort{};
-        assert(data->async->queue); // Queue should never be null here
         RETURN_IF_FAILED(XTaskQueueGetPort(data->async->queue, XTaskQueuePort::Work, &workPort));
         RETURN_IF_FAILED(XTaskQueueCreateComposite(workPort, workPort, &performContext->internalAsyncBlock.queue));
+
+        std::unique_lock<std::mutex> lock{ env->m_mutex };
+        env->m_activeHttpRequests.insert(performContext->clientAsyncBlock);
+        lock.unlock();
 
         return performContext->callHandle->PerformAsync(&performContext->internalAsyncBlock);
     }
@@ -272,15 +278,22 @@ HRESULT CALLBACK HC_PERFORM_ENV::HttpPerformAsyncShimProvider(XAsyncOp op, const
     case XAsyncOp::Cleanup:
     {
         std::unique_lock<std::mutex> lock{ env->m_mutex };
-        env->m_activeHttpRequests.erase(performContext->callHandle);
-        bool scheduleCleanup = env->m_activeHttpRequests.empty() && env->m_cleanupAsyncBlock;
+        env->m_activeHttpRequests.erase(performContext->clientAsyncBlock);
+        bool scheduleProviderCleanup = env->CanScheduleProviderCleanup();
         lock.unlock();
 
-        if (scheduleCleanup)
+        // Free performContext before scheduling ProviderCleanup to ensure it happens before returing to client
+        HC_UNIQUE_PTR<HttpPerformContext> reclaim{ performContext };
+        reclaim.reset();
+
+        if (scheduleProviderCleanup)
         {
-            HRESULT hr = XAsyncSchedule(env->m_cleanupAsyncBlock, 0);
-            assert(SUCCEEDED(hr)); // How to handle failure here?
-            UNREFERENCED_LOCAL(hr);
+            HRESULT hr = XTaskQueueSubmitCallback(env->m_cleanupAsyncBlock->queue, XTaskQueuePort::Work, env, ProviderCleanup);
+            if (FAILED(hr))
+            {
+                // This should only fail due to client terminating the queue in which case there isn't anything we can do anyhow
+                HC_TRACE_ERROR_HR(HTTPCLIENT, hr, "Unable to schedule ProviderCleanup");
+            }
         }
         return S_OK;
     }
@@ -294,8 +307,175 @@ HRESULT CALLBACK HC_PERFORM_ENV::HttpPerformAsyncShimProvider(XAsyncOp op, const
 void CALLBACK HC_PERFORM_ENV::HttpPerformComplete(XAsyncBlock* async)
 {
     HttpPerformContext* performContext{ static_cast<HttpPerformContext*>(async->context) };
-    HRESULT hr = XAsyncGetStatus(async, false);
-    XAsyncComplete(performContext->clientAsyncBlock, hr, 0);
+    XAsyncComplete(performContext->clientAsyncBlock, XAsyncGetStatus(async, false), 0);
+}
+
+struct HC_PERFORM_ENV::WebSocketConnectContext
+{
+    WebSocketConnectContext(
+        HC_PERFORM_ENV* _env,
+        http_internal_string&& _uri,
+        http_internal_string&& _subprotocol,
+        HCWebsocketHandle websocketHandle,
+        XAsyncBlock* _clientAsyncBlock
+    ) : env{ _env },
+        uri{ std::move(_uri) },
+        subprotocol{ std::move(_subprotocol) },
+        websocket{ websocketHandle->websocket },
+        clientAsyncBlock{ _clientAsyncBlock },
+        internalAsyncBlock{ nullptr, this, HC_PERFORM_ENV::WebSocketConnectComplete }
+    {
+    }
+
+    ~WebSocketConnectContext()
+    {
+        if (internalAsyncBlock.queue)
+        {
+            XTaskQueueCloseHandle(internalAsyncBlock.queue);
+        }
+    }
+
+    HC_PERFORM_ENV* const env{};
+    http_internal_string uri;
+    http_internal_string subprotocol;  
+    std::shared_ptr<WebSocket> websocket;
+    XAsyncBlock* const clientAsyncBlock;
+    XAsyncBlock internalAsyncBlock{};
+    WebSocketCompletionResult connectResult{};
+};
+
+struct HC_PERFORM_ENV::ActiveWebSocketContext
+{
+    ActiveWebSocketContext(HC_PERFORM_ENV* _env, std::shared_ptr<WebSocket> websocket) :
+        env{ _env },
+        websocketObserver{ HC_WEBSOCKET_OBSERVER::Initialize(std::move(websocket), nullptr, nullptr, nullptr, HC_PERFORM_ENV::WebSocketClosed, this) }
+    {
+    }
+
+    HC_PERFORM_ENV* const env{};
+    HC_UNIQUE_PTR<HC_WEBSOCKET_OBSERVER> websocketObserver;
+};
+
+HRESULT HC_PERFORM_ENV::WebSocketConnectAsyncShim(
+    _In_ http_internal_string&& uri,
+    _In_ http_internal_string&& subprotocol,
+    _In_ HCWebsocketHandle clientWebSocketHandle,
+    _Inout_ XAsyncBlock* asyncBlock
+)
+{
+    auto context = http_allocate_unique<WebSocketConnectContext>(this, std::move(uri), std::move(subprotocol), clientWebSocketHandle, asyncBlock);
+    RETURN_IF_FAILED(XAsyncBegin(asyncBlock, context.get(), (void*)HCWebSocketConnectAsync, nullptr, WebSocketConnectAsyncShimProvider));
+    context.release();
+
+    return S_OK;
+}
+
+HRESULT CALLBACK HC_PERFORM_ENV::WebSocketConnectAsyncShimProvider(XAsyncOp op, const XAsyncProviderData* data)
+{
+    WebSocketConnectContext* context{ static_cast<WebSocketConnectContext*>(data->context) };
+    HC_PERFORM_ENV* env{ context->env };
+
+    switch (op)
+    {
+    case XAsyncOp::Begin:
+    {
+        XTaskQueuePortHandle workPort{};
+        RETURN_IF_FAILED(XTaskQueueGetPort(data->async->queue, XTaskQueuePort::Work, &workPort));
+        RETURN_IF_FAILED(XTaskQueueCreateComposite(workPort, workPort, &context->internalAsyncBlock.queue));
+
+        std::unique_lock<std::mutex> lock{ env->m_mutex };
+        env->m_connectingWebSockets.insert(context->clientAsyncBlock);
+        lock.unlock();
+
+        return context->websocket->ConnectAsync(std::move(context->uri), std::move(context->subprotocol), &context->internalAsyncBlock);
+    }
+    case XAsyncOp::GetResult:
+    {
+        WebSocketCompletionResult* result{ reinterpret_cast<WebSocketCompletionResult*>(data->buffer) };
+        *result = context->connectResult;
+        return S_OK;
+    }
+    case XAsyncOp::Cleanup:
+    {
+        HC_UNIQUE_PTR<WebSocketConnectContext> reclaim{ context };
+        return S_OK;
+    }
+    default:
+    {
+        return S_OK;
+    }
+    }
+}
+
+void CALLBACK HC_PERFORM_ENV::WebSocketConnectComplete(XAsyncBlock* async)
+{
+    WebSocketConnectContext* context{ static_cast<WebSocketConnectContext*>(async->context) };
+    HC_PERFORM_ENV* env{ context->env };
+
+    std::unique_lock<std::mutex> lock{ env->m_mutex };
+    env->m_connectingWebSockets.erase(context->clientAsyncBlock);
+
+    // If cleanup is pending and the connect succeeded, immediately disconnect
+    bool disconnect{ false };
+
+    HRESULT hr = HCGetWebSocketConnectResult(&context->internalAsyncBlock, &context->connectResult);
+    if (SUCCEEDED(hr) && SUCCEEDED(context->connectResult.errorCode))
+    {
+        env->m_connectedWebSockets.insert(new (http_stl_allocator<ActiveWebSocketContext>{}.allocate(1)) ActiveWebSocketContext{ env, context->websocket });
+        if (env->m_cleanupAsyncBlock)
+        {
+            disconnect = true;
+        }
+    } 
+    
+    bool scheduleProviderCleanup = env->CanScheduleProviderCleanup();
+    lock.unlock();
+
+    assert(!scheduleProviderCleanup || !disconnect);
+    if (disconnect)
+    {
+        hr = context->websocket->Disconnect();
+        if (FAILED(hr))
+        {
+            HC_TRACE_ERROR_HR(HTTPCLIENT, hr, "WebSocket::Disconnect failed during HCCleanup");
+        }
+    }
+    else if (scheduleProviderCleanup)
+    {
+        hr = XTaskQueueSubmitCallback(env->m_cleanupAsyncBlock->queue, XTaskQueuePort::Work, env, ProviderCleanup);
+        if (FAILED(hr))
+        {
+            // This should only fail due to client terminating the queue in which case there isn't anything we can do anyhow
+            HC_TRACE_ERROR_HR(HTTPCLIENT, hr, "Unable to schedule ProviderCleanup");
+        }
+    }
+
+    XAsyncComplete(context->clientAsyncBlock, hr, sizeof(WebSocketCompletionResult));
+}
+
+void CALLBACK HC_PERFORM_ENV::WebSocketClosed(HCWebsocketHandle /*websocket*/, HCWebSocketCloseStatus /*closeStatus*/, void* c)
+{
+    ActiveWebSocketContext* context{ static_cast<ActiveWebSocketContext*>(c) };
+    HC_PERFORM_ENV* env{ context->env };
+
+    std::unique_lock<std::mutex> lock{ env->m_mutex };
+    env->m_connectedWebSockets.erase(context);
+    bool scheduleProviderCleanup = env->CanScheduleProviderCleanup();
+    lock.unlock();
+
+    // Free context before scheduling ProviderCleanup to ensure it happens before returing to client
+    HC_UNIQUE_PTR<ActiveWebSocketContext> reclaim{ context };
+    reclaim.reset();    
+
+    if (scheduleProviderCleanup)
+    {
+        HRESULT hr = XTaskQueueSubmitCallback(env->m_cleanupAsyncBlock->queue, XTaskQueuePort::Work, env, ProviderCleanup);
+        if (FAILED(hr))
+        {
+            // This should only fail due to client terminating the queue in which case there isn't anything we can do anyhow
+            HC_TRACE_ERROR_HR(HTTPCLIENT, hr, "Unable to schedule ProviderCleanup");
+        }
+    }
 }
 
 HRESULT HC_PERFORM_ENV::CleanupAsync(HC_UNIQUE_PTR<HC_PERFORM_ENV>&& env, XAsyncBlock* async) noexcept
@@ -315,58 +495,107 @@ HRESULT CALLBACK HC_PERFORM_ENV::CleanupAsyncProvider(XAsyncOp op, const XAsyncP
     {
         std::unique_lock<std::mutex> lock{ env->m_mutex };
         env->m_cleanupAsyncBlock = data->async;
-
-        bool haveActiveHttpRequests{ !env->m_activeHttpRequests.empty() };
+        bool scheduleProviderCleanup = env->CanScheduleProviderCleanup();
 
         for (auto& activeRequest : env->m_activeHttpRequests)
         {
-            XAsyncCancel(&activeRequest.second->internalAsyncBlock);
+            XAsyncCancel(activeRequest);
+        }
+        for (auto& context : env->m_connectedWebSockets)
+        {
+            HRESULT hr = context->websocketObserver->websocket->Disconnect();
+            if (FAILED(hr))
+            {
+                HC_TRACE_ERROR_HR(HTTPCLIENT, hr, "WebSocket::Disconnect failed during HCCleanup");
+            }
         }
         lock.unlock();
 
-        if (haveActiveHttpRequests)
+        if (scheduleProviderCleanup)
         {
-            return S_OK;
+            return XTaskQueueSubmitCallback(data->async->queue, XTaskQueuePort::Work, env, ProviderCleanup);
         }
-        else
-        {
-            return XAsyncSchedule(data->async, 0);
-        }
-    }
-    case XAsyncOp::DoWork:
-    {
-        HC_UNIQUE_PTR<HC_PERFORM_ENV> reclaim{ env };
-#if HC_PLATFORM == HC_PLATFORM_GDK
-        auto curlCleanupAsyncBlock = http_allocate_unique<XAsyncBlock>();
-        curlCleanupAsyncBlock->queue = data->async->queue;
-        curlCleanupAsyncBlock->context = data->async;
-        curlCleanupAsyncBlock->callback = [](XAsyncBlock* async)
-        {
-            HC_UNIQUE_PTR<XAsyncBlock> curlCleanupAsyncBlock{ async };
-            XAsyncBlock* envCleanupAsyncBlock = static_cast<XAsyncBlock*>(curlCleanupAsyncBlock->context);
-            
-            HRESULT cleanupResult = XAsyncGetStatus(curlCleanupAsyncBlock.get(), false);
-            curlCleanupAsyncBlock.reset();
-
-            // HC_PERFORM_ENV fully cleaned up at this point
-            XAsyncComplete(envCleanupAsyncBlock, cleanupResult, 0);
-        };
-
-        auto curlProvider = std::move(env->curlProvider);       
-        reclaim.reset();
-
-        RETURN_IF_FAILED(CurlProvider::CleanupAsync(std::move(curlProvider), curlCleanupAsyncBlock.get()));
-        curlCleanupAsyncBlock.release();
-        return E_PENDING;
-#else
-        reclaim.reset();
-        XAsyncComplete(data->async, S_OK, 0);
         return S_OK;
-#endif
     }
     default:
     {
         return S_OK;
     }
     }
+}
+
+void CALLBACK HC_PERFORM_ENV::ProviderCleanup(void* context, bool /*canceled*/)
+{
+    HC_UNIQUE_PTR<HC_PERFORM_ENV> env{ static_cast<HC_PERFORM_ENV*>(context) };
+    XAsyncBlock* cleanupAsyncBlock{ env->m_cleanupAsyncBlock };
+
+#if HC_PLATFORM == HC_PLATFORM_GDK
+    HC_UNIQUE_PTR<XAsyncBlock> curlCleanupAsyncBlock{ new (http_stl_allocator<XAsyncBlock>{}.allocate(1)) XAsyncBlock
+    {
+        cleanupAsyncBlock->queue,
+        cleanupAsyncBlock,
+        ProviderCleanupComplete
+    }};
+
+    auto curlProvider = std::move(env->curlProvider);
+    env.reset();
+
+    HRESULT hr = CurlProvider::CleanupAsync(std::move(curlProvider), curlCleanupAsyncBlock.get());
+    if (FAILED(hr))
+    {
+        XAsyncComplete(cleanupAsyncBlock, hr, 0);
+    }
+    else
+    {
+        curlCleanupAsyncBlock.release();
+    }
+#else
+    // No additional provider cleanup needed
+    env.reset();
+    XAsyncComplete(cleanupAsyncBlock, S_OK, 0);
+#endif
+}
+
+void CALLBACK HC_PERFORM_ENV::ProviderCleanupComplete(XAsyncBlock* async)
+{
+#if HC_PLATFORM == HC_PLATFORM_GDK
+    HC_UNIQUE_PTR<XAsyncBlock> curlCleanupAsyncBlock{ async };
+    XAsyncBlock* envCleanupAsyncBlock = static_cast<XAsyncBlock*>(curlCleanupAsyncBlock->context);
+
+    HRESULT cleanupResult = XAsyncGetStatus(curlCleanupAsyncBlock.get(), false);
+    curlCleanupAsyncBlock.reset();
+
+    // HC_PERFORM_ENV fully cleaned up at this point
+    XAsyncComplete(envCleanupAsyncBlock, cleanupResult, 0);
+#else
+    UNREFERENCED_PARAMETER(async);
+    assert(false);
+#endif
+}
+
+bool HC_PERFORM_ENV::CanScheduleProviderCleanup()
+{
+    // mutex should always be held when calling this method
+    assert(!m_mutex.try_lock());
+    if (!m_cleanupAsyncBlock)
+    {
+        // HC_PERFORM_ENV::CleanupAsync has not yet been called
+        return false;
+    }
+    else if (!m_activeHttpRequests.empty())
+    {
+        // Pending Http Requests
+        return false;
+    }
+    else if (!m_connectingWebSockets.empty())
+    {
+        // Pending WebSocket Connect operations
+        return false;
+    }
+    else if (!m_connectedWebSockets.empty())
+    {
+        // Pending WebSocket CloseFunc callbacks
+        return false;
+    }
+    return true;
 }

--- a/Source/Global/perform_env.h
+++ b/Source/Global/perform_env.h
@@ -65,12 +65,14 @@ public:
 
     HRESULT HttpCallPerformAsyncShim(HCCallHandle call, XAsyncBlock* async);
 
+#if !HC_NOWEBSOCKETS
     HRESULT WebSocketConnectAsyncShim(
         _In_ http_internal_string&& uri,
         _In_ http_internal_string&& subProtocol,
         _In_ HCWebsocketHandle handle,
         _Inout_ XAsyncBlock* asyncBlock
     );
+#endif
 
     static HRESULT CleanupAsync(HC_UNIQUE_PTR<HC_PERFORM_ENV>&& env, XAsyncBlock* async) noexcept;
 
@@ -89,9 +91,11 @@ private:
     static HRESULT CALLBACK HttpPerformAsyncShimProvider(XAsyncOp op, const XAsyncProviderData* data);
     static void CALLBACK HttpPerformComplete(XAsyncBlock* async);
 
+#if !HC_NOWEBSOCKETS
     static HRESULT CALLBACK WebSocketConnectAsyncShimProvider(XAsyncOp op, const XAsyncProviderData* data);
     static void CALLBACK WebSocketConnectComplete(XAsyncBlock* async);
     static void CALLBACK WebSocketClosed(HCWebsocketHandle websocket, HCWebSocketCloseStatus closeStatus, void* context);
+#endif
 
     static HRESULT CALLBACK CleanupAsyncProvider(XAsyncOp op, const XAsyncProviderData* data);  
     static void CALLBACK ProviderCleanup(void* context, bool canceled);
@@ -104,10 +108,12 @@ private:
     struct HttpPerformContext;
     http_internal_set<XAsyncBlock*> m_activeHttpRequests;
 
+#if !HC_NOWEBSOCKETS
     struct WebSocketConnectContext;
     struct ActiveWebSocketContext;
     http_internal_set<XAsyncBlock*> m_connectingWebSockets;
     http_internal_set<ActiveWebSocketContext*> m_connectedWebSockets;
+#endif
 
     XAsyncBlock* m_cleanupAsyncBlock{ nullptr }; // non-owning
 };

--- a/Source/HTTP/WinHttp/winhttp_connection.h
+++ b/Source/HTTP/WinHttp/winhttp_connection.h
@@ -9,6 +9,9 @@
 #if HC_PLATFORM == HC_PLATFORM_GDK
 #include <XNetworking.h>
 #endif
+#if !HC_NOWEBSOCKETS
+#include "WebSocket/hcwebsocket.h"
+#endif
 
 NAMESPACE_XBOX_HTTP_CLIENT_BEGIN
 
@@ -147,6 +150,8 @@ public:
     static Result<std::shared_ptr<WinHttpConnection>> Initialize(
         HINTERNET hSession,
         HCWebsocketHandle webSocket,
+        const char* uri,
+        const char* subprotocol,
         proxy_type proxyType,
         XPlatSecurityInformation&& securityInformation
     );

--- a/Source/HTTP/httpcall.cpp
+++ b/Source/HTTP/httpcall.cpp
@@ -54,9 +54,18 @@ struct PerformContext
 
     ~PerformContext()
     {
-        HCHttpCallCloseHandle(call);
-        XTaskQueueCloseHandle(workQueue);
-        XTaskQueueCloseHandle(providerQueue);
+        if (call)
+        {
+            HCHttpCallCloseHandle(call);
+        }
+        if (workQueue)
+        {
+            XTaskQueueCloseHandle(workQueue);
+        }
+        if (providerQueue)
+        {
+            XTaskQueueCloseHandle(providerQueue);
+        }
     }
 
     HC_CALL* call{ nullptr };

--- a/Source/HTTP/httpcall.h
+++ b/Source/HTTP/httpcall.h
@@ -110,6 +110,6 @@ private:
     uint32_t m_iterationNumber{ 0 };  
 
     HttpPerformInfo m_performInfo;
-    HC_PERFORM_ENV* m_performEnv; // non-owning
+    HC_PERFORM_ENV* m_performEnv{ nullptr }; // non-owning
 };
 

--- a/Source/HTTP/httpcall_publics.cpp
+++ b/Source/HTTP/httpcall_publics.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "httpClient.h"
 #include "httpcall.h"
 
 using namespace xbox::httpclient;

--- a/Source/HTTP/httpcall_publics.cpp
+++ b/Source/HTTP/httpcall_publics.cpp
@@ -1,5 +1,4 @@
 #include "pch.h"
-#include "httpClient.h"
 #include "httpcall.h"
 
 using namespace xbox::httpclient;

--- a/Source/WebSocket/hcwebsocket.cpp
+++ b/Source/WebSocket/hcwebsocket.cpp
@@ -1,5 +1,10 @@
+// Copyright (c) Microsoft Corporation
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 #include "pch.h"
 #include "hcwebsocket.h"
+
+#if !HC_NOWEBSOCKETS
 
 using namespace xbox::httpclient;
 
@@ -510,3 +515,5 @@ void WebSocket::NotifyWebSocketRoutedHandlers(
 
 } // namespace httpclient
 } // namespace xbox
+
+#endif

--- a/Source/WebSocket/hcwebsocket.cpp
+++ b/Source/WebSocket/hcwebsocket.cpp
@@ -1,371 +1,340 @@
-// Copyright (c) Microsoft Corporation
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
 #include "pch.h"
-
-#if !HC_NOWEBSOCKETS
-
 #include "hcwebsocket.h"
 
 using namespace xbox::httpclient;
 
 #define WEBSOCKET_RECVBUFFER_MAXSIZE_DEFAULT (1024 * 20)
 
-HC_WEBSOCKET::HC_WEBSOCKET(
-    _In_ uint64_t _id,
+HC_WEBSOCKET_OBSERVER::HC_WEBSOCKET_OBSERVER(std::shared_ptr<xbox::httpclient::WebSocket> websocket) : websocket{ std::move(websocket) }
+{
+}
+
+HC_WEBSOCKET_OBSERVER::~HC_WEBSOCKET_OBSERVER()
+{
+    HC_TRACE_VERBOSE(WEBSOCKET, __FUNCTION__);
+
+    websocket->UnregisterEventCallbacks(m_handlerToken);
+}
+
+HC_UNIQUE_PTR<HC_WEBSOCKET_OBSERVER> HC_WEBSOCKET_OBSERVER::Initialize(
+    _In_ std::shared_ptr<xbox::httpclient::WebSocket> websocket,
     _In_opt_ HCWebSocketMessageFunction messageFunc,
     _In_opt_ HCWebSocketBinaryMessageFunction binaryMessageFunc,
+    _In_opt_ HCWebSocketBinaryMessageFragmentFunction binaryFragmentFunc,
     _In_opt_ HCWebSocketCloseEventFunction closeFunc,
-    _In_opt_ void* functionContext
-) :
+    _In_opt_ void* callbackContext
+)
+{
+    http_stl_allocator<HC_WEBSOCKET_OBSERVER> a{};
+    HC_UNIQUE_PTR<HC_WEBSOCKET_OBSERVER> observer{ new (a.allocate(1)) HC_WEBSOCKET_OBSERVER{ std::move(websocket) } };
+
+    observer->m_messageFunc = messageFunc;
+    observer->m_binaryMessageFunc = binaryMessageFunc;
+    observer->m_binaryFragmentFunc = binaryFragmentFunc;
+    observer->m_closeFunc = closeFunc;
+    observer->m_callbackContext = callbackContext;
+    observer->m_handlerToken = observer->websocket->RegisterEventCallbacks(messageFunc, binaryMessageFunc, binaryFragmentFunc, closeFunc, callbackContext);
+
+    return observer;
+}
+
+void HC_WEBSOCKET_OBSERVER::SetBinaryMessageFragmentEventFunction(HCWebSocketBinaryMessageFragmentFunction binaryFragmentFunc)
+{  
+    websocket->UnregisterEventCallbacks(m_handlerToken);
+    m_binaryFragmentFunc = binaryFragmentFunc;
+    m_handlerToken = websocket->RegisterEventCallbacks(m_messageFunc, m_binaryMessageFunc, m_binaryFragmentFunc, m_closeFunc, m_callbackContext);
+}
+
+namespace xbox
+{
+namespace httpclient
+{
+
+WebSocket::WebSocket(uint64_t _id, WebSocketPerformInfo performInfo, HC_PERFORM_ENV* performEnv) :
     id{ _id },
-    m_clientMessageFunc{ messageFunc },
-    m_clientBinaryMessageFunc{ binaryMessageFunc },
-    m_clientCloseEventFunc{ closeFunc },
-    m_clientContext{ functionContext },
-    m_maxReceiveBufferSize{ WEBSOCKET_RECVBUFFER_MAXSIZE_DEFAULT }
+    m_performInfo{ performInfo },
+    m_performEnv{ performEnv }
 {
 }
 
-HC_WEBSOCKET::~HC_WEBSOCKET()
+WebSocket::~WebSocket()
 {
-#if !HC_NOWEBSOCKETS
-    HC_TRACE_VERBOSE(WEBSOCKET, "HCWebsocketHandle dtor");
-#endif
+    HC_TRACE_VERBOSE(WEBSOCKET, __FUNCTION__);
 }
 
-HRESULT HC_WEBSOCKET::Connect(
-    _In_z_ const char* uri,
-    _In_z_ const char* subProtocol,
+Result<std::shared_ptr<WebSocket>> WebSocket::Initialize()
+{
+    auto httpSingleton = get_http_singleton();
+    RETURN_HR_IF(E_HC_NOT_INITIALISED, !httpSingleton);
+
+    http_stl_allocator<WebSocket> a{};
+    std::shared_ptr<WebSocket> websocket{ new (a.allocate(1)) WebSocket
+    {
+        ++httpSingleton->m_lastId,
+        httpSingleton->m_websocketPerform,
+        httpSingleton->m_performEnv.get()
+    }, http_alloc_deleter<WebSocket>{} };
+
+    return websocket;
+}
+
+uint32_t WebSocket::RegisterEventCallbacks(
+    _In_opt_ HCWebSocketMessageFunction messageFunc,
+    _In_opt_ HCWebSocketBinaryMessageFunction binaryMessageFunc,
+    _In_opt_ HCWebSocketBinaryMessageFragmentFunction binaryFragmentFunc,
+    _In_opt_ HCWebSocketCloseEventFunction closeFunc,
+    _In_opt_ void* callbackContext
+)
+{
+    std::unique_lock<std::mutex> lock{ m_mutex };
+    m_eventCallbacks[m_nextToken] = EventCallbacks{ messageFunc, binaryMessageFunc, binaryFragmentFunc, closeFunc, callbackContext };
+    return m_nextToken++;
+}
+
+void WebSocket::UnregisterEventCallbacks(uint32_t registrationToken)
+{
+    std::unique_lock<std::mutex> lock{ m_mutex };
+    m_eventCallbacks.erase(registrationToken);
+}
+
+// Context for ConnectAsync operation. Ensures lifetime until Connect operation completes
+struct WebSocket::ConnectContext
+{
+    ConnectContext(std::shared_ptr<WebSocket> websocket, XAsyncBlock* async) :
+        observer{ HC_WEBSOCKET_OBSERVER::Initialize(std::move(websocket)) },
+        clientAsyncBlock{ async },
+        internalAsyncBlock{ nullptr, this, WebSocket::ConnectComplete }
+    {
+    }
+
+    ~ConnectContext()
+    {
+        if (internalAsyncBlock.queue)
+        {
+            XTaskQueueCloseHandle(internalAsyncBlock.queue);
+        }
+    }
+
+    HC_UNIQUE_PTR<HC_WEBSOCKET_OBSERVER> observer{ nullptr };
+    XAsyncBlock* const clientAsyncBlock;
+    XAsyncBlock internalAsyncBlock;
+    WebSocketCompletionResult result{};
+};
+
+// Context for Provider event callbacks. Ensure's lifetime as long as the WebSocket is connected (until CloseFunc is called)
+struct WebSocket::ProviderContext
+{
+    HC_UNIQUE_PTR<HC_WEBSOCKET_OBSERVER> observer{ nullptr };
+};
+
+HRESULT WebSocket::ConnectAsync(
+    _In_ http_internal_string&& uri,
+    _In_ http_internal_string&& subProtocol,
     _Inout_ XAsyncBlock* asyncBlock
 ) noexcept
 {
-    auto httpSingleton = get_http_singleton();
-    if (!httpSingleton)
+    m_uri = std::move(uri);
+    m_subProtocol = std::move(subProtocol);
+
+    auto context = http_allocate_unique<ConnectContext>(shared_from_this(), asyncBlock);
+    RETURN_IF_FAILED(XAsyncBegin(asyncBlock, context.get(), (void*)HCWebSocketConnectAsync, nullptr, ConnectAsyncProvider));
+    context.release();
+    return S_OK;
+}
+
+HRESULT CALLBACK WebSocket::ConnectAsyncProvider(XAsyncOp op, XAsyncProviderData const* data)
+{
+    ConnectContext* context{ static_cast<ConnectContext*>(data->context) };
+    auto& ws{ context->observer->websocket };
+
+    switch (op)
     {
-        return E_HC_NOT_INITIALISED;
-    }
-
-    if (m_state != State::Initial)
+    case XAsyncOp::Begin:
     {
-        return E_UNEXPECTED;
-    }
+        std::unique_lock<std::mutex> lock{ ws->m_mutex };
 
-    m_uri = uri;
-    m_subProtocol = subProtocol;
+        RETURN_HR_IF(E_UNEXPECTED, !ws->m_performInfo.connect);
+        RETURN_HR_IF(E_UNEXPECTED, ws->m_state != State::Initial);
 
-    WebSocketPerformInfo const& info = httpSingleton->m_websocketPerform;
+        XTaskQueuePortHandle workPort{ nullptr };
+        XTaskQueueGetPort(data->async->queue, XTaskQueuePort::Work, &workPort);
+        XTaskQueueCreateComposite(workPort, workPort, &context->internalAsyncBlock.queue);
 
-    auto connectFunc = info.connect;
-    if (connectFunc != nullptr)
-    {
+        ws->m_state = State::Connecting;
+        lock.unlock();
+
         try
         {
-            // Trap the result of the connect before returning to client. Otherwise we have no way of knowing
-            // if we are in a connected state. This also helps us handle proper disconnection if we were connecting,
-            // when the client closed their handle.
-
-            ZeroMemory(&m_connectAsyncBlock, sizeof(XAsyncBlock));
-            m_connectAsyncBlock.queue = asyncBlock->queue;
-            m_connectAsyncBlock.context = this;
-            m_connectAsyncBlock.callback = [](XAsyncBlock* async)
-            {
-                auto thisPtr{ static_cast<HC_WEBSOCKET*>(async->context) };
-                HRESULT hr = HCGetWebSocketConnectResult(async, &thisPtr->m_connectResult);
-
-                // We auto disconnect if the client has already closed all handles.
-                bool doDisconnect{ false };
-
-                // We release the provider's reference if we don't expect any more callbacks from the WebSocket provider.
-                bool doDecRef { false };
-                {
-                    std::lock_guard<std::recursive_mutex> lock{ thisPtr->m_mutex };
-
-                    if (thisPtr->m_state != State::Connecting)
-                    {
-                        hr = E_UNEXPECTED;
-                    }
-
-                    if (SUCCEEDED(hr) && SUCCEEDED(thisPtr->m_connectResult.errorCode))
-                    {
-                        if (thisPtr->m_clientRefCount > 0)
-                        {
-                            thisPtr->m_state = State::Connected;
-                        }
-                        else
-                        {
-                            doDisconnect = true;
-                        }
-                    }
-                    else
-                    {
-                        HC_TRACE_INFORMATION(WEBSOCKET, "Websocket connection attempt failed");
-
-                        // Release providers ref if connect fails. We do not expect a close event in this case.
-                        thisPtr->m_state = State::Disconnected;
-                        doDecRef = true;
-                    }
-                }
-
-                if (doDisconnect)
-                {
-                    thisPtr->Disconnect();
-                }
-
-                if (doDecRef)
-                {
-                    thisPtr->DecRef();
-                }
-
-                XAsyncComplete(thisPtr->m_clientConnectAsyncBlock, hr, sizeof(WebSocketCompletionResult));
-            };
-
-            m_clientConnectAsyncBlock = asyncBlock;
-            XAsyncBegin(m_clientConnectAsyncBlock, this, (void*)HCWebSocketConnectAsync, __FUNCTION__,
-                [](XAsyncOp op, const XAsyncProviderData* data)
-                {
-                    auto thisPtr{ static_cast<HC_WEBSOCKET*>(data->context) };
-
-                    switch (op)
-                    {
-                    case XAsyncOp::DoWork: return E_PENDING;
-                    case XAsyncOp::GetResult:
-                    {
-                        auto clientResult{ reinterpret_cast<WebSocketCompletionResult*>(data->buffer) };
-                        *clientResult = thisPtr->m_connectResult;
-                    }
-                    default: return S_OK;
-                    }
-                }
-            );
-
-            HRESULT hr = connectFunc(uri, subProtocol, this, &m_connectAsyncBlock, info.context, httpSingleton->m_performEnv.get());
-
-            if (SUCCEEDED(hr))
-            {
-                {
-                    std::lock_guard<std::recursive_mutex> lock{ m_mutex };
-                    m_state = State::Connecting;
-                }
-                // Add a ref for the provider. This guarantees the HC_WEBSOCKET is alive until disconnect.
-                AddRef();
-            }
-            return hr;
+            return ws->m_performInfo.connect(ws->m_uri.data(), ws->m_subProtocol.data(), context->observer.get(), &context->internalAsyncBlock, ws->m_performInfo.context, ws->m_performEnv);
         }
         catch (...)
         {
-            HC_TRACE_ERROR(WEBSOCKET, "HCWebSocketConnect [ID %llu]: failed", TO_ULL(id));
+            HC_TRACE_ERROR(WEBSOCKET, "Caught unhandled exception in HCWebSocketConnectFunction [ID %llu]", TO_ULL(ws->id));
             return E_FAIL;
         }
     }
+    case XAsyncOp::GetResult:
+    {
+        WebSocketCompletionResult* result{ reinterpret_cast<WebSocketCompletionResult*>(data->buffer) };
+        *result = context->result;
+        return S_OK;
+    }
+    case XAsyncOp::Cleanup:
+    {
+        HC_UNIQUE_PTR<ConnectContext> reclaim{ context };
+        return S_OK;
+    }
+    default:
+    {
+        return S_OK;
+    }
+    }
+}
+
+void CALLBACK WebSocket::ConnectComplete(XAsyncBlock* async)
+{
+    ConnectContext* context{ static_cast<ConnectContext*>(async->context) };
+    auto& ws{ context->observer->websocket };
+
+    assert(ws->m_state == State::Connecting);
+
+    HRESULT hr = HCGetWebSocketConnectResult(&context->internalAsyncBlock, &context->result);
+
+    std::unique_lock<std::mutex> lock{ ws->m_mutex };
+    if (SUCCEEDED(hr) && SUCCEEDED(context->result.errorCode))
+    {
+        // Connect was sucessful. Allocate ProviderContext to ensure WebSocket lifetime until it is reclaimed in WebSocket::CloseFunc
+        ws->m_state = State::Connected;
+        ws->m_providerContext = new (http_stl_allocator<ProviderContext>{}.allocate(1)) ProviderContext{ std::move(context->observer) };
+    }
     else
     {
-        HC_TRACE_ERROR(WEBSOCKET, "HC_WEBSOCKET::Connect [ID %llu]: Websocket connect implementation not found!", TO_ULL(id));
-        return E_UNEXPECTED;
+        ws->m_state = State::Disconnected;
     }
+    lock.unlock();
+
+    XAsyncComplete(context->clientAsyncBlock, hr, sizeof(WebSocketCompletionResult));
 }
 
-void notify_websocket_routed_handlers(
-    std::shared_ptr<http_singleton> httpSingleton,
-    _In_ HCWebsocketHandle websocket,
-    _In_ bool receiving,
-    _In_opt_z_ const char* message,
-    _In_opt_ const uint8_t* payloadBytes,
-    _In_ size_t payloadSize
-    )
-{
-    if (httpSingleton == nullptr)
-    {
-        return;
-    }
-
-    std::lock_guard<std::recursive_mutex> lock(httpSingleton->m_callRoutedHandlersLock);
-    for (const auto& pair : httpSingleton->m_webSocketRoutedHandlers)
-    {
-        pair.second.first(
-            websocket,
-            receiving,
-            message,
-            payloadBytes,
-            payloadSize,
-            pair.second.second);
-    }
-}
-
-HRESULT HC_WEBSOCKET::Send(
+HRESULT WebSocket::SendAsync(
     _In_z_ const char* message,
     _Inout_ XAsyncBlock* asyncBlock
 ) noexcept
 {
-    auto httpSingleton = get_http_singleton();
-    if (nullptr == httpSingleton)
-    {
-        return E_HC_NOT_INITIALISED;
-    }
+    RETURN_HR_IF(E_UNEXPECTED, m_state != State::Connected);
+    RETURN_HR_IF(E_UNEXPECTED, !m_providerContext);
+    RETURN_HR_IF(E_UNEXPECTED, !m_performInfo.sendText);
 
-    if (m_state != State::Connected)
+    try
     {
-        return E_UNEXPECTED;
+        NotifyWebSocketRoutedHandlers(m_providerContext->observer.get(), false, message, nullptr, 0);
+        return m_performInfo.sendText(m_providerContext->observer.get(), message, asyncBlock, m_performInfo.context);
     }
-
-    WebSocketPerformInfo const& info = httpSingleton->m_websocketPerform;
-
-    auto sendFunc = info.sendText;
-    if (sendFunc != nullptr)
+    catch (...)
     {
-        try
-        {
-            notify_websocket_routed_handlers(httpSingleton, this, false, message, nullptr, 0);
-            return sendFunc(this, message, asyncBlock, info.context);
-        }
-        catch (...)
-        {
-            HC_TRACE_ERROR(WEBSOCKET, "HCWebSocketSendMessage [ID %llu]: failed", TO_ULL(id));
-            return E_FAIL;
-        }
+        HC_TRACE_ERROR(WEBSOCKET, "Caught unhandled exception in HCWebSocketSendMessageFunction [ID %llu]", TO_ULL(id));
+        return E_FAIL;
     }
-    else
-    {
-        HC_TRACE_ERROR(WEBSOCKET, "HC_WEBSOCKET::Send [ID %llu]: Websocket send implementation not found!", TO_ULL(id));
-        return E_UNEXPECTED;
-    }
-    return S_OK;
 }
 
-HRESULT HC_WEBSOCKET::SendBinary(
+HRESULT WebSocket::SendBinaryAsync(
     _In_reads_bytes_(payloadSize) const uint8_t* payloadBytes,
     _In_ uint32_t payloadSize,
     _Inout_ XAsyncBlock* asyncBlock
 ) noexcept
 {
-    auto httpSingleton = get_http_singleton();
-    if (nullptr == httpSingleton)
-    {
-        return E_HC_NOT_INITIALISED;
-    }
+    RETURN_HR_IF(E_UNEXPECTED, m_state != State::Connected);
+    RETURN_HR_IF(E_UNEXPECTED, !m_providerContext);
+    RETURN_HR_IF(E_UNEXPECTED, !m_performInfo.sendBinary);
 
-    if (m_state != State::Connected)
+    try
     {
-        return E_UNEXPECTED;
+        NotifyWebSocketRoutedHandlers(m_providerContext->observer.get(), false, nullptr, payloadBytes, payloadSize);
+        return m_performInfo.sendBinary(m_providerContext->observer.get(), payloadBytes, payloadSize, asyncBlock, m_performInfo.context);
     }
-
-    WebSocketPerformInfo const& info = httpSingleton->m_websocketPerform;
-
-    auto sendFunc = info.sendBinary;
-    if (sendFunc != nullptr)
+    catch (...)
     {
-        try
-        {
-            notify_websocket_routed_handlers(httpSingleton, this, false, nullptr, payloadBytes, payloadSize);
-            return sendFunc(this, payloadBytes, payloadSize, asyncBlock, info.context);
-        }
-        catch (...)
-        {
-            HC_TRACE_ERROR(WEBSOCKET, "HCWebSocketSendBinaryMessageAsync [ID %llu]: failed", TO_ULL(id));
-            return E_FAIL;
-        }
-    }
-    else
-    {
-        HC_TRACE_ERROR(WEBSOCKET, "HC_WEBSOCKET::Send [ID %llu]: Websocket send implementation not found!", TO_ULL(id));
-        return E_UNEXPECTED;
+        HC_TRACE_ERROR(WEBSOCKET, "Caught unhandled exception in HCWebSocketSendBinaryMessageFunction [ID %llu]", TO_ULL(id));
+        return E_FAIL;
     }
 }
 
-HRESULT HC_WEBSOCKET::Disconnect()
+HRESULT WebSocket::Disconnect()
 {
-    auto httpSingleton = get_http_singleton();
-    if (nullptr == httpSingleton)
-    {
-        return E_HC_NOT_INITIALISED;
-    }
+    RETURN_HR_IF(E_UNEXPECTED, !m_providerContext);
+    RETURN_HR_IF(E_UNEXPECTED, !m_performInfo.disconnect);
 
-    if (m_state != State::Connected)
-    {
-        return E_UNEXPECTED;
-    }
+    std::unique_lock<std::mutex> lock{ m_mutex };
+    RETURN_HR_IF(S_OK, m_state == State::Disconnecting);
+    RETURN_HR_IF(E_UNEXPECTED, m_state != State::Connected);
+    
+    m_state = State::Disconnecting;
+    lock.unlock();
 
-    WebSocketPerformInfo const& info = httpSingleton->m_websocketPerform;
-
-    auto disconnectFunc = info.disconnect;
-    if (disconnectFunc != nullptr)
+    try
     {
-        try
-        {
-            HRESULT hr = disconnectFunc(this, HCWebSocketCloseStatus::Normal, info.context);
-            if (SUCCEEDED(hr))
-            {
-                std::lock_guard<std::recursive_mutex> lock{ m_mutex };
-                m_state = State::Disconnecting;
-            }
-            return hr;
-        }
-        catch (...)
-        {
-            HC_TRACE_ERROR(WEBSOCKET, "HCWebSocketClose [ID %llu]: failed", TO_ULL(id));
-            return E_FAIL;
-        }
+        return m_performInfo.disconnect(m_providerContext->observer.get(), HCWebSocketCloseStatus::Normal, m_performInfo.context);
     }
-    else
+    catch (...)
     {
-        HC_TRACE_ERROR(WEBSOCKET, "HC_WEBSOCKET::Disconnect [ID %llu]: Websocket disconnect implementation not found!", TO_ULL(id));
-        return E_UNEXPECTED;
+        HC_TRACE_ERROR(WEBSOCKET, "Caught unhandled exception in HCWebSocketDisconnectFunction [ID %llu]", TO_ULL(id));
+        return E_FAIL;
     }
 }
 
-const HttpHeaders& HC_WEBSOCKET::Headers() const noexcept
-{
-    return m_connectHeaders;
-}
-
-const http_internal_string& HC_WEBSOCKET::ProxyUri() const noexcept
-{
-    return m_proxyUri;
-}
-
-const bool HC_WEBSOCKET::ProxyDecryptsHttps() const noexcept
-{
-    return m_allowProxyToDecryptHttps;
-}
-
-const http_internal_string& HC_WEBSOCKET::Uri() const noexcept
+const http_internal_string& WebSocket::Uri() const noexcept
 {
     return m_uri;
 }
 
-const http_internal_string& HC_WEBSOCKET::SubProtocol() const noexcept
+const http_internal_string& WebSocket::SubProtocol() const noexcept
 {
     return m_subProtocol;
 }
 
-size_t HC_WEBSOCKET::MaxReceiveBufferSize() const noexcept
+const HttpHeaders& WebSocket::Headers() const noexcept
+{
+    return m_connectHeaders;
+}
+
+const http_internal_string& WebSocket::ProxyUri() const noexcept
+{
+    return m_proxyUri;
+}
+
+const bool WebSocket::ProxyDecryptsHttps() const noexcept
+{
+    return m_allowProxyToDecryptHttps;
+}
+
+size_t WebSocket::MaxReceiveBufferSize() const noexcept
 {
     return m_maxReceiveBufferSize;
 }
 
-HRESULT HC_WEBSOCKET::SetBinaryMessageFragmentFunc(HCWebSocketBinaryMessageFragmentFunction func) noexcept
+HRESULT WebSocket::SetHeader(
+    http_internal_string&& headerName,
+    http_internal_string&& headerValue
+) noexcept
 {
-    std::lock_guard<std::recursive_mutex> lock{ m_mutex };
-    m_clientBinaryMessageFragmentFunc = func;
+    RETURN_HR_IF(E_HC_CONNECT_ALREADY_CALLED, m_state != State::Initial);
+    m_connectHeaders[headerName] = headerValue;
     return S_OK;
 }
 
-HRESULT HC_WEBSOCKET::SetProxyUri(
+HRESULT WebSocket::SetProxyUri(
     http_internal_string&& proxyUri
 ) noexcept
 {
-    if (m_state != State::Initial)
-    {
-        return E_HC_CONNECT_ALREADY_CALLED;
-    }
+    RETURN_HR_IF(E_HC_CONNECT_ALREADY_CALLED, m_state != State::Initial);
     m_proxyUri = std::move(proxyUri);
     m_allowProxyToDecryptHttps = false;
     return S_OK;
 }
 
-HRESULT HC_WEBSOCKET::SetProxyDecryptsHttps(
+HRESULT WebSocket::SetProxyDecryptsHttps(
     bool allowProxyToDecryptHttps
-    ) noexcept
+) noexcept
 {
     if (m_proxyUri.empty())
     {
@@ -375,674 +344,169 @@ HRESULT HC_WEBSOCKET::SetProxyDecryptsHttps(
     return S_OK;
 }
 
-HRESULT HC_WEBSOCKET::SetHeader(
-    http_internal_string&& headerName,
-    http_internal_string&& headerValue
-) noexcept
-{
-    if (m_state != State::Initial)
-    {
-        return E_HC_CONNECT_ALREADY_CALLED;
-    }
-    m_connectHeaders[headerName] = headerValue;
-    return S_OK;
-}
-
-HRESULT HC_WEBSOCKET::SetMaxReceiveBufferSize(size_t maxReceiveBufferSizeBytes) noexcept
+HRESULT WebSocket::SetMaxReceiveBufferSize(size_t maxReceiveBufferSizeBytes) noexcept
 {
     m_maxReceiveBufferSize = maxReceiveBufferSizeBytes;
     return S_OK;
 }
 
-void HC_WEBSOCKET::AddClientRef()
-{
-    {
-        std::lock_guard<std::recursive_mutex> lock{ m_mutex };
-        ++m_clientRefCount;
-    }
-    AddRef();
-}
-
-void HC_WEBSOCKET::DecClientRef()
-{
-    bool doDisconnect{ false };
-    {
-        std::lock_guard<std::recursive_mutex> lock{ m_mutex };
-        if (--m_clientRefCount == 0)
-        {
-            if (m_state == State::Connected)
-            {
-                HC_TRACE_WARNING(WEBSOCKET, "No client reference remain for HC_WEBSOCKET but it is either connected/connecting. Disconnecting now.");
-                doDisconnect = true;
-            }
-        }
-    }
-
-    if (doDisconnect)
-    {
-        HRESULT hr = Disconnect();
-        if (FAILED(hr))
-        {
-            HC_TRACE_WARNING(WEBSOCKET, "Disconnect failed with hresult hr=%u", hr);
-        }
-    }
-
-    DecRef();
-}
-
-void HC_WEBSOCKET::AddRef()
-{
-    if (m_totalRefCount++ == 0)
-    {
-        m_extraRefHolder = shared_from_this();
-    }
-}
-
-void HC_WEBSOCKET::DecRef()
-{
-    if (--m_totalRefCount == 0)
-    {
-        m_extraRefHolder.reset();
-    }
-}
-
-void HC_WEBSOCKET::MessageFunc(
-    HC_WEBSOCKET* websocket,
+void CALLBACK WebSocket::MessageFunc(
+    HCWebsocketHandle handle,
     const char* message,
-    void* context
+    void* /*context*/
 )
 {
-    UNREFERENCED_PARAMETER(context);
-    std::unique_lock<std::recursive_mutex> lock{ websocket->m_mutex };
-    if (websocket->m_clientRefCount > 0)
+    auto& websocket{ handle->websocket };
+
+    NotifyWebSocketRoutedHandlers(handle, true, message, nullptr, 0);
+
+    std::unique_lock<std::mutex> lock{ websocket->m_mutex };
+    auto callbacks{ websocket->m_eventCallbacks };
+    lock.unlock();
+
+    for (auto& pair : callbacks)
     {
         try
         {
-            if (websocket->m_clientMessageFunc)
+            if (pair.second.messageFunc)
             {
-                auto httpSingleton = get_http_singleton();
-                notify_websocket_routed_handlers(httpSingleton, websocket, true, message, nullptr, 0);
-                lock.unlock();
-                websocket->m_clientMessageFunc(websocket, message, websocket->m_clientContext);
+                pair.second.messageFunc(handle, message, pair.second.context);
             }
         }
         catch (...)
         {
-            HC_TRACE_WARNING(WEBSOCKET, "Caught exception in client HCWebSocketMessageFunction");
+            HC_TRACE_ERROR(WEBSOCKET, "Caught unhandled exception in HCWebSocketMessageFunction");
         }
-    }
+    }  
 }
 
-void HC_WEBSOCKET::BinaryMessageFunc(
-    HC_WEBSOCKET* websocket,
+void CALLBACK WebSocket::BinaryMessageFunc(
+    HCWebsocketHandle handle,
     const uint8_t* bytes,
     uint32_t payloadSize,
-    void* context
+    void* /*context*/
 )
 {
-    UNREFERENCED_PARAMETER(context);
-    std::unique_lock<std::recursive_mutex> lock{ websocket->m_mutex };
-    if (websocket->m_clientRefCount > 0)
+    auto& websocket{ handle->websocket };
+
+    NotifyWebSocketRoutedHandlers(handle, true, nullptr, bytes, payloadSize);
+
+    std::unique_lock<std::mutex> lock{ websocket->m_mutex };
+    auto callbacks{ websocket->m_eventCallbacks };
+    lock.unlock();
+
+    for (auto& pair : callbacks)
     {
         try
         {
-            if (websocket->m_clientBinaryMessageFunc)
+            if (pair.second.binaryMessageFunc)
             {
-                auto httpSingleton = get_http_singleton();
-                notify_websocket_routed_handlers(httpSingleton, websocket, true, nullptr, bytes, payloadSize);
-                lock.unlock();
-                websocket->m_clientBinaryMessageFunc(websocket, bytes, payloadSize, websocket->m_clientContext);
+                pair.second.binaryMessageFunc(handle, bytes, payloadSize, pair.second.context);
             }
         }
         catch (...)
         {
-            HC_TRACE_WARNING(WEBSOCKET, "Caught exception in client HCWebSocketBinaryMessageFunction");
+            HC_TRACE_ERROR(WEBSOCKET, "Caught unhandled exception in HCWebSocketBinaryMessageFunction");
         }
     }
 }
 
-void HC_WEBSOCKET::BinaryMessageFragmentFunc(
-    HC_WEBSOCKET* websocket,
+void CALLBACK WebSocket::BinaryMessageFragmentFunc(
+    HCWebsocketHandle handle,
     const uint8_t* bytes,
     uint32_t payloadSize,
     bool isLastFragment,
     void* /*context*/
 )
 {
-    std::unique_lock<std::recursive_mutex> lock{ websocket->m_mutex };
-    if (websocket->m_clientRefCount > 0)
+    auto& websocket{ handle->websocket };
+
+    NotifyWebSocketRoutedHandlers(handle, true, nullptr, bytes, payloadSize);
+
+    std::unique_lock<std::mutex> lock{ websocket->m_mutex };
+    auto callbacks{ websocket->m_eventCallbacks };
+    lock.unlock();
+
+    for (auto& pair : callbacks)
     {
         try
         {
-            auto httpSingleton = get_http_singleton();
-            notify_websocket_routed_handlers(httpSingleton, websocket, true, nullptr, bytes, payloadSize);
-            lock.unlock();
-
-            if (websocket->m_clientBinaryMessageFragmentFunc)
+            if (pair.second.binaryMessageFragmentFunc)
             {
-                websocket->m_clientBinaryMessageFragmentFunc(websocket, bytes, payloadSize, isLastFragment, websocket->m_clientContext);
+                pair.second.binaryMessageFragmentFunc(handle, bytes, payloadSize, isLastFragment, pair.second.context);
             }
-            else if (websocket->m_clientBinaryMessageFunc)
+            else if (pair.second.binaryMessageFunc)
             {
                 HC_TRACE_INFORMATION(WEBSOCKET, "Received binary message fragment but no client handler has been set. Invoking HCWebSocketBinaryMessageFunction instead.");
-                websocket->m_clientBinaryMessageFunc(websocket, bytes, payloadSize, websocket->m_clientContext);
+                pair.second.binaryMessageFunc(handle, bytes, payloadSize, pair.second.context);
             }
         }
         catch (...)
         {
-            HC_TRACE_WARNING(WEBSOCKET, "Caught exception in client HCWebSocketBinaryMessageFragmentFunction");
+            HC_TRACE_WARNING(WEBSOCKET, "Caught unhandled exception in HCWebSocketBinaryMessageFragmentFunction");
         }
     }
 }
 
-void HC_WEBSOCKET::CloseFunc(
-    HC_WEBSOCKET* websocket,
+void CALLBACK WebSocket::CloseFunc(
+    HCWebsocketHandle handle,
     HCWebSocketCloseStatus status,
-    void* context
+    void* /*context*/
 )
 {
-    UNREFERENCED_PARAMETER(context);
+    HC_TRACE_VERBOSE(WEBSOCKET, __FUNCTION__);
 
-    // We release the provider's reference if we handle the close.
-    bool shouldDecRef { false };
+    auto& websocket{ handle->websocket };
+
+    std::unique_lock<std::mutex> lock{ websocket->m_mutex };
+    if (!websocket->m_providerContext)
     {
-        std::unique_lock<std::recursive_mutex> lock{ websocket->m_mutex };
+        HC_TRACE_ERROR(WEBSOCKET, "Unexpected call to WebSocket::CloseFunc will be ignored!");
+        return;
+    }
 
-        auto state = websocket->m_state;
-        websocket->m_state = State::Disconnected;
+    // We no longer expect callbacks from Provider at this point, so cleanup m_providerContext. If there are no other
+    // observers of websocket, it may be destroyed now
+    HC_UNIQUE_PTR<ProviderContext> reclaim{ websocket->m_providerContext };
+    websocket->m_state = State::Disconnected;
 
-        switch (state)
+    auto callbacks{ websocket->m_eventCallbacks };
+    lock.unlock();
+
+    for (auto& pair : callbacks)
+    {
+        try
         {
-        case State::Initial:
-            // provider error: should not be calling CloseFunc when websocket connection hasn't been created.
-            break;
-        case State::Connecting:
-            // provider error: providers should complete connect async context rather than calling closeFunc if a connect attempt fails.
-            break;
-        case State::Disconnected:
-            // provider error: providers should call closeFunc exactly once per successful attempt.
-            break;
-        case State::Connected:
-        case State::Disconnecting:
-            shouldDecRef = true;
-            if (websocket->m_clientRefCount > 0)
+            if (pair.second.closeFunc)
             {
-                try
-                {
-                    if (websocket->m_clientCloseEventFunc)
-                    {
-                        lock.unlock();
-                        websocket->m_clientCloseEventFunc(websocket, status, websocket->m_clientContext);
-                    }
-                }
-                catch (...)
-                {
-                    HC_TRACE_WARNING(WEBSOCKET, "Caught exception in client HCWebSocketCloseEventFunction");
-                }
+                pair.second.closeFunc(handle, status, pair.second.context);
             }
-            break;
+        }
+        catch (...)
+        {
+            HC_TRACE_ERROR(WEBSOCKET, "Caught unhandled exception in HCWebSocketCloseEventFunction");
         }
     }
-
-    if (shouldDecRef)
-    {
-        // Release the providers ref
-        websocket->DecRef();
-    }
 }
 
-STDAPI
-HCWebSocketCreate(
-    _Out_ HCWebsocketHandle* websocket,
-    _In_opt_ HCWebSocketMessageFunction messageFunc,
-    _In_opt_ HCWebSocketBinaryMessageFunction binaryMessageFunc,
-    _In_opt_ HCWebSocketCloseEventFunction closeFunc,
-    _In_opt_ void* functionContext
-    ) noexcept
-try
-{
-    if (websocket == nullptr)
-    {
-        return E_INVALIDARG;
-    }
-
-    auto httpSingleton = get_http_singleton();
-    if (nullptr == httpSingleton)
-    {
-        return E_HC_NOT_INITIALISED;
-    }
-
-    std::shared_ptr<HC_WEBSOCKET> socket = http_allocate_shared<HC_WEBSOCKET>(
-        ++httpSingleton->m_lastId,
-        messageFunc,
-        binaryMessageFunc,
-        closeFunc,
-        functionContext
-    );
-
-    HC_TRACE_INFORMATION(WEBSOCKET, "HCWebSocketCreate [ID %llu]", TO_ULL(socket->id));
-
-    socket->AddClientRef();
-    *websocket = socket.get();
-    return S_OK;
-}
-CATCH_RETURN()
-
-STDAPI HCWebSocketSetBinaryMessageFragmentEventFunction(
+void WebSocket::NotifyWebSocketRoutedHandlers(
     _In_ HCWebsocketHandle websocket,
-    _In_ HCWebSocketBinaryMessageFragmentFunction binaryMessageFragmentFunc
-) noexcept
-try
+    _In_ bool receiving,
+    _In_opt_z_ const char* message,
+    _In_opt_ const uint8_t* payloadBytes,
+    _In_ size_t payloadSize
+)
 {
-    RETURN_HR_IF(E_INVALIDARG, !websocket);
-    return websocket->SetBinaryMessageFragmentFunc(binaryMessageFragmentFunc);
-}
-CATCH_RETURN()
-
-STDAPI
-HCWebSocketSetProxyUri(
-    _In_ HCWebsocketHandle websocket,
-    _In_z_ const char* proxyUri
-    ) noexcept
-try
-{
-    if (websocket == nullptr || proxyUri == nullptr)
-    {
-        return E_INVALIDARG;
-    }
-    return websocket->SetProxyUri(proxyUri);
-}
-CATCH_RETURN()
-
-STDAPI
-HCWebSocketSetProxyDecryptsHttps(
-    _In_ HCWebsocketHandle websocket,
-    _In_z_ bool allowProxyToDecryptHttps
-) noexcept
-try
-{
-    if (websocket == nullptr)
-    {
-        return E_INVALIDARG;
-    }
-    return websocket->SetProxyDecryptsHttps(allowProxyToDecryptHttps);
-}
-CATCH_RETURN()
-
-STDAPI
-HCWebSocketSetHeader(
-    _In_ HCWebsocketHandle websocket,
-    _In_z_ const char* headerName,
-    _In_z_ const char* headerValue
-    ) noexcept
-try
-{
-    if (websocket == nullptr || headerName == nullptr || headerValue == nullptr)
-    {
-        return E_INVALIDARG;
-    }
-    return websocket->SetHeader(headerName, headerValue);
-}
-CATCH_RETURN()
-
-STDAPI
-HCWebSocketConnectAsync(
-    _In_z_ const char* uri,
-    _In_z_ const char* subProtocol,
-    _In_ HCWebsocketHandle websocket,
-    _Inout_ XAsyncBlock* asyncBlock
-    ) noexcept
-try
-{
-    if (uri == nullptr || websocket == nullptr || subProtocol == nullptr)
-    {
-        return E_INVALIDARG;
-    }
-    return websocket->Connect(uri, subProtocol, asyncBlock);
-}
-CATCH_RETURN()
-
-STDAPI
-HCWebSocketSendMessageAsync(
-    _In_ HCWebsocketHandle websocket,
-    _In_z_ const char* message,
-    _Inout_ XAsyncBlock* asyncBlock
-    ) noexcept
-try
-{
-    if (message == nullptr || websocket == nullptr)
-    {
-        return E_INVALIDARG;
-    }
-    return websocket->Send(message, asyncBlock);
-}
-CATCH_RETURN()
-
-STDAPI
-HCWebSocketSendBinaryMessageAsync(
-    _In_ HCWebsocketHandle websocket,
-    _In_reads_bytes_(payloadSize) const uint8_t* payloadBytes,
-    _In_ uint32_t payloadSize,
-    _Inout_ XAsyncBlock* asyncBlock
-    ) noexcept
-try
-{
-    if (payloadBytes == nullptr || payloadSize == 0 || websocket == nullptr)
-    {
-        return E_INVALIDARG;
-    }
-    return websocket->SendBinary(payloadBytes, payloadSize, asyncBlock);
-}
-CATCH_RETURN()
-
-STDAPI
-HCWebSocketDisconnect(
-    _In_ HCWebsocketHandle websocket
-    ) noexcept
-try
-{
-    if (websocket == nullptr)
-    {
-        return E_INVALIDARG;
-    }
-    return websocket->Disconnect();
-}
-CATCH_RETURN()
-
-STDAPI HCWebSocketSetMaxReceiveBufferSize(
-    _In_ HCWebsocketHandle websocket,
-    _In_ size_t bufferSizeInBytes
-) noexcept
-try
-{
-    RETURN_HR_IF(E_INVALIDARG, !websocket);
-    return websocket->SetMaxReceiveBufferSize(bufferSizeInBytes);
-}
-CATCH_RETURN()
-
-STDAPI_(HCWebsocketHandle) HCWebSocketDuplicateHandle(
-    _In_ HCWebsocketHandle websocket
-    ) noexcept
-try
-{
-    if (websocket == nullptr)
-    {
-        return nullptr;
-    }
-
-    HC_TRACE_INFORMATION(WEBSOCKET, "HCWebSocketDuplicateHandle [ID %llu]", TO_ULL(websocket->id));
-    websocket->AddClientRef();
-
-    return websocket;
-}
-CATCH_RETURN_WITH(nullptr)
-
-STDAPI
-HCWebSocketCloseHandle(
-    _In_ HCWebsocketHandle websocket
-    ) noexcept
-try
-{
-    if (websocket == nullptr)
-    {
-        return E_INVALIDARG;
-    }
-
-    HC_TRACE_INFORMATION(WEBSOCKET, "HCWebSocketCloseHandle [ID %llu]", TO_ULL(websocket->id));
-    websocket->DecClientRef();
-
-    return S_OK;
-}
-CATCH_RETURN()
-
-STDAPI
-HCSetWebSocketFunctions(
-    _In_ HCWebSocketConnectFunction websocketConnectFunc,
-    _In_ HCWebSocketSendMessageFunction websocketSendMessageFunc,
-    _In_ HCWebSocketSendBinaryMessageFunction websocketSendBinaryMessageFunc,
-    _In_ HCWebSocketDisconnectFunction websocketDisconnectFunc,
-    _In_opt_ void* context
-    ) noexcept
-try
-{
-    if (websocketConnectFunc == nullptr ||
-        websocketSendMessageFunc == nullptr ||
-        websocketSendBinaryMessageFunc == nullptr ||
-        websocketDisconnectFunc == nullptr)
-    {
-        return E_INVALIDARG;
-    }
-
     auto httpSingleton = get_http_singleton();
     if (httpSingleton)
     {
-        return E_HC_ALREADY_INITIALISED;
-    }
-
-    auto& info = GetUserWebSocketPerformHandlers();
-
-    info.connect = websocketConnectFunc;
-    info.sendText = websocketSendMessageFunc;
-    info.sendBinary = websocketSendBinaryMessageFunc;
-    info.disconnect = websocketDisconnectFunc;
-    info.context = context;
-    return S_OK;
-}
-CATCH_RETURN()
-
-STDAPI
-HCGetWebSocketFunctions(
-    _Out_ HCWebSocketConnectFunction* websocketConnectFunc,
-    _Out_ HCWebSocketSendMessageFunction* websocketSendMessageFunc,
-    _Out_ HCWebSocketSendBinaryMessageFunction* websocketSendBinaryMessageFunc,
-    _Out_ HCWebSocketDisconnectFunction* websocketDisconnectFunc,
-    _Out_ void** context
-) noexcept
-try
-{
-    if (websocketConnectFunc == nullptr ||
-        websocketSendMessageFunc == nullptr ||
-        websocketSendBinaryMessageFunc == nullptr ||
-        websocketDisconnectFunc == nullptr ||
-        context == nullptr)
-    {
-        return E_INVALIDARG;
-    }
-
-    auto const& info = GetUserWebSocketPerformHandlers();
-
-    *websocketConnectFunc = info.connect;
-    *websocketSendMessageFunc = info.sendText;
-    *websocketSendBinaryMessageFunc = info.sendBinary;
-    *websocketDisconnectFunc = info.disconnect;
-    *context = info.context;
-    return S_OK;
-}
-CATCH_RETURN()
-
-STDAPI
-HCWebSocketGetProxyUri(
-    _In_ HCWebsocketHandle websocket,
-    _Out_ const char** proxyUri
-) noexcept
-try
-{
-    if (websocket == nullptr || proxyUri == nullptr)
-    {
-        return E_INVALIDARG;
-    }
-
-    *proxyUri = websocket->ProxyUri().data();
-    return S_OK;
-}
-CATCH_RETURN()
-
-STDAPI
-HCWebSocketGetHeader(
-    _In_ HCWebsocketHandle websocket,
-    _In_z_ const char* headerName,
-    _Out_ const char** headerValue
-) noexcept
-try
-{
-    if (websocket == nullptr || headerName == nullptr || headerValue == nullptr)
-    {
-        return E_INVALIDARG;
-    }
-
-    auto& headers{ websocket->Headers() };
-    auto it = headers.find(headerName);
-    if (it != headers.end())
-    {
-        *headerValue = it->second.c_str();
-    }
-    else
-    {
-        *headerValue = nullptr;
-    }
-    return S_OK;
-}
-CATCH_RETURN()
-
-STDAPI
-HCWebSocketGetNumHeaders(
-    _In_ HCWebsocketHandle websocket,
-    _Out_ uint32_t* numHeaders
-    ) noexcept
-try
-{
-    if (websocket == nullptr || numHeaders == nullptr)
-    {
-        return E_INVALIDARG;
-    }
-
-    *numHeaders = static_cast<uint32_t>(websocket->Headers().size());
-    return S_OK;
-}
-CATCH_RETURN()
-
-STDAPI
-HCWebSocketGetHeaderAtIndex(
-    _In_ HCWebsocketHandle websocket,
-    _In_ uint32_t headerIndex,
-    _Out_ const char** headerName,
-    _Out_ const char** headerValue
-    ) noexcept
-try
-{
-    if (websocket == nullptr || headerName == nullptr || headerValue == nullptr)
-    {
-        return E_INVALIDARG;
-    }
-
-    uint32_t index = 0;
-    auto& headers{ websocket->Headers() };
-    for (auto it = headers.cbegin(); it != headers.cend(); ++it)
-    {
-        if (index == headerIndex)
+        std::lock_guard<std::recursive_mutex> lock(httpSingleton->m_callRoutedHandlersLock);
+        for (const auto& pair : httpSingleton->m_webSocketRoutedHandlers)
         {
-            *headerName = it->first.c_str();
-            *headerValue = it->second.c_str();
-            return S_OK;
+            pair.second.first(websocket, receiving, message, payloadBytes, payloadSize, pair.second.second);
         }
-
-        index++;
     }
-
-    *headerName = nullptr;
-    *headerValue = nullptr;
-    return S_OK;
 }
-CATCH_RETURN()
 
-STDAPI
-HCWebSocketGetEventFunctions(
-    _In_ HCWebsocketHandle websocket,
-    _Out_opt_ HCWebSocketMessageFunction* messageFunc,
-    _Out_opt_ HCWebSocketBinaryMessageFunction* binaryMessageFunc,
-    _Out_opt_ HCWebSocketCloseEventFunction* closeFunc,
-    _Out_ void** context
-    ) noexcept
-try
-{
-    if (websocket == nullptr)
-    {
-        return E_INVALIDARG;
-    }
-
-    if (messageFunc != nullptr)
-    {
-        *messageFunc = HC_WEBSOCKET::MessageFunc;
-    }
-
-    if (binaryMessageFunc != nullptr)
-    {
-        *binaryMessageFunc = HC_WEBSOCKET::BinaryMessageFunc;
-    }
-
-    if (closeFunc != nullptr)
-    {
-        *closeFunc = HC_WEBSOCKET::CloseFunc;
-    }
-
-    if (context != nullptr)
-    {
-        *context = nullptr;
-    }
-
-    return S_OK;
-}
-CATCH_RETURN()
-
-STDAPI HCWebSocketGetBinaryMessageFragmentEventFunction(
-    _In_ HCWebsocketHandle websocket,
-    _Out_ HCWebSocketBinaryMessageFragmentFunction* binaryMessageFragmentFunc,
-    _Out_ void** context
-) noexcept
-try
-{
-    RETURN_HR_IF(E_INVALIDARG, !websocket || !binaryMessageFragmentFunc || !context);
-
-    *binaryMessageFragmentFunc = HC_WEBSOCKET::BinaryMessageFragmentFunc;
-    *context = nullptr;
-    return S_OK;
-}
-CATCH_RETURN()
-
-
-STDAPI
-HCGetWebSocketConnectResult(
-    _Inout_ XAsyncBlock* asyncBlock,
-    _In_ WebSocketCompletionResult* result
-    ) noexcept
-try
-{
-    return XAsyncGetResult(
-        asyncBlock,
-        reinterpret_cast<void*>(HCWebSocketConnectAsync),
-        sizeof(WebSocketCompletionResult),
-        result,
-        nullptr
-    );
-}
-CATCH_RETURN()
-
-STDAPI
-HCGetWebSocketSendMessageResult(
-    _Inout_ XAsyncBlock* asyncBlock,
-    _In_ WebSocketCompletionResult* result
-    ) noexcept
-try
-{
-    return XAsyncGetResult(
-        asyncBlock,
-        reinterpret_cast<void*>(HCWebSocketSendMessageAsync),
-        sizeof(WebSocketCompletionResult),
-        result,
-        nullptr
-    );
-}
-CATCH_RETURN()
-
-#endif
-
+} // namespace httpclient
+} // namespace xbox

--- a/Source/WebSocket/hcwebsocket.h
+++ b/Source/WebSocket/hcwebsocket.h
@@ -9,39 +9,92 @@
 
 HC_DECLARE_TRACE_AREA(WEBSOCKET);
 
+namespace xbox
+{
+namespace httpclient
+{
+class WebSocket;
+
 // Base class for platform specific implementations
-struct hc_websocket_impl 
+struct hc_websocket_impl
 {
     hc_websocket_impl() {}
     virtual ~hc_websocket_impl() {}
 };
 
+}
+}
+
 #if !HC_NOWEBSOCKETS
 
-typedef struct HC_WEBSOCKET : std::enable_shared_from_this<HC_WEBSOCKET>
+// An observer of a WebSocket. Holds a shared reference to the WebSocket and receives callbacks on WebSocket events
+struct HC_WEBSOCKET_OBSERVER
+{
+public: 
+    virtual ~HC_WEBSOCKET_OBSERVER();
+
+    static HC_UNIQUE_PTR<HC_WEBSOCKET_OBSERVER> Initialize(
+        _In_ std::shared_ptr<xbox::httpclient::WebSocket> WebSocket,
+        _In_opt_ HCWebSocketMessageFunction messageFunc = nullptr,
+        _In_opt_ HCWebSocketBinaryMessageFunction binaryMessageFunc = nullptr,
+        _In_opt_ HCWebSocketBinaryMessageFragmentFunction binaryFragmentFunc = nullptr,
+        _In_opt_ HCWebSocketCloseEventFunction closeFunc = nullptr,
+        _In_opt_ void* callbackContext = nullptr
+    );
+
+    void SetBinaryMessageFragmentEventFunction(HCWebSocketBinaryMessageFragmentFunction binaryFragmentFunc);
+
+    std::atomic<int> refCount{ 1 };
+    std::shared_ptr<xbox::httpclient::WebSocket> const websocket;
+
+private:
+    HC_WEBSOCKET_OBSERVER(std::shared_ptr<xbox::httpclient::WebSocket> WebSocket);
+
+    HCWebSocketMessageFunction m_messageFunc{ nullptr };
+    HCWebSocketBinaryMessageFunction m_binaryMessageFunc{ nullptr };
+    HCWebSocketBinaryMessageFragmentFunction m_binaryFragmentFunc{ nullptr };
+    HCWebSocketCloseEventFunction m_closeFunc{ nullptr };
+    void* m_callbackContext{ nullptr };
+    uint32_t m_handlerToken{ 0 };
+};
+
+namespace xbox
+{
+namespace httpclient
+{
+
+class WebSocket : public std::enable_shared_from_this<WebSocket>
 {
 public:
-    HC_WEBSOCKET(
-        _In_ uint64_t id,
+    WebSocket(const WebSocket&) = delete;
+    WebSocket(WebSocket&&) = delete;
+    WebSocket& operator=(const WebSocket&) = delete;
+    virtual ~WebSocket();
+
+    static Result<std::shared_ptr<WebSocket>> Initialize();
+
+    uint32_t RegisterEventCallbacks(
         _In_opt_ HCWebSocketMessageFunction messageFunc,
         _In_opt_ HCWebSocketBinaryMessageFunction binaryMessageFunc,
+        _In_opt_ HCWebSocketBinaryMessageFragmentFunction binaryFragmentFunc,
         _In_opt_ HCWebSocketCloseEventFunction closeFunc,
-        _In_opt_ void* functionContext
+        _In_opt_ void* callbackContext
     );
-    virtual ~HC_WEBSOCKET();
 
-    HRESULT Connect(
-        _In_z_ const char* uri,
-        _In_z_ const char* subProtocol,
+    void UnregisterEventCallbacks(uint32_t registrationToken);
+
+    HRESULT ConnectAsync(
+        _In_ http_internal_string&& uri,
+        _In_ http_internal_string&& subProtocol,
         _Inout_ XAsyncBlock* asyncBlock
     ) noexcept;
 
-    HRESULT Send(
+    HRESULT SendAsync(
         _In_z_ const char* message,
         _Inout_ XAsyncBlock* asyncBlock
     ) noexcept;
 
-    HRESULT SendBinary(
+    HRESULT SendBinaryAsync(
         _In_reads_bytes_(payloadSize) const uint8_t* payloadBytes,
         _In_ uint32_t payloadSize,
         _Inout_ XAsyncBlock* asyncBlock
@@ -49,45 +102,43 @@ public:
 
     HRESULT Disconnect();
 
-    const uint64_t id;
+    // Unique ID for logging
+    uint64_t const id;
+
+    const http_internal_string& Uri() const noexcept;
+    const http_internal_string& SubProtocol() const noexcept;
     const xbox::httpclient::HttpHeaders& Headers() const noexcept;
     const http_internal_string& ProxyUri() const noexcept;
     const bool ProxyDecryptsHttps() const noexcept;
-    const http_internal_string& Uri() const noexcept;
-    const http_internal_string& SubProtocol() const noexcept;
     size_t MaxReceiveBufferSize() const noexcept;
 
-    HRESULT SetBinaryMessageFragmentFunc(HCWebSocketBinaryMessageFragmentFunction func) noexcept;
-    HRESULT SetProxyUri(http_internal_string&& proxyUri) noexcept;
-    HRESULT SetProxyDecryptsHttps(bool allowProxyToDecryptHttps) noexcept;
     HRESULT SetHeader(http_internal_string&& headerName, http_internal_string&& headerValue) noexcept;
+    HRESULT SetProxyUri(http_internal_string&& proxyUri) noexcept;
+    HRESULT SetProxyDecryptsHttps(bool allowProxyToDecryptHttps) noexcept;  
     HRESULT SetMaxReceiveBufferSize(size_t maxReceiveBufferSizeBytes) noexcept;
 
-    void AddClientRef();
-    void DecClientRef();
-    void AddRef();
-    void DecRef();
+    // Event functions
+    static void CALLBACK MessageFunc(HCWebsocketHandle handle, const char* message, void* context);
+    static void CALLBACK BinaryMessageFunc(HCWebsocketHandle handle, const uint8_t* bytes, uint32_t payloadSize, void* context);
+    static void CALLBACK BinaryMessageFragmentFunc(HCWebsocketHandle handle, const uint8_t* payloadBytes, uint32_t payloadSize, bool isLastFragment, void* functionContext);
+    static void CALLBACK CloseFunc(HCWebsocketHandle handle, HCWebSocketCloseStatus status, void* context);
 
-    static void CALLBACK MessageFunc(HC_WEBSOCKET* websocket, const char* message, void* context);
-    static void CALLBACK BinaryMessageFunc(HC_WEBSOCKET* websocket, const uint8_t* bytes, uint32_t payloadSize, void* context);
-    static void CALLBACK BinaryMessageFragmentFunc(HC_WEBSOCKET* websocket, const uint8_t* payloadBytes, uint32_t payloadSize, bool isLastFragment, void* functionContext);
-    static void CALLBACK CloseFunc(HC_WEBSOCKET* websocket, HCWebSocketCloseStatus status, void* context);
-
+    // Internal providers use this to store context
     std::shared_ptr<hc_websocket_impl> impl;
 
 private:
-    XAsyncBlock m_connectAsyncBlock{};
-    WebSocketCompletionResult m_connectResult{};
-    XAsyncBlock* m_clientConnectAsyncBlock{ nullptr };
+    WebSocket(uint64_t id, WebSocketPerformInfo performInfo, HC_PERFORM_ENV* performEnv);
 
-    enum class State
-    {
-        Initial,
-        Disconnecting,
-        Disconnected,
-        Connecting,
-        Connected
-    } m_state{ State::Initial };
+    static HRESULT CALLBACK ConnectAsyncProvider(XAsyncOp op, XAsyncProviderData const* data);
+    static void CALLBACK ConnectComplete(XAsyncBlock* async);
+
+    static void NotifyWebSocketRoutedHandlers(
+        _In_ HCWebsocketHandle websocket,
+        _In_ bool receiving,
+        _In_opt_z_ const char* message,
+        _In_opt_ const uint8_t* payloadBytes,
+        _In_ size_t payloadSize
+    );
 
     xbox::httpclient::HttpHeaders m_connectHeaders;
     bool m_allowProxyToDecryptHttps{ false };
@@ -96,17 +147,38 @@ private:
     http_internal_string m_subProtocol;
     size_t m_maxReceiveBufferSize{ 0 };
 
-    HCWebSocketMessageFunction const m_clientMessageFunc{ nullptr };
-    HCWebSocketBinaryMessageFunction const m_clientBinaryMessageFunc{ nullptr };
-    HCWebSocketBinaryMessageFragmentFunction m_clientBinaryMessageFragmentFunc{ nullptr };
-    HCWebSocketCloseEventFunction const m_clientCloseEventFunc{ nullptr };
-    void* m_clientContext{ nullptr };
+    struct ConnectContext;
+    struct ProviderContext;
 
-    std::recursive_mutex m_mutex;
-    std::atomic<int> m_clientRefCount{ 0 };
-    std::atomic<int> m_totalRefCount{ 0 };
-    std::shared_ptr<HC_WEBSOCKET> m_extraRefHolder;
+    struct EventCallbacks
+    {
+        HCWebSocketMessageFunction messageFunc{ nullptr };
+        HCWebSocketBinaryMessageFunction binaryMessageFunc{ nullptr };
+        HCWebSocketBinaryMessageFragmentFunction binaryMessageFragmentFunc{ nullptr };
+        HCWebSocketCloseEventFunction closeFunc{ nullptr };
+        void* context{ nullptr };
+    };
 
-} HC_WEBSOCKET;
+    enum class State
+    {
+        Initial,
+        Connecting,
+        Connected,
+        Disconnecting,
+        Disconnected
+    } m_state{ State::Initial };
+
+    std::mutex m_mutex;
+    http_internal_map<uint32_t, EventCallbacks> m_eventCallbacks{};
+    uint32_t m_nextToken{ 1 };
+
+    WebSocketPerformInfo const m_performInfo;
+    HC_PERFORM_ENV* const m_performEnv; // non-owning
+
+    ProviderContext* m_providerContext{ nullptr };
+};
+
+} // namespace httpclient
+} // namespace xbox
 
 #endif // !HC_NOWEBSOCKETS

--- a/Source/WebSocket/websocket_publics.cpp
+++ b/Source/WebSocket/websocket_publics.cpp
@@ -3,6 +3,8 @@
 
 using namespace xbox::httpclient;
 
+#if !HC_NOWEBSOCKETS
+
 STDAPI HCWebSocketCreate(
     _Out_ HCWebsocketHandle* handle,
     _In_opt_ HCWebSocketMessageFunction messageFunc,
@@ -394,3 +396,5 @@ try
     );
 }
 CATCH_RETURN()
+
+#endif //!HC_NOWEBSOCKETS

--- a/Source/WebSocket/websocket_publics.cpp
+++ b/Source/WebSocket/websocket_publics.cpp
@@ -1,1 +1,396 @@
 #include "pch.h"
+#include "hcwebsocket.h"
+
+using namespace xbox::httpclient;
+
+STDAPI HCWebSocketCreate(
+    _Out_ HCWebsocketHandle* handle,
+    _In_opt_ HCWebSocketMessageFunction messageFunc,
+    _In_opt_ HCWebSocketBinaryMessageFunction binaryMessageFunc,
+    _In_opt_ HCWebSocketCloseEventFunction closeFunc,
+    _In_opt_ void* functionContext
+) noexcept
+try
+{
+    RETURN_HR_IF(E_INVALIDARG, !handle);
+
+    auto createWebSocketResult = WebSocket::Initialize();
+    RETURN_IF_FAILED(createWebSocketResult.hr);
+
+    *handle = HC_WEBSOCKET_OBSERVER::Initialize(createWebSocketResult.ExtractPayload(), messageFunc, binaryMessageFunc, nullptr, closeFunc, functionContext).release();
+
+    return S_OK;
+}
+CATCH_RETURN()
+
+STDAPI HCWebSocketSetBinaryMessageFragmentEventFunction(
+    _In_ HCWebsocketHandle handle,
+    _In_ HCWebSocketBinaryMessageFragmentFunction binaryMessageFragmentFunc
+) noexcept
+try
+{
+    RETURN_HR_IF(E_INVALIDARG, !handle);
+    handle->SetBinaryMessageFragmentEventFunction(binaryMessageFragmentFunc);
+    return S_OK;
+}
+CATCH_RETURN()
+
+STDAPI HCWebSocketSetProxyUri(
+    _In_ HCWebsocketHandle handle,
+    _In_z_ const char* proxyUri
+) noexcept
+try
+{
+    RETURN_HR_IF(E_INVALIDARG, !handle || !proxyUri);
+    return handle->websocket->SetProxyUri(proxyUri);
+}
+CATCH_RETURN()
+
+STDAPI HCWebSocketSetProxyDecryptsHttps(
+    _In_ HCWebsocketHandle handle,
+    _In_ bool allowProxyToDecryptHttps
+) noexcept
+try
+{
+    RETURN_HR_IF(E_INVALIDARG, !handle);
+    return handle->websocket->SetProxyDecryptsHttps(allowProxyToDecryptHttps);
+}
+CATCH_RETURN()
+
+STDAPI HCWebSocketSetHeader(
+    _In_ HCWebsocketHandle handle,
+    _In_z_ const char* headerName,
+    _In_z_ const char* headerValue
+) noexcept
+try
+{
+    RETURN_HR_IF(E_INVALIDARG, !handle || !headerName || !headerValue);
+    return handle->websocket->SetHeader(headerName, headerValue);
+}
+CATCH_RETURN()
+
+
+STDAPI HCWebSocketConnectAsync(
+    _In_z_ const char* uri,
+    _In_z_ const char* subProtocol,
+    _In_ HCWebsocketHandle handle,
+    _Inout_ XAsyncBlock* asyncBlock
+) noexcept
+try
+{
+    RETURN_HR_IF(E_INVALIDARG, !handle || !uri || !subProtocol);
+
+    auto httpSingleton = get_http_singleton();
+    RETURN_HR_IF(E_HC_NOT_INITIALISED, !httpSingleton);
+
+    return httpSingleton->m_performEnv->WebSocketConnectAsyncShim(uri, subProtocol, handle, asyncBlock);
+}
+CATCH_RETURN()
+
+STDAPI HCWebSocketSendMessageAsync(
+    _In_ HCWebsocketHandle handle,
+    _In_z_ const char* message,
+    _Inout_ XAsyncBlock* asyncBlock
+) noexcept
+try
+{
+    RETURN_HR_IF(E_INVALIDARG, !handle || !message);
+    return handle->websocket->SendAsync(message, asyncBlock);
+}
+CATCH_RETURN()
+
+STDAPI HCWebSocketSendBinaryMessageAsync(
+    _In_ HCWebsocketHandle handle,
+    _In_reads_bytes_(payloadSize) const uint8_t* payloadBytes,
+    _In_ uint32_t payloadSize,
+    _Inout_ XAsyncBlock* asyncBlock
+) noexcept
+try
+{
+    RETURN_HR_IF(E_INVALIDARG, !handle || !payloadBytes || !payloadSize);
+    return handle->websocket->SendBinaryAsync(payloadBytes, payloadSize, asyncBlock);
+}
+CATCH_RETURN()
+
+STDAPI HCWebSocketDisconnect(
+    _In_ HCWebsocketHandle handle
+) noexcept
+try
+{
+    RETURN_HR_IF(E_INVALIDARG, !handle);
+    return handle->websocket->Disconnect();
+}
+CATCH_RETURN()
+
+STDAPI HCWebSocketSetMaxReceiveBufferSize(
+    _In_ HCWebsocketHandle handle,
+    _In_ size_t bufferSizeInBytes
+) noexcept
+try
+{
+    RETURN_HR_IF(E_INVALIDARG, !handle);
+    return handle->websocket->SetMaxReceiveBufferSize(bufferSizeInBytes);
+}
+CATCH_RETURN()
+
+STDAPI_(HCWebsocketHandle) HCWebSocketDuplicateHandle(
+    _In_ HCWebsocketHandle handle
+) noexcept
+try
+{
+    if (handle == nullptr)
+    {
+        return nullptr;
+    }
+
+    HC_TRACE_INFORMATION(WEBSOCKET, "HCWebSocketDuplicateHandle [ID %llu]", TO_ULL(handle->websocket->id));
+    ++handle->refCount;
+
+    return handle;
+}
+CATCH_RETURN_WITH(nullptr)
+
+STDAPI HCWebSocketCloseHandle(
+    _In_ HCWebsocketHandle handle
+) noexcept
+try
+{
+    RETURN_HR_IF(E_INVALIDARG, !handle);
+
+    HC_TRACE_INFORMATION(WEBSOCKET, "HCWebSocketCloseHandle [ID %llu]", TO_ULL(handle->websocket->id));
+    int refCount = --handle->refCount;
+    if (refCount <= 0)
+    {
+        ASSERT(refCount == 0); // should only fire at 0
+        HC_UNIQUE_PTR<HC_WEBSOCKET_OBSERVER> reclaim{ handle };
+    }
+
+    return S_OK;
+}
+CATCH_RETURN()
+
+STDAPI HCSetWebSocketFunctions(
+    _In_ HCWebSocketConnectFunction websocketConnectFunc,
+    _In_ HCWebSocketSendMessageFunction websocketSendMessageFunc,
+    _In_ HCWebSocketSendBinaryMessageFunction websocketSendBinaryMessageFunc,
+    _In_ HCWebSocketDisconnectFunction websocketDisconnectFunc,
+    _In_opt_ void* context
+) noexcept
+try
+{
+    if (websocketConnectFunc == nullptr ||
+        websocketSendMessageFunc == nullptr ||
+        websocketSendBinaryMessageFunc == nullptr ||
+        websocketDisconnectFunc == nullptr)
+    {
+        return E_INVALIDARG;
+    }
+
+    auto httpSingleton = get_http_singleton();
+    if (httpSingleton)
+    {
+        return E_HC_ALREADY_INITIALISED;
+    }
+
+    auto& info = GetUserWebSocketPerformHandlers();
+
+    info.connect = websocketConnectFunc;
+    info.sendText = websocketSendMessageFunc;
+    info.sendBinary = websocketSendBinaryMessageFunc;
+    info.disconnect = websocketDisconnectFunc;
+    info.context = context;
+    return S_OK;
+}
+CATCH_RETURN()
+
+STDAPI HCGetWebSocketFunctions(
+    _Out_ HCWebSocketConnectFunction* websocketConnectFunc,
+    _Out_ HCWebSocketSendMessageFunction* websocketSendMessageFunc,
+    _Out_ HCWebSocketSendBinaryMessageFunction* websocketSendBinaryMessageFunc,
+    _Out_ HCWebSocketDisconnectFunction* websocketDisconnectFunc,
+    _Out_ void** context
+) noexcept
+try
+{
+    if (websocketConnectFunc == nullptr ||
+        websocketSendMessageFunc == nullptr ||
+        websocketSendBinaryMessageFunc == nullptr ||
+        websocketDisconnectFunc == nullptr ||
+        context == nullptr)
+    {
+        return E_INVALIDARG;
+    }
+
+    auto const& info = GetUserWebSocketPerformHandlers();
+
+    *websocketConnectFunc = info.connect;
+    *websocketSendMessageFunc = info.sendText;
+    *websocketSendBinaryMessageFunc = info.sendBinary;
+    *websocketDisconnectFunc = info.disconnect;
+    *context = info.context;
+    return S_OK;
+}
+CATCH_RETURN()
+
+STDAPI HCWebSocketGetProxyUri(
+    _In_ HCWebsocketHandle handle,
+    _Out_ const char** proxyUri
+) noexcept
+try
+{
+    RETURN_HR_IF(E_INVALIDARG, !handle || !proxyUri);
+    *proxyUri = handle->websocket->ProxyUri().data();
+    return S_OK;
+}
+CATCH_RETURN()
+
+STDAPI HCWebSocketGetHeader(
+    _In_ HCWebsocketHandle handle,
+    _In_z_ const char* headerName,
+    _Out_ const char** headerValue
+) noexcept
+try
+{
+    RETURN_HR_IF(E_INVALIDARG, !handle || !headerName || !headerValue);
+
+    auto& headers{ handle->websocket->Headers() };
+    auto it = headers.find(headerName);
+    if (it != headers.end())
+    {
+        *headerValue = it->second.c_str();
+    }
+    else
+    {
+        *headerValue = nullptr;
+    }
+    return S_OK;
+}
+CATCH_RETURN()
+
+STDAPI HCWebSocketGetNumHeaders(
+    _In_ HCWebsocketHandle handle,
+    _Out_ uint32_t* numHeaders
+) noexcept
+try
+{
+    RETURN_HR_IF(E_INVALIDARG, !handle || !numHeaders);
+    *numHeaders = static_cast<uint32_t>(handle->websocket->Headers().size());
+    return S_OK;
+}
+CATCH_RETURN()
+
+STDAPI HCWebSocketGetHeaderAtIndex(
+    _In_ HCWebsocketHandle handle,
+    _In_ uint32_t headerIndex,
+    _Out_ const char** headerName,
+    _Out_ const char** headerValue
+) noexcept
+try
+{
+    RETURN_HR_IF(E_INVALIDARG, !handle || !headerName || !headerValue);
+
+    uint32_t index = 0;
+    auto& headers{ handle->websocket->Headers() };
+    for (auto it = headers.cbegin(); it != headers.cend(); ++it)
+    {
+        if (index == headerIndex)
+        {
+            *headerName = it->first.c_str();
+            *headerValue = it->second.c_str();
+            return S_OK;
+        }
+
+        index++;
+    }
+
+    *headerName = nullptr;
+    *headerValue = nullptr;
+    return S_OK;
+}
+CATCH_RETURN()
+
+STDAPI HCWebSocketGetEventFunctions(
+    _In_ HCWebsocketHandle websocket,
+    _Out_opt_ HCWebSocketMessageFunction* messageFunc,
+    _Out_opt_ HCWebSocketBinaryMessageFunction* binaryMessageFunc,
+    _Out_opt_ HCWebSocketCloseEventFunction* closeFunc,
+    _Out_ void** context
+) noexcept
+try
+{
+    if (websocket == nullptr)
+    {
+        return E_INVALIDARG;
+    }
+
+    if (messageFunc != nullptr)
+    {
+        *messageFunc = WebSocket::MessageFunc;
+    }
+
+    if (binaryMessageFunc != nullptr)
+    {
+        *binaryMessageFunc = WebSocket::BinaryMessageFunc;
+    }
+
+    if (closeFunc != nullptr)
+    {
+        *closeFunc = WebSocket::CloseFunc;
+    }
+
+    if (context != nullptr)
+    {
+        *context = nullptr;
+    }
+
+    return S_OK;
+}
+CATCH_RETURN()
+
+STDAPI HCWebSocketGetBinaryMessageFragmentEventFunction(
+    _In_ HCWebsocketHandle websocket,
+    _Out_ HCWebSocketBinaryMessageFragmentFunction* binaryMessageFragmentFunc,
+    _Out_ void** context
+) noexcept
+try
+{
+    RETURN_HR_IF(E_INVALIDARG, !websocket || !binaryMessageFragmentFunc || !context);
+
+    *binaryMessageFragmentFunc = WebSocket::BinaryMessageFragmentFunc;
+    *context = nullptr;
+    return S_OK;
+}
+CATCH_RETURN()
+
+
+STDAPI HCGetWebSocketConnectResult(
+    _Inout_ XAsyncBlock* asyncBlock,
+    _In_ WebSocketCompletionResult* result
+) noexcept
+try
+{
+    return XAsyncGetResult(
+        asyncBlock,
+        reinterpret_cast<void*>(HCWebSocketConnectAsync),
+        sizeof(WebSocketCompletionResult),
+        result,
+        nullptr
+    );
+}
+CATCH_RETURN()
+
+STDAPI HCGetWebSocketSendMessageResult(
+    _Inout_ XAsyncBlock* asyncBlock,
+    _In_ WebSocketCompletionResult* result
+) noexcept
+try
+{
+    return XAsyncGetResult(
+        asyncBlock,
+        reinterpret_cast<void*>(HCWebSocketSendMessageAsync),
+        sizeof(WebSocketCompletionResult),
+        result,
+        nullptr
+    );
+}
+CATCH_RETURN()

--- a/Utilities/CMake/GetCommonHCSourceFiles.cmake
+++ b/Utilities/CMake/GetCommonHCSourceFiles.cmake
@@ -56,6 +56,7 @@ function(GET_COMMON_HC_SOURCE_FILES
     set(${OUT_WEBSOCKET_SOURCE_FILES}
         "${PATH_TO_ROOT}/Source/WebSocket/hcwebsocket.h"
         "${PATH_TO_ROOT}/Source/WebSocket/hcwebsocket.cpp"
+        "${PATH_TO_ROOT}/Source/WebSocket/websocket_publics.cpp"
         PARENT_SCOPE
         )
 


### PR DESCRIPTION
* WebSocket class reworked allowing multiple "observers" to independently register for events.  This allows both clients and HC_PERFORM_ENV to keep track of the connection state
* HCWebSocketConnectAsync Shim added to HC_PERFORM_ENV, tracking WebSocket connect attempts
  * During cleanup, WebSockets in the process of connecting will be allowed to finish connecting (currently no support for cancellation)
  * Connected WebSockets will be properly closed
* Validated E2E using local WebSocket echo server + API runner scripts (added in separate PR)
* Regression tested via API runner