### PR TITLE
Re-classifying NO_NETWORK to be only UnknownHostException on Android

### DIFF
--- a/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -67,10 +67,7 @@ public class HttpClientRequest {
         OK_CLIENT.newCall(this.requestBuilder.build()).enqueue(new Callback() {
             @Override
             public void onFailure(final Call call, IOException e) {
-                boolean isNoNetworkFailure =
-                    e instanceof UnknownHostException ||
-                    e instanceof ConnectException ||
-                    e instanceof SocketTimeoutException;
+                boolean isNoNetworkFailure = e instanceof UnknownHostException;
 
                 StringWriter sw = new StringWriter();
                 PrintWriter pw = new PrintWriter(sw);

--- a/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
+++ b/Build/libHttpClient.Android/src/main/java/com/xbox/httpclient/HttpClientRequest.java
@@ -67,6 +67,9 @@ public class HttpClientRequest {
         OK_CLIENT.newCall(this.requestBuilder.build()).enqueue(new Callback() {
             @Override
             public void onFailure(final Call call, IOException e) {
+                // isNoNetworkFailure indicates to the native code when to assume the client is
+                // disconnected from the internet. In no network cases, retry logic will not be
+                // activated.
                 boolean isNoNetworkFailure = e instanceof UnknownHostException;
 
                 StringWriter sw = new StringWriter();


### PR DESCRIPTION
At some point recently various socket exceptions started getting classified as "isNoNetworkFailure". While this was intended to be helpful classification, the resulting behavior is that on a socket exception, retry logic will not get engaged. This is because retry logic does not attempt to retry if there is no network in order to save from repeatedly waiting when there isn't a reason to wait. This behavior change was not good or intended so I am reverting it.