### PR TITLE
Ignoring deprecated declarations warnings for external asio code.

### DIFF
--- a/Source/WebSocket/Websocketpp/x509_cert_utilities.hpp
+++ b/Source/WebSocket/Websocketpp/x509_cert_utilities.hpp
@@ -19,6 +19,7 @@
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #pragma clang diagnostic ignored "-Wdocumentation"
 #pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
 #include <asio/ssl.hpp>
 #if defined(__clang__)


### PR DESCRIPTION
sprintf(3) is deprecated in at very least MacOS builds since 5 years ago. Newer asio code still makes use of sprintf(3) so I'm just wrapping the inclusion of asio in an ignore of -Wdeprecated-declarations.