### PR TITLE
Fix bad logic in WinHttp WebSocket fragment handling

### DIFF
--- a/Source/HTTP/WinHttp/winhttp_connection.h
+++ b/Source/HTTP/WinHttp/winhttp_connection.h
@@ -310,7 +310,7 @@ private:
     void WebSocketSendMessage(const WebSocketSendContext& sendContext);
     void WebSocketCompleteEntireSendQueueWithError(HRESULT error);
     HRESULT WebSocketReadAsync();
-    HRESULT WebSocketReadComplete(bool binaryMessage, bool isFragment, bool isFinalFragment);
+    HRESULT WebSocketReadComplete(bool binaryMessage, bool endOfMessage);
     void on_websocket_disconnected(_In_ USHORT closeReason);
 
     static HRESULT CALLBACK WebSocketConnectProvider(XAsyncOp op, const XAsyncProviderData* data);
@@ -322,7 +322,7 @@ private:
     std::recursive_mutex m_websocketSendMutex; // controls access to m_websocketSendQueue
     http_internal_queue<WebSocketSendContext*> m_websocketSendQueue{};
     websocket_message_buffer m_websocketReceiveBuffer;
-    bool m_websocketReceivingMessageFragments{ false };
+    bool m_websocketForwardingFragments{ false };
 };
 
 NAMESPACE_XBOX_HTTP_CLIENT_END

--- a/Source/WebSocket/hcwebsocket.cpp
+++ b/Source/WebSocket/hcwebsocket.cpp
@@ -107,6 +107,7 @@ namespace httpclient
 
 WebSocket::WebSocket(uint64_t _id, WebSocketPerformInfo performInfo, HC_PERFORM_ENV* performEnv) :
     id{ _id },
+    m_maxReceiveBufferSize{ WEBSOCKET_RECVBUFFER_MAXSIZE_DEFAULT },
     m_performInfo{ performInfo },
     m_performEnv{ performEnv }
 {


### PR DESCRIPTION
When WebSocket message fragments are received, they are collected in a buffer within LHC.  They are only forwarded to the client when that buffer is full or when the final fragment has been received.  When WinHttp has given us fragments, LHC incorrectly invokes the HCWebSocketBinaryMessageFragmentFunction even if we were able to accumulate the fragments in our buffer before passing them along to the client.

This also fixes a bug where the WebSocket's default m_maxReceiveBufferSize isn't correctly initialized to 20kb as documented in the header.