### PR TITLE
Adding support for /Zc:strictStrings

### DIFF
--- a/Build/libHttpClient.142.GDK.C/libHttpClient.142.GDK.C.vcxproj
+++ b/Build/libHttpClient.142.GDK.C/libHttpClient.142.GDK.C.vcxproj
@@ -54,7 +54,7 @@
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
       <SDLCheck>true</SDLCheck>
-      <AdditionalOptions>/bigobj /Zm300 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /Zm300 /Zc:strictStrings %(AdditionalOptions)</AdditionalOptions>
       <ProgramDataBaseFileName>$(OutDir)$(ProjectName).pdb</ProgramDataBaseFileName>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <ShowIncludes Condition="'$(Configuration)'=='Debug'">false</ShowIncludes>

--- a/Build/libHttpClient.142.Win32.C/libHttpClient.142.Win32.C.vcxproj
+++ b/Build/libHttpClient.142.Win32.C/libHttpClient.142.Win32.C.vcxproj
@@ -72,7 +72,7 @@
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
       <SDLCheck>true</SDLCheck>
-      <AdditionalOptions>/bigobj /Zm300 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /Zm300 /Zc:strictStrings %(AdditionalOptions)</AdditionalOptions>
       <ProgramDataBaseFileName>$(OutDir)$(ProjectName).pdb</ProgramDataBaseFileName>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <ShowIncludes Condition="'$(Configuration)'=='Debug'">false</ShowIncludes>

--- a/Source/HTTP/WinHttp/winhttp_connection.cpp
+++ b/Source/HTTP/WinHttp/winhttp_connection.cpp
@@ -1331,7 +1331,7 @@ void WinHttpConnection::on_websocket_disconnected(_In_ USHORT closeReason)
 #endif
 }
 
-char* WinHttpConnection::winhttp_web_socket_buffer_type_to_string(
+const char* WinHttpConnection::winhttp_web_socket_buffer_type_to_string(
     _In_ WINHTTP_WEB_SOCKET_BUFFER_TYPE bufferType
 )
 {

--- a/Source/HTTP/WinHttp/winhttp_connection.h
+++ b/Source/HTTP/WinHttp/winhttp_connection.h
@@ -263,7 +263,7 @@ private:
         _In_ WinHttpConnection* pRequestContext,
         _In_ void* statusInfo);
 
-    static char* winhttp_web_socket_buffer_type_to_string(
+    static const char* winhttp_web_socket_buffer_type_to_string(
         _In_ WINHTTP_WEB_SOCKET_BUFFER_TYPE bufferType
     );
 

--- a/Source/WebSocket/Websocketpp/x509_cert_utilities.hpp
+++ b/Source/WebSocket/Websocketpp/x509_cert_utilities.hpp
@@ -479,7 +479,7 @@ bool verify_X509_cert_chain(const http_internal_vector<http_internal_string> &ce
     ZeroMemory(&params, sizeof(params));
     params.cbSize = sizeof(CERT_CHAIN_PARA);
     params.RequestedUsage.dwType = USAGE_MATCH_TYPE_OR;
-    LPSTR usages [] =
+    PCSTR usages [] =
     {
         szOID_PKIX_KP_SERVER_AUTH,
 
@@ -488,7 +488,7 @@ bool verify_X509_cert_chain(const http_internal_vector<http_internal_string> &ce
         szOID_SGC_NETSCAPE
     };
     params.RequestedUsage.Usage.cUsageIdentifier = std::extent<decltype(usages)>::value;
-    params.RequestedUsage.Usage.rgpszUsageIdentifier = usages;
+    params.RequestedUsage.Usage.rgpszUsageIdentifier = const_cast<LPSTR*>(usages);
     PCCERT_CHAIN_CONTEXT chainContext;
     chain_context chain;
     if (!CertGetCertificateChain(


### PR DESCRIPTION
from https://docs.microsoft.com/en-us/cpp/build/reference/zc-strictstrings-disable-string-literal-type-conversion?view=msvc-170

If /Zc:strictStrings is specified, the compiler enforces the standard C++ const qualifications for string literals, as type 'array of const char' or 'array of const wchar_t', depending on the declaration. String literals are immutable, and an attempt to modify the contents of one results in an access violation error at run time. You must declare a string pointer as const to initialize it by using a string literal, or use an explicit const_cast to initialize a non-const pointer. 