### PR TITLE
Fixed hang in XblCleanupAsync

### DIFF
--- a/Source/HTTP/Curl/CurlProvider.cpp
+++ b/Source/HTTP/Curl/CurlProvider.cpp
@@ -81,13 +81,21 @@ HRESULT CurlProvider::PerformAsync(HCCallHandle hcCall, XAsyncBlock* async) noex
     auto easyInitResult = CurlEasyRequest::Initialize(hcCall, async);
     RETURN_IF_FAILED(easyInitResult.hr);
 
-    auto iter = m_curlMultis.find(workPort);
-    if (iter == m_curlMultis.end())
-    {
-        auto multiInitResult = CurlMulti::Initialize(workPort);
-        RETURN_IF_FAILED(multiInitResult.hr);
+    http_internal_map<XTaskQueuePortHandle, HC_UNIQUE_PTR<xbox::httpclient::CurlMulti>>::iterator iter;
 
-        iter = m_curlMultis.emplace(workPort, multiInitResult.ExtractPayload()).first;
+	{
+        // CurlProvider::PerformAsync can be called simultaneously from multiple threads so we need to lock
+        // to prevent unsafe access to m_curlMultis
+		std::lock_guard<std::mutex> lock{ m_mutex };
+
+		iter = m_curlMultis.find(workPort);
+		if (iter == m_curlMultis.end())
+		{
+			auto multiInitResult = CurlMulti::Initialize(workPort);
+			RETURN_IF_FAILED(multiInitResult.hr);
+
+			iter = m_curlMultis.emplace(workPort, multiInitResult.ExtractPayload()).first;
+		}
     }
 
     auto& multi{ iter->second };
@@ -133,28 +141,26 @@ HRESULT CALLBACK CurlProvider::CleanupAsyncProvider(XAsyncOp op, const XAsyncPro
         size_t multiIndex{ 0 };
         bool cleanupComplete{ false };
 
-        for (auto& pair : provider->m_curlMultis)
-        {
-            HRESULT hr = CurlMulti::CleanupAsync(std::move(pair.second), &provider->m_multiCleanupAsyncBlocks[multiIndex++]);
-            if (FAILED(hr))
-            {
-                // Continue cleanup if this fails, but we should expect 1 fewer MultiCleanupComplete callback
-                HC_TRACE_ERROR_HR(HTTPCLIENT, hr, "CurlMulti::CleanupAsync failed, continuing cleanup");
+		{
+			std::lock_guard<std::mutex> lock{ provider->m_mutex };
+			for (auto& pair : provider->m_curlMultis)
+			{
+				HRESULT hr = CurlMulti::CleanupAsync(std::move(pair.second), &provider->m_multiCleanupAsyncBlocks[multiIndex++]);
+				if (FAILED(hr))
+				{
+					// Continue cleanup if this fails, but we should expect 1 fewer MultiCleanupComplete callback
+					HC_TRACE_ERROR_HR(HTTPCLIENT, hr, "CurlMulti::CleanupAsync failed, continuing cleanup");
 
-                std::lock_guard<std::mutex> lock{ provider->m_mutex };
-                --provider->m_cleanupTasksRemaining;
-            }
-        }
+					--provider->m_cleanupTasksRemaining;
+				}
+			}
 
-
-        {
-            std::lock_guard<std::mutex> lock{ provider->m_mutex };
-            if (--provider->m_cleanupTasksRemaining == 0)
-            {
-                // If there are no pending pending multi cleanups, complete cleanup here
-                cleanupComplete = true;
-            }
-        }
+			if (--provider->m_cleanupTasksRemaining == 0)
+			{
+				// If there are no pending pending multi cleanups, complete cleanup here
+				cleanupComplete = true;
+			}
+		}
 
         if (cleanupComplete)
         {

--- a/Source/HTTP/Curl/CurlProvider.cpp
+++ b/Source/HTTP/Curl/CurlProvider.cpp
@@ -81,21 +81,13 @@ HRESULT CurlProvider::PerformAsync(HCCallHandle hcCall, XAsyncBlock* async) noex
     auto easyInitResult = CurlEasyRequest::Initialize(hcCall, async);
     RETURN_IF_FAILED(easyInitResult.hr);
 
-    http_internal_map<XTaskQueuePortHandle, HC_UNIQUE_PTR<xbox::httpclient::CurlMulti>>::iterator iter;
+    auto iter = m_curlMultis.find(workPort);
+    if (iter == m_curlMultis.end())
+    {
+        auto multiInitResult = CurlMulti::Initialize(workPort);
+        RETURN_IF_FAILED(multiInitResult.hr);
 
-	{
-        // CurlProvider::PerformAsync can be called simultaneously from multiple threads so we need to lock
-        // to prevent unsafe access to m_curlMultis
-		std::lock_guard<std::mutex> lock{ m_mutex };
-
-		iter = m_curlMultis.find(workPort);
-		if (iter == m_curlMultis.end())
-		{
-			auto multiInitResult = CurlMulti::Initialize(workPort);
-			RETURN_IF_FAILED(multiInitResult.hr);
-
-			iter = m_curlMultis.emplace(workPort, multiInitResult.ExtractPayload()).first;
-		}
+        iter = m_curlMultis.emplace(workPort, multiInitResult.ExtractPayload()).first;
     }
 
     auto& multi{ iter->second };
@@ -141,26 +133,28 @@ HRESULT CALLBACK CurlProvider::CleanupAsyncProvider(XAsyncOp op, const XAsyncPro
         size_t multiIndex{ 0 };
         bool cleanupComplete{ false };
 
-		{
-			std::lock_guard<std::mutex> lock{ provider->m_mutex };
-			for (auto& pair : provider->m_curlMultis)
-			{
-				HRESULT hr = CurlMulti::CleanupAsync(std::move(pair.second), &provider->m_multiCleanupAsyncBlocks[multiIndex++]);
-				if (FAILED(hr))
-				{
-					// Continue cleanup if this fails, but we should expect 1 fewer MultiCleanupComplete callback
-					HC_TRACE_ERROR_HR(HTTPCLIENT, hr, "CurlMulti::CleanupAsync failed, continuing cleanup");
+        for (auto& pair : provider->m_curlMultis)
+        {
+            HRESULT hr = CurlMulti::CleanupAsync(std::move(pair.second), &provider->m_multiCleanupAsyncBlocks[multiIndex++]);
+            if (FAILED(hr))
+            {
+                // Continue cleanup if this fails, but we should expect 1 fewer MultiCleanupComplete callback
+                HC_TRACE_ERROR_HR(HTTPCLIENT, hr, "CurlMulti::CleanupAsync failed, continuing cleanup");
 
-					--provider->m_cleanupTasksRemaining;
-				}
-			}
+                std::lock_guard<std::mutex> lock{ provider->m_mutex };
+                --provider->m_cleanupTasksRemaining;
+            }
+        }
 
-			if (--provider->m_cleanupTasksRemaining == 0)
-			{
-				// If there are no pending pending multi cleanups, complete cleanup here
-				cleanupComplete = true;
-			}
-		}
+
+        {
+            std::lock_guard<std::mutex> lock{ provider->m_mutex };
+            if (--provider->m_cleanupTasksRemaining == 0)
+            {
+                // If there are no pending pending multi cleanups, complete cleanup here
+                cleanupComplete = true;
+            }
+        }
 
         if (cleanupComplete)
         {

--- a/Source/HTTP/Curl/CurlProvider.h
+++ b/Source/HTTP/Curl/CurlProvider.h
@@ -34,6 +34,8 @@ private:
 
     HRESULT PerformAsync(HCCallHandle hcCall, XAsyncBlock* async) noexcept;
 
+    void CheckCurlMultis();
+
     static HRESULT CALLBACK CleanupAsyncProvider(XAsyncOp op, const XAsyncProviderData* data) noexcept;
     static void CALLBACK MultiCleanupComplete(_Inout_ struct XAsyncBlock* asyncBlock) noexcept;
 
@@ -45,6 +47,8 @@ private:
     http_internal_vector<XAsyncBlock> m_multiCleanupAsyncBlocks;
     XTaskQueueHandle m_multiCleanupQueue{ nullptr };
     size_t m_cleanupTasksRemaining{ 0 };
+    volatile bool m_curlMultisLock{ false };
+    DWORD m_lockingThread{ 0 };
 };
 
 } // httpclient

--- a/Source/HTTP/Curl/CurlProvider.h
+++ b/Source/HTTP/Curl/CurlProvider.h
@@ -34,8 +34,6 @@ private:
 
     HRESULT PerformAsync(HCCallHandle hcCall, XAsyncBlock* async) noexcept;
 
-    void CheckCurlMultis();
-
     static HRESULT CALLBACK CleanupAsyncProvider(XAsyncOp op, const XAsyncProviderData* data) noexcept;
     static void CALLBACK MultiCleanupComplete(_Inout_ struct XAsyncBlock* asyncBlock) noexcept;
 
@@ -47,8 +45,6 @@ private:
     http_internal_vector<XAsyncBlock> m_multiCleanupAsyncBlocks;
     XTaskQueueHandle m_multiCleanupQueue{ nullptr };
     size_t m_cleanupTasksRemaining{ 0 };
-    volatile bool m_curlMultisLock{ false };
-    DWORD m_lockingThread{ 0 };
 };
 
 } // httpclient


### PR DESCRIPTION
CurlProvider::PerformAsync can be called simultaneously from multiple threads, which leaves CurlProvider::m_curlMultis in a bad state.  That results in m_curlMultis.size() being incorrect, which results in m_cleanupTasksRemaining being incorrect, which results in XAsyncComplete never being called in CurlProvider cleanup.

I protect against this by protecting access to m_curlMultis with m_mutex.