### PR TITLE
Unregister Android network observer callback during LHC cleanup

### DIFF
--- a/Source/HTTP/Android/android_platform_context.h
+++ b/Source/HTTP/Android/android_platform_context.h
@@ -14,10 +14,17 @@ public:
     jclass GetHttpResponseClass() { return m_httpResponseClass; }
 
 private:
-    AndroidPlatformContext(JavaVM* javaVm, jobject applicationContext, jclass requestClass, jclass responseClass);
+    AndroidPlatformContext(
+        JavaVM* javaVm,
+        jobject applicationContext,
+        jclass networkObserverClass,
+        jclass requestClass,
+        jclass responseClass
+    );
 
     JavaVM * m_javaVm;
     jobject m_applicationContext;
+    jclass m_networkObserverClass;
     jclass m_httpRequestClass;
     jclass m_httpResponseClass;
 };


### PR DESCRIPTION
Currently, we never unregister the callback we give to the Android `ConnectivityManager` service, which throws an exception once we have done so ~100 times (rare in the wild, but relevant to test scenarios).

This PR adds logic to the `AndroidPlatformContext` to unregister the callback during destruction.