### PR TITLE
Check allocated buffer size before copying response

### DIFF
--- a/Source/HTTP/httpcall_response.cpp
+++ b/Source/HTTP/httpcall_response.cpp
@@ -126,6 +126,11 @@ try
         return E_FAIL;
     }
 
+    if (call->responseBodyBytes.size() > bufferSize)
+    {
+        return E_BOUNDS;
+    }
+
 #if HC_PLATFORM_IS_MICROSOFT
     memcpy_s(buffer, bufferSize, call->responseBodyBytes.data(), call->responseBodyBytes.size());
 #else


### PR DESCRIPTION
Small safety check to ensure destination buffer has enough space.