### PR TITLE
Addressing several WebSocket bugs

### DIFF
--- a/Samples/Win32WebSocket/main.cpp
+++ b/Samples/Win32WebSocket/main.cpp
@@ -239,7 +239,7 @@ int main()
     XTaskQueueRegisterMonitor(g_queue, nullptr, HandleAsyncQueueCallback, &g_callbackToken);
     StartBackgroundThread();
 
-    std::string url = "ws://localhost:9002";
+    std::string url = "ws://JOHLAFO-DEV1:9002";
 
     auto websocketContext = new WebSocketContext{};
     HCWebSocketCreate(&websocketContext->handle, WebSocketMessageReceived, WebSocketBinaryMessageReceived, WebSocketClosed, websocketContext);
@@ -324,6 +324,7 @@ int main()
     }
 
     printf_s("Calling HCWebSocketDisconnect...\n");
+    Sleep(5000);
     HCWebSocketDisconnect(websocketContext->handle);
     WaitForSingleObject(websocketContext->closeEventHandle, INFINITE);
     delete websocketContext;

--- a/Samples/Win32WebSocket/main.cpp
+++ b/Samples/Win32WebSocket/main.cpp
@@ -239,7 +239,7 @@ int main()
     XTaskQueueRegisterMonitor(g_queue, nullptr, HandleAsyncQueueCallback, &g_callbackToken);
     StartBackgroundThread();
 
-    std::string url = "ws://JOHLAFO-DEV1:9002";
+    std::string url = "ws://localhost:9002";
 
     auto websocketContext = new WebSocketContext{};
     HCWebSocketCreate(&websocketContext->handle, WebSocketMessageReceived, WebSocketBinaryMessageReceived, WebSocketClosed, websocketContext);
@@ -324,7 +324,6 @@ int main()
     }
 
     printf_s("Calling HCWebSocketDisconnect...\n");
-    Sleep(5000);
     HCWebSocketDisconnect(websocketContext->handle);
     WaitForSingleObject(websocketContext->closeEventHandle, INFINITE);
     delete websocketContext;

--- a/Source/HTTP/WinHttp/winhttp_connection.cpp
+++ b/Source/HTTP/WinHttp/winhttp_connection.cpp
@@ -368,7 +368,7 @@ HRESULT WinHttpConnection::WebSocketDisconnect(_In_ HCWebSocketCloseStatus close
     }
 
     // Shutdown closes the send channel after sending a close frame. When we receive a close frame we are fully disconnected
-    DWORD dwError = m_winHttpWebSocketExports.close(m_hRequest, static_cast<short>(closeStatus), nullptr, 0);
+    DWORD dwError = m_winHttpWebSocketExports.shutdown(m_hRequest, static_cast<short>(closeStatus), nullptr, 0);
     return HRESULT_FROM_WIN32(dwError);
 }
 #endif

--- a/Source/HTTP/WinHttp/winhttp_connection.cpp
+++ b/Source/HTTP/WinHttp/winhttp_connection.cpp
@@ -368,7 +368,7 @@ HRESULT WinHttpConnection::WebSocketDisconnect(_In_ HCWebSocketCloseStatus close
     }
 
     // Shutdown closes the send channel after sending a close frame. When we receive a close frame we are fully disconnected
-    DWORD dwError = m_winHttpWebSocketExports.shutdown(m_hRequest, static_cast<short>(closeStatus), nullptr, 0);
+    DWORD dwError = m_winHttpWebSocketExports.close(m_hRequest, static_cast<short>(closeStatus), nullptr, 0);
     return HRESULT_FROM_WIN32(dwError);
 }
 #endif
@@ -680,7 +680,6 @@ void WinHttpConnection::callback_status_request_error(
     }
     else
     {
-#if HC_WINHTTP_WEBSOCKETS
         if (pRequestContext->m_websocketHandle && (pRequestContext->m_state == ConnectionState::WebSocketConnected || pRequestContext->m_state == ConnectionState::WebSocketClosing))
         {
             // Only trigger if we're already connected, never during a connection attempt
@@ -689,7 +688,6 @@ void WinHttpConnection::callback_status_request_error(
                 pRequestContext->on_websocket_disconnected(static_cast<USHORT>(errorCode));
             }
         }
-#endif
 
         pRequestContext->complete_task(E_FAIL, HRESULT_FROM_WIN32(errorCode));
     }
@@ -1528,6 +1526,14 @@ void WinHttpConnection::callback_websocket_status_headers_available(
         winHttpConnection->m_lock.unlock();
         winHttpConnection->complete_task(E_FAIL, HRESULT_FROM_WIN32(dwError));
         return;
+    }
+
+    constexpr DWORD closeTimeoutMs = 1000;
+    bool status = WinHttpSetOption(winHttpConnection->m_hRequest, WINHTTP_OPTION_WEB_SOCKET_CLOSE_TIMEOUT, (LPVOID)&closeTimeoutMs, sizeof(DWORD));
+    if (!status)
+    {
+        DWORD dwError = GetLastError();
+        HC_TRACE_ERROR(HTTPCLIENT, "WinHttpConnection [ID %llu] [TID %ul] WinHttpSetOption errorcode %d", TO_ULL(HCHttpCallGetId(winHttpConnection->m_call)), GetCurrentThreadId(), dwError);
     }
 
     winHttpConnection->m_state = ConnectionState::WebSocketConnected;

--- a/Source/WebSocket/hcwebsocket.h
+++ b/Source/WebSocket/hcwebsocket.h
@@ -164,6 +164,7 @@ private:
         void* context{ nullptr };
     };
 
+    std::mutex m_stateMutex;
     enum class State
     {
         Initial,
@@ -173,7 +174,7 @@ private:
         Disconnected
     } m_state{ State::Initial };
 
-    std::mutex m_mutex;
+    std::recursive_mutex m_eventCallbacksMutex;
     http_internal_map<uint32_t, EventCallbacks> m_eventCallbacks{};
     uint32_t m_nextToken{ 1 };
 


### PR DESCRIPTION
* WinHttp request error not correctly handled when a disconnect isn't acknowledged by the server
* Fixes race condition between WebSocket disconnect event handler invocation and unregistration when closing a WebSocket handle
* HCWebSocketConnectAsync will now pass back the client's WebSocket handle in the XAsync result rather than an internal handle