### PR TITLE
Fix deadlock in threadpool_stl

### DIFF
--- a/Source/Task/ThreadPool_stl.cpp
+++ b/Source/Task/ThreadPool_stl.cpp
@@ -57,10 +57,7 @@ namespace OS
                         std::unique_lock<std::mutex> lock(m_wakeLock);
                         while (true)
                         {
-                            if (m_calls == 0)
-                            {
-                                m_wake.wait(lock);
-                            }
+                            m_wake.wait(lock, [this]{ return m_calls != 0 || m_terminate; });
 
                             if (m_terminate)
                             {


### PR DESCRIPTION
Short lived libHC instances were deadlocking because of insufficient checks upon entering condvar wait.

If large number of threads created, then threads could start execution with `m_terminate` being set to true already.
Waiting for on `m_wake` condvar without prior check of `m_terminate` causes deadlock