### PR TITLE
Fix race condition in CurlProvider::CleanupAsync (#669)

### DIFF
--- a/Source/Global/perform_env.cpp
+++ b/Source/Global/perform_env.cpp
@@ -222,7 +222,7 @@ Result<HC_UNIQUE_PTR<HC_PERFORM_ENV>> HC_PERFORM_ENV::Initialize(HCInitArgs* arg
     return std::move(performEnv);
 }
 
-HRESULT HC_PERFORM_ENV::CleanupAsync(HC_UNIQUE_PTR<HC_PERFORM_ENV>&& env, XAsyncBlock* async) noexcept
+HRESULT HC_PERFORM_ENV::CleanupAsync(HC_UNIQUE_PTR<HC_PERFORM_ENV> env, XAsyncBlock* async) noexcept
 {
     RETURN_IF_FAILED(XAsyncBegin(async, env.get(), __FUNCTION__, __FUNCTION__, CleanupAsyncProvider));
     env.release();

--- a/Source/Global/perform_env.h
+++ b/Source/Global/perform_env.h
@@ -26,7 +26,7 @@ public:
     // Called during HCInitialize. HC_PERFORM_ENV will be passed to Http/WebSocket hooks and is needed by default providers
     static Result<HC_UNIQUE_PTR<HC_PERFORM_ENV>> Initialize(HCInitArgs* args) noexcept;
 
-    static HRESULT CleanupAsync(HC_UNIQUE_PTR<HC_PERFORM_ENV>&& env, XAsyncBlock* async) noexcept;
+    static HRESULT CleanupAsync(HC_UNIQUE_PTR<HC_PERFORM_ENV> env, XAsyncBlock* async) noexcept;
 
     HC_PERFORM_ENV(const HC_PERFORM_ENV&) = delete;
     HC_PERFORM_ENV(HC_PERFORM_ENV&&) = delete;

--- a/Source/HTTP/Curl/CurlMulti.cpp
+++ b/Source/HTTP/Curl/CurlMulti.cpp
@@ -49,7 +49,7 @@ CurlMulti::~CurlMulti()
     }
 }
 
-HRESULT CurlMulti::AddRequest(HC_UNIQUE_PTR<CurlEasyRequest>&& easyRequest)
+HRESULT CurlMulti::AddRequest(HC_UNIQUE_PTR<CurlEasyRequest> easyRequest)
 {
     std::unique_lock<std::mutex> lock{ m_mutex };
 
@@ -69,7 +69,7 @@ HRESULT CurlMulti::AddRequest(HC_UNIQUE_PTR<CurlEasyRequest>&& easyRequest)
     return S_OK;
 }
 
-HRESULT CurlMulti::CleanupAsync(HC_UNIQUE_PTR<CurlMulti>&& multi, XAsyncBlock* async)
+HRESULT CurlMulti::CleanupAsync(HC_UNIQUE_PTR<CurlMulti> multi, XAsyncBlock* async)
 {
     assert(multi->m_cleanupAsyncBlock == nullptr);
     multi->m_cleanupAsyncBlock = async;
@@ -113,7 +113,7 @@ void CALLBACK CurlMulti::TaskQueueCallback(_In_opt_ void* context, _In_ bool can
     auto multi = static_cast<CurlMulti*>(context);
 
     if (!canceled)
-    {        
+    {
         HRESULT hr = multi->Perform();
         if (FAILED(hr))
         {

--- a/Source/HTTP/Curl/CurlMulti.h
+++ b/Source/HTTP/Curl/CurlMulti.h
@@ -18,10 +18,10 @@ public:
     ~CurlMulti();
 
     // Wrapper around curl_multi_add_handle
-    HRESULT AddRequest(HC_UNIQUE_PTR<CurlEasyRequest>&& easyRequest);
+    HRESULT AddRequest(HC_UNIQUE_PTR<CurlEasyRequest> easyRequest);
 
     // Asyncronously cleanup and outstanding requests
-    static HRESULT CleanupAsync(HC_UNIQUE_PTR<CurlMulti>&& multi, XAsyncBlock* async);
+    static HRESULT CleanupAsync(HC_UNIQUE_PTR<CurlMulti> multi, XAsyncBlock* async);
 
 private:
     CurlMulti() = default;

--- a/Source/HTTP/Curl/CurlProvider.cpp
+++ b/Source/HTTP/Curl/CurlProvider.cpp
@@ -41,8 +41,8 @@ Result<HC_UNIQUE_PTR<CurlProvider>> CurlProvider::Initialize()
 CurlProvider::~CurlProvider()
 {
     // Either CleanupAsync was never called or CurlProvider shouldn't be destroyed until it completes.
-    assert(!m_pendingMultiCleanups);
-    
+    assert(!m_cleanupTasksRemaining);
+
     if (m_multiCleanupQueue)
     {
         XTaskQueueCloseHandle(m_multiCleanupQueue);
@@ -96,7 +96,7 @@ HRESULT CurlProvider::PerformAsync(HCCallHandle hcCall, XAsyncBlock* async) noex
     return S_OK;
 }
 
-HRESULT CurlProvider::CleanupAsync(HC_UNIQUE_PTR<CurlProvider>&& provider, XAsyncBlock* async) noexcept
+HRESULT CurlProvider::CleanupAsync(HC_UNIQUE_PTR<CurlProvider> provider, XAsyncBlock* async) noexcept
 {
     // CleanupAsync should never be called more than once
     assert(provider->m_cleanupAsyncBlock == nullptr);
@@ -125,7 +125,10 @@ HRESULT CALLBACK CurlProvider::CleanupAsyncProvider(XAsyncOp op, const XAsyncPro
 
         {
             std::lock_guard<std::mutex> lock{ provider->m_mutex };
-            provider->m_pendingMultiCleanups = provider->m_curlMultis.size();
+            // There is a race condition where the last CurlMulti::CleanupAsync task can complete before the cleanup loop is finished.
+            // Because the loop condition relies on the provider being alive, we add an additional cleanup task, ensuring the provider
+            // can never be destroyed until after the loop.
+            provider->m_cleanupTasksRemaining = 1 + provider->m_curlMultis.size();
         }
 
         size_t multiIndex{ 0 };
@@ -140,15 +143,16 @@ HRESULT CALLBACK CurlProvider::CleanupAsyncProvider(XAsyncOp op, const XAsyncPro
                 HC_TRACE_ERROR_HR(HTTPCLIENT, hr, "CurlMulti::CleanupAsync failed, continuing cleanup");
 
                 std::lock_guard<std::mutex> lock{ provider->m_mutex };
-                --provider->m_pendingMultiCleanups;
+                --provider->m_cleanupTasksRemaining;
             }
         }
 
+
         {
             std::lock_guard<std::mutex> lock{ provider->m_mutex };
-            if (provider->m_pendingMultiCleanups == 0)
+            if (--provider->m_cleanupTasksRemaining == 0)
             {
-                // If there are no pending pending multi cleanups, we can complete synchronously
+                // If there are no pending pending multi cleanups, complete cleanup here
                 cleanupComplete = true;
             }
         }
@@ -178,7 +182,7 @@ void CALLBACK CurlProvider::MultiCleanupComplete(_Inout_ struct XAsyncBlock* asy
     CurlProvider* provider{ static_cast<CurlProvider*>(asyncBlock->context) };
 
     std::unique_lock<std::mutex> lock{ provider->m_mutex };
-    if (--provider->m_pendingMultiCleanups == 0)
+    if (--provider->m_cleanupTasksRemaining == 0)
     {
         // All CurlMultis have finished asyncCleanup. Destroy provider and complete provider's Cleanup XAsyncBlock
         XAsyncBlock* providerCleanupAsyncBlock{ provider->m_cleanupAsyncBlock };

--- a/Source/HTTP/Curl/CurlProvider.h
+++ b/Source/HTTP/Curl/CurlProvider.h
@@ -27,7 +27,7 @@ public:
         HCPerformEnv env
     ) noexcept;
 
-    static HRESULT CleanupAsync(HC_UNIQUE_PTR<CurlProvider>&& provider, XAsyncBlock* async) noexcept;
+    static HRESULT CleanupAsync(HC_UNIQUE_PTR<CurlProvider> provider, XAsyncBlock* async) noexcept;
 
 private:
     CurlProvider() = default;
@@ -44,7 +44,7 @@ private:
     XAsyncBlock* m_cleanupAsyncBlock{ nullptr };
     http_internal_vector<XAsyncBlock> m_multiCleanupAsyncBlocks;
     XTaskQueueHandle m_multiCleanupQueue{ nullptr };
-    size_t m_pendingMultiCleanups{ 0 };
+    size_t m_cleanupTasksRemaining{ 0 };
 };
 
 } // httpclient


### PR DESCRIPTION
During cleaning, CurlProvider loops over its CurlMultis and kicks off CurlMulti::CleanupAsync for each of them.  When the last of those sub-tasks completes, the Provider will be freed and then the CurlProvider::CleanupAsync task will be completed.  There is a race condition such that the final CurlMulti cleanup may complete _before_ CurlProvider::CleanupAsyncProvider's XAsyncOp::Begin.  This race exposes a couple of nasty bugs:
* Due to a tricky detail of how c++ move semantics work, ownership of the CurlMulti isn't properly transferred to CurlMulti::CleanupAsync, leading to the CurlMulti object (and its curl_multi handle) being cleaned up twice: once as part of CurlMulti::CleanupAsync (expected), and then a second time when the final MultiCleanupComplete fires while the CurlMulti object is still in the CurlProvider's m_curlMultis map (unexpected).  The fix is to properly transfer ownership of the CurlMulti by passing it by value rather than r-value reference.
* Because CurlProvider is looping over its member m_curlMultis, we need to ensure that the provider isn't destroyed before that loop completes.  The fix for this is to gate cleanup of the CurlProvider on not only the CurlMulti cleanup operations completing, but also on CurlProvider::CleanupAsyncProvider having exited that cleanup loop.

I also fixed a couple of other spots where ownership of unique_ptrs wasn't properly transferred, even though they didn't directly lead to bugs.