### PR TITLE
Fix Android build on Linux hosts

### DIFF
--- a/Source/Logger/Android/android_logger.cpp
+++ b/Source/Logger/Android/android_logger.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-#include <Android/log.h>
+#include <android/log.h>
 #include <httpClient/pal.h>
 #include <httpClient/trace.h>
 


### PR DESCRIPTION
Filsystem on Linux is case sensitive and `android/log.h` header in NDK is all lowercase.