### PR TITLE
Fix include directories when linking to via CMake

### DIFF
--- a/Utilities/CMake/Android/libHttpClient/CMakeLists.txt
+++ b/Utilities/CMake/Android/libHttpClient/CMakeLists.txt
@@ -55,8 +55,6 @@ set(ANDROID_SOURCE_FILES
     "${PATH_TO_ROOT}/Source/Common"
     "${PATH_TO_ROOT}/Source/HTTP"
     "${PATH_TO_ROOT}/Source/Logger"
-    "${PATH_TO_ROOT}/Include"
-    "${PATH_TO_ROOT}/Include/httpClient"
     "${PATH_TO_ROOT}/External/asio/asio/include"
     "${PATH_TO_ROOT}/External/openssl/include"
     "${PATH_TO_ROOT}/External/websocketpp"
@@ -79,6 +77,8 @@ add_library(
 
 target_include_directories(
     "${PROJECT_NAME}"
+    PUBLIC
+    "${PUBLIC_INCLUDE_DIRS}"
     PRIVATE
     "${COMMON_INCLUDE_DIRS}"
     "${ANDROID_INCLUDE_DIRS}"

--- a/Utilities/CMake/Android/libHttpClient/CMakeLists.txt
+++ b/Utilities/CMake/Android/libHttpClient/CMakeLists.txt
@@ -12,7 +12,6 @@ set(CMAKE_STATIC_LIBRARY_PREFIX "")
 
 include("../../GetCommonHCSourceFiles.cmake")
 get_common_hc_source_files(
-    PUBLIC_SOURCE_FILES
     HC_COMMON_SOURCE_FILES
     GLOBAL_SOURCE_FILES
     WEBSOCKET_SOURCE_FILES
@@ -35,7 +34,6 @@ set(COMMON_SOURCE_FILES
     )
 
 set(ANDROID_SOURCE_FILES
-    "${PATH_TO_ROOT}/Include/httpClient/async_jvm.h"
     "${PATH_TO_ROOT}/Source/Common/Android/utils_android.cpp"
     "${PATH_TO_ROOT}/Source/Common/Android/utils_android.h"
     "${PATH_TO_ROOT}/Source/HTTP/Android/http_android.cpp"
@@ -78,7 +76,10 @@ add_library(
 target_include_directories(
     "${PROJECT_NAME}"
     PUBLIC
-    "${PUBLIC_INCLUDE_DIRS}"
+    $<BUILD_INTERFACE:${PATH_TO_ROOT}/Include>
+    $<INSTALL_INTERFACE:Include>
+    $<BUILD_INTERFACE:${PATH_TO_ROOT}/Include/httpClient>
+    $<INSTALL_INTERFACE:Include/httpClient>
     PRIVATE
     "${COMMON_INCLUDE_DIRS}"
     "${ANDROID_INCLUDE_DIRS}"

--- a/Utilities/CMake/CMakeLists.txt
+++ b/Utilities/CMake/CMakeLists.txt
@@ -76,9 +76,11 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../Source/Common
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../Source/HTTP
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../Source/Logger
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../Include
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../Include/httpClient
-    )
+    $<BUILD_INTERFACE:${PATH_TO_ROOT}/Include>
+    $<INSTALL_INTERFACE:Include>
+    $<BUILD_INTERFACE:${PATH_TO_ROOT}/Include/httpClient>
+    $<INSTALL_INTERFACE:Include/httpClient>
+)
 
 set(CMAKE_SUPPRESS_REGENERATION true)
 
@@ -173,7 +175,6 @@ set(UnitTests_Source_Files_Tests
 
 include(GetCommonHCSourceFiles.cmake)
 get_common_hc_source_files(
-    Public_Source_Files
     Common_Source_Files
     Global_Source_Files
     WebSocket_Source_Files
@@ -194,7 +195,6 @@ source_group("C++ Source\\HTTP" FILES ${HTTP_Source_Files})
 source_group("C++ Source\\Logger" FILES ${Logger_Source_Files})
 
 set( SOURCE_FILES
-    ${Public_Source_Files}
     ${Common_Source_Files}
     ${Global_Source_Files}
     ${WebSocket_Source_Files}

--- a/Utilities/CMake/GetCommonHCSourceFiles.cmake
+++ b/Utilities/CMake/GetCommonHCSourceFiles.cmake
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.6)
 
 function(GET_COMMON_HC_SOURCE_FILES
-         OUT_PUBLIC_SOURCE_FILES
          OUT_COMMON_SOURCE_FILES
          OUT_GLOBAL_SOURCE_FILES
          OUT_WEBSOCKET_SOURCE_FILES
@@ -11,20 +10,6 @@ function(GET_COMMON_HC_SOURCE_FILES
          OUT_LOGGER_SOURCE_FILES
          PATH_TO_ROOT
          )
-
-    set(${OUT_PUBLIC_SOURCE_FILES}
-        "${PATH_TO_ROOT}/Include/httpClient/config.h"
-        "${PATH_TO_ROOT}/Include/httpClient/httpClient.h"
-        "${PATH_TO_ROOT}/Include/httpClient/httpProvider.h"
-        "${PATH_TO_ROOT}/Include/httpClient/mock.h"
-        "${PATH_TO_ROOT}/Include/XAsync.h"
-        "${PATH_TO_ROOT}/Include/XAsyncProvider.h"
-        "${PATH_TO_ROOT}/Include/XTaskQueue.h"
-        "${PATH_TO_ROOT}/Include/httpClient/trace.h"
-        "${PATH_TO_ROOT}/Include/httpClient/pal.h"
-        "${PATH_TO_ROOT}/Include/httpClient/async.h"
-        PARENT_SCOPE
-        )
 
     set(${OUT_COMMON_SOURCE_FILES}
         "${PATH_TO_ROOT}/Source/Common/buildver.h"


### PR DESCRIPTION
The libhttpclient includes cannot be linked to from a CMake project because what were the `PUBLIC_SOURCE_FILES` were included via a PRIVATE scope in `target_include_directories`. This change makes them public.