### PR TITLE
Add network-detail logging around network failures

### DIFF
--- a/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -30,7 +30,7 @@ public class HttpClientRequest {
     private static final OkHttpClient OK_CLIENT;
     private static final byte[] NO_BODY = new byte[0];
 
-    private Context appContext;
+    private final Context appContext;
     private Request.Builder requestBuilder;
 
     static {
@@ -148,6 +148,10 @@ public class HttpClientRequest {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             networkDetails.addSection("internetWasValidated", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED));
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            networkDetails.addSection("isNotSuspended", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_SUSPENDED));
         }
 
         return networkDetails.toString();

--- a/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -113,6 +113,12 @@ public class HttpClientRequest {
             .append('\n');
 
         Network activeNetwork = cm.getActiveNetwork();
+
+        builder
+            .append("Has active network: ")
+            .append(activeNetwork != null)
+            .append('\n');
+
         Network[] allNetworks = cm.getAllNetworks();
 
         for (Network network : allNetworks) {
@@ -133,25 +139,33 @@ public class HttpClientRequest {
 
         LinkProperties linkProperties = cm.getLinkProperties(network);
 
-        networkDetails.addSection("hasProxy", linkProperties.getHttpProxy() != null);
+        if (linkProperties != null) {
+            networkDetails.addSection("hasProxy", linkProperties.getHttpProxy() != null);
+        } else {
+            networkDetails.addSection("hasLinkProperties", false);
+        }
 
         NetworkCapabilities networkCapabilities = cm.getNetworkCapabilities(network);
 
-        networkDetails.addSection("isWifi", networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI));
-        networkDetails.addSection("isBluetooth", networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH));
-        networkDetails.addSection("isCellular", networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR));
-        networkDetails.addSection("isVpn", networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN));
-        networkDetails.addSection("isEthernet", networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET));
+        if (networkCapabilities != null) {
+            networkDetails.addSection("isWifi", networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI));
+            networkDetails.addSection("isBluetooth", networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH));
+            networkDetails.addSection("isCellular", networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR));
+            networkDetails.addSection("isVpn", networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN));
+            networkDetails.addSection("isEthernet", networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET));
 
-        networkDetails.addSection("shouldHaveInternet", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET));
-        networkDetails.addSection("isNotVpn", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN));
+            networkDetails.addSection("shouldHaveInternet", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET));
+            networkDetails.addSection("isNotVpn", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN));
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            networkDetails.addSection("internetWasValidated", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED));
-        }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                networkDetails.addSection("internetWasValidated", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED));
+            }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            networkDetails.addSection("isNotSuspended", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_SUSPENDED));
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                networkDetails.addSection("isNotSuspended", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_SUSPENDED));
+            }
+        } else {
+            networkDetails.addSection("hasNetworkCapabilities", false);
         }
 
         return networkDetails.toString();

--- a/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -1,9 +1,22 @@
 package com.xbox.httpclient;
 
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.LinkProperties;
+import android.net.Network;
+import android.net.NetworkCapabilities;
+import android.os.Build;
+
+import org.jetbrains.annotations.NotNull;
+
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
 
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -17,6 +30,7 @@ public class HttpClientRequest {
     private static final OkHttpClient OK_CLIENT;
     private static final byte[] NO_BODY = new byte[0];
 
+    private Context appContext;
     private Request.Builder requestBuilder;
 
     static {
@@ -25,8 +39,9 @@ public class HttpClientRequest {
                 .build();
     }
 
-    public HttpClientRequest() {
-        requestBuilder = new Request.Builder();
+    public HttpClientRequest(Context appContext) {
+        this.appContext = appContext;
+        this.requestBuilder = new Request.Builder();
     }
 
     @SuppressWarnings("unused")
@@ -58,13 +73,22 @@ public class HttpClientRequest {
         OK_CLIENT.newCall(this.requestBuilder.build()).enqueue(new Callback() {
             @Override
             public void onFailure(final Call call, IOException e) {
-                boolean isNoNetworkFailure = e instanceof UnknownHostException;
+                boolean isNoNetworkFailure =
+                    e instanceof UnknownHostException ||
+                    e instanceof ConnectException ||
+                    e instanceof SocketTimeoutException;
 
                 StringWriter sw = new StringWriter();
                 PrintWriter pw = new PrintWriter(sw);
                 e.printStackTrace(pw);
 
-                OnRequestFailed(sourceCall, e.getClass().getCanonicalName(), sw.toString(), isNoNetworkFailure);
+                OnRequestFailed(
+                    sourceCall,
+                    e.getClass().getCanonicalName(),
+                    sw.toString(),
+                    GetAllNetworksInfo(),
+                    isNoNetworkFailure
+                );
             }
 
             @Override
@@ -74,6 +98,92 @@ public class HttpClientRequest {
         });
     }
 
+    private String GetAllNetworksInfo() {
+        ConnectivityManager cm = (ConnectivityManager)appContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return "API version too old - no network info!";
+        }
+
+        StringBuilder builder = new StringBuilder();
+
+        builder
+            .append("Default proxy: ")
+            .append(cm.getDefaultProxy() != null)
+            .append('\n');
+
+        Network activeNetwork = cm.getActiveNetwork();
+        Network[] allNetworks = cm.getAllNetworks();
+
+        for (Network network : allNetworks) {
+            String networkDetails = GetDetailsForNetwork(cm, network, network.equals(activeNetwork));
+
+            builder
+                .append(networkDetails)
+                .append('\n');
+        }
+
+        return builder.toString();
+    }
+
+    private String GetDetailsForNetwork(ConnectivityManager cm, Network network, boolean isActiveNetwork) {
+        NetworkDetails networkDetails = new NetworkDetails();
+
+        networkDetails.addSection("isActiveNetwork", isActiveNetwork);
+
+        LinkProperties linkProperties = cm.getLinkProperties(network);
+
+        networkDetails.addSection("hasProxy", linkProperties.getHttpProxy() != null);
+
+        NetworkCapabilities networkCapabilities = cm.getNetworkCapabilities(network);
+
+        networkDetails.addSection("isWifi", networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI));
+        networkDetails.addSection("isBluetooth", networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH));
+        networkDetails.addSection("isCellular", networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR));
+        networkDetails.addSection("isVpn", networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN));
+        networkDetails.addSection("isEthernet", networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET));
+
+        networkDetails.addSection("shouldHaveInternet", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET));
+        networkDetails.addSection("isNotVpn", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN));
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            networkDetails.addSection("internetWasValidated", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED));
+        }
+
+        return networkDetails.toString();
+    }
+
     private native void OnRequestCompleted(long call, HttpClientResponse response);
-    private native void OnRequestFailed(long call, String errorMessage, String stackTrace, boolean isNoNetwork);
+    private native void OnRequestFailed(
+        long call,
+        String errorMessage,
+        String stackTrace,
+        String networkDetails,
+        boolean isNoNetwork
+    );
+
+    private static class NetworkDetails {
+        private final List<String> sections = new ArrayList<>();
+
+        void addSection(String key, boolean value) {
+            sections.add(key + ": " + value);
+        }
+
+        @NotNull
+        public String toString() {
+            StringBuilder builder = new StringBuilder();
+            builder.append("Network details: ");
+
+            // String.join() is only available in API 26+ *rolls-eyes*
+            for (int i = 0; i < sections.size(); i++) {
+                if (i > 0) {
+                    builder.append(", ");
+                }
+
+                builder.append(sections.get(i));
+            }
+
+            return builder.toString();
+        }
+    }
 }

--- a/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -115,10 +115,12 @@ public class HttpClientRequest {
 
         Network[] allNetworks = cm.getAllNetworks();
 
-        for (Network network : allNetworks) {
-            builder
-                .append("\n  ")
-                .append(NetworkObserver.NetworkDetails.getNetworkDetails(network, cm));
+        for (int i = 0; i < allNetworks.length; i++) {
+            if (i > 0) {
+                builder.append("\n");
+            }
+
+            builder.append(NetworkObserver.NetworkDetails.getNetworkDetails(allNetworks[i], cm));
         }
 
         return builder.toString();

--- a/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -102,15 +102,13 @@ public class HttpClientRequest {
         StringBuilder builder = new StringBuilder();
 
         builder
-            .append("Default proxy: ")
+            .append("Has default proxy: ")
             .append(cm.getDefaultProxy() != null)
             .append('\n');
 
-        Network activeNetwork = cm.getActiveNetwork();
-
         builder
             .append("Has active network: ")
-            .append(activeNetwork != null)
+            .append(cm.getActiveNetwork() != null)
             .append('\n');
 
         Network[] allNetworks = cm.getAllNetworks();

--- a/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/NetworkObserver.java
+++ b/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/NetworkObserver.java
@@ -124,11 +124,8 @@ public class NetworkObserver {
         private static String join(Map<String, Boolean> sections) {
             StringBuilder builder = new StringBuilder();
 
-            boolean firstEntry = true;
             for (Map.Entry<String, Boolean> entry : sections.entrySet()) {
-                if (firstEntry) {
-                    firstEntry = false;
-                } else {
+                if (builder.length() > 0)  {
                     builder.append(", ");
                 }
 

--- a/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/NetworkObserver.java
+++ b/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/NetworkObserver.java
@@ -15,6 +15,9 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class NetworkObserver {
+    @NotNull private static String s_lastCapabilities = "";
+    @NotNull private static String s_lastLinkProperties = "";
+
     @SuppressWarnings("unused")
     public static void Initialize(Context appContext) {
         ConnectivityManager cm = (ConnectivityManager) appContext.getSystemService(Context.CONNECTIVITY_SERVICE);
@@ -32,13 +35,33 @@ public class NetworkObserver {
             }
 
             @Override
+            public void onLost(Network network) {
+                LogMessage(network, "was lost");
+            }
+
+            @Override
+            public void onUnavailable() {
+                Log("No networks were available");
+            }
+
+            @Override
             public void onCapabilitiesChanged(Network network, NetworkCapabilities capabilities) {
-                LogMessage(network, "has capabilities: " + NetworkDetails.checkNetworkCapabilities(capabilities));
+                String newCapabilities = NetworkDetails.checkNetworkCapabilities(capabilities);
+
+                if (!newCapabilities.equals(s_lastCapabilities)) {
+                    s_lastCapabilities = newCapabilities;
+                    LogMessage(network, "has capabilities: " + s_lastCapabilities);
+                }
             }
 
             @Override
             public void onLinkPropertiesChanged(Network network, LinkProperties linkProperties) {
-                LogMessage(network, "has link properties: " + NetworkDetails.checkLinkProperties(linkProperties));
+                String newLinkProperties = NetworkDetails.checkLinkProperties(linkProperties);
+
+                if (!newLinkProperties.equals(s_lastLinkProperties)) {
+                    s_lastLinkProperties = newLinkProperties;
+                    LogMessage(network, "has link properties: " + s_lastLinkProperties);
+                }
             }
 
             private void LogMessage(Network network, String message) {

--- a/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/NetworkObserver.java
+++ b/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/NetworkObserver.java
@@ -1,0 +1,122 @@
+package com.xbox.httpclient;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.LinkProperties;
+import android.net.Network;
+import android.net.NetworkCapabilities;
+import android.net.NetworkRequest;
+import android.os.Build;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class NetworkObserver {
+    @SuppressWarnings("unused")
+    public static void Initialize(Context appContext) {
+        ConnectivityManager cm = (ConnectivityManager) appContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+
+        // Build a network request to query for all networks that "should" be
+        // able to access the internet
+        NetworkRequest networkRequest = new NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .build();
+
+        cm.registerNetworkCallback(networkRequest, new ConnectivityManager.NetworkCallback() {
+            @Override
+            public void onAvailable(Network network) {
+                LogMessage(network, "is available");
+            }
+
+            @Override
+            public void onCapabilitiesChanged(Network network, NetworkCapabilities capabilities) {
+                LogMessage(network, "has capabilities: " + NetworkDetails.checkNetworkCapabilities(capabilities));
+            }
+
+            @Override
+            public void onLinkPropertiesChanged(Network network, LinkProperties linkProperties) {
+                LogMessage(network, "has link properties: " + NetworkDetails.checkLinkProperties(linkProperties));
+            }
+
+            private void LogMessage(Network network, String message) {
+                Log("Network ID " + network.hashCode() + " " + message);
+            }
+        });
+    }
+
+    private static native void Log(String message);
+
+    static class NetworkDetails {
+        static String getNetworkDetails(Network network, ConnectivityManager cm) {
+            StringBuilder builder = new StringBuilder();
+
+            @Nullable NetworkCapabilities capabilities = cm.getNetworkCapabilities(network);
+            @Nullable LinkProperties linkProperties = cm.getLinkProperties(network);
+
+            return builder
+                .append("Network ")
+                .append(network.hashCode())
+                .append(":")
+                .append("\n  Capabilities: ")
+                .append(capabilities != null ? checkNetworkCapabilities(capabilities) : "Got null capabilities")
+                .append("\n  Link properties: ")
+                .append(linkProperties != null ? checkLinkProperties(linkProperties) : "Got null link properties")
+                .toString();
+        }
+
+        private static String checkNetworkCapabilities(@NotNull NetworkCapabilities capabilities) {
+            Map<String, Boolean> sections = new LinkedHashMap<>();
+
+            sections.put("isWifi", capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI));
+            sections.put("isBluetooth", capabilities.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH));
+            sections.put("isCellular", capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR));
+            sections.put("isVpn", capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN));
+            sections.put("isEthernet", capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET));
+
+            sections.put("shouldHaveInternet", capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET));
+            sections.put("isNotVpn", capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN));
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                sections.put("internetWasValidated", capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED));
+            }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                sections.put("isNotSuspended", capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_SUSPENDED));
+            }
+
+            return join(sections);
+        }
+
+        private static String checkLinkProperties(@NotNull LinkProperties properties) {
+            Map<String, Boolean> sections = new LinkedHashMap<>();
+
+            sections.put("hasProxy", properties.getHttpProxy() != null);
+
+            return join(sections);
+        }
+
+        private static String join(Map<String, Boolean> sections) {
+            StringBuilder builder = new StringBuilder();
+
+            boolean firstEntry = true;
+            for (Map.Entry<String, Boolean> entry : sections.entrySet()) {
+                if (firstEntry) {
+                    firstEntry = false;
+                } else {
+                    builder.append(", ");
+                }
+
+                builder
+                    .append(entry.getKey())
+                    .append(": ")
+                    .append(entry.getValue());
+            }
+
+            return builder.toString();
+        }
+    }
+}
+

--- a/Source/HTTP/Android/android_http_request.h
+++ b/Source/HTTP/Android/android_http_request.h
@@ -4,7 +4,13 @@
 
 class HttpRequest {
 public:
-    HttpRequest(XAsyncBlock* asyncBlock, JavaVM* javaVm, jclass httpRequestClass, jclass httpResponseClass);
+    HttpRequest(
+        XAsyncBlock* asyncBlock,
+        JavaVM* javaVm,
+        jobject applicationContext,
+        jclass httpRequestClass,
+        jclass httpResponseClass
+    );
     virtual ~HttpRequest();
 
     HRESULT Initialize();
@@ -27,6 +33,7 @@ private:
     XAsyncBlock* m_asyncBlock;
 
     JavaVM* m_javaVm;
+    jobject m_applicationContext;
     jclass m_httpRequestClass;
     jclass m_httpResponseClass;
 };

--- a/Source/HTTP/Android/android_platform_context.cpp
+++ b/Source/HTTP/Android/android_platform_context.cpp
@@ -24,6 +24,26 @@ Result<std::shared_ptr<AndroidPlatformContext>> AndroidPlatformContext::Initiali
         return E_FAIL;
     }
 
+    // Initialize the network observer
+
+    jclass localNetworkObserver = jniEnv->FindClass("com/xbox/httpclient/NetworkObserver");
+    if (localNetworkObserver == nullptr)
+    {
+        HC_TRACE_ERROR(HTTPCLIENT, "Could not find NetworkObserver class");
+        return E_FAIL;
+    }
+
+    jmethodID networkObserverInitialize = jniEnv->GetStaticMethodID(localNetworkObserver, "Initialize", "(Landroid/content/Context;)V");
+    if (networkObserverInitialize == nullptr)
+    {
+        HC_TRACE_ERROR(HTTPCLIENT, "Could not find NetworkObserver.Initialize method");
+        return E_FAIL;
+    }
+
+    jniEnv->CallStaticVoidMethod(localNetworkObserver, networkObserverInitialize, args->applicationContext);
+
+    // Get class references we need to hold onto
+
     jclass localHttpRequest = jniEnv->FindClass("com/xbox/httpclient/HttpClientRequest");
     if (localHttpRequest == nullptr)
     {

--- a/Source/HTTP/Android/http_android.cpp
+++ b/Source/HTTP/Android/http_android.cpp
@@ -69,6 +69,17 @@ void LogByLine(JNIEnv* env, jstring javaString, char const* intro, char const* l
 extern "C"
 {
 
+JNIEXPORT void JNICALL Java_com_xbox_httpclient_NetworkObserver_Log(
+    JNIEnv* env,
+    jclass /*clazz*/,
+    jstring message
+)
+{
+    const char* nativeMessage = env->GetStringUTFChars(message, nullptr);
+    HC_TRACE_IMPORTANT(HTTPCLIENT, "NetworkObserver: %s", nativeMessage);
+    env->ReleaseStringUTFChars(message, nativeMessage);
+}
+
 JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientRequest_OnRequestCompleted(
     JNIEnv* /* env */,
     jobject /* instance */,

--- a/Source/HTTP/Android/http_android.cpp
+++ b/Source/HTTP/Android/http_android.cpp
@@ -134,7 +134,7 @@ JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientRequest_OnRequestFaile
     );
 
     LogByLine(env, networkDetails,
-        "Network request failed, network details:", // intro
+        "Network request failed, all network details:", // intro
         "  %.*s" // lineFormat
     );
 

--- a/Source/HTTP/Android/http_android.h
+++ b/Source/HTTP/Android/http_android.h
@@ -22,6 +22,7 @@ JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientRequest_OnRequestFaile
         jlong call,
         jstring errorMessage,
         jstring stackTrace,
+        jstring networkDetails,
         jboolean isNoNetwork
 );
 

--- a/Source/HTTP/Android/http_android.h
+++ b/Source/HTTP/Android/http_android.h
@@ -9,6 +9,12 @@
 extern "C"
 {
 
+JNIEXPORT void JNICALL Java_com_xbox_httpclient_NetworkObserver_Log(
+    JNIEnv* env,
+    jclass clazz,
+    jstring message
+);
+
 JNIEXPORT void JNICALL Java_com_xbox_httpclient_HttpClientRequest_OnRequestCompleted(
     JNIEnv * /* env */,
     jobject /* instance */,


### PR DESCRIPTION
For unknown reasons, libHttpClient on Android sometimes fails to perform HTTP requests (OkHttp fails with an instance of a `ConnectException`, `UnknownHostException`, or `SocketTimeoutException`) when it is known that other components in the app are able to make requests.

This PR adds significant logging of network details to try and identify in the wild, through logs via bug reports, any correlations between "libHttpClient failed to make a request" and details of what networks are available.

Specifically, on network failure libHttpClient will now synchronously collect details of the networks present on the device, such as if they have a proxy configured.

Additionally, libHttpClient will now also collect those details of networks as they change, via the `ConnectivityManager.registerNetworkCallback` asynchronous listener.

The goal of this logging is to identify why libHttpClient sometimes gets stuck in failing to make requests, and should be considered temporary in that once the bug is fixed this logging should be removed.