### PR TITLE
Fix a few unhooked allocations

### DIFF
--- a/Source/HTTP/WinHttp/winhttp_connection.cpp
+++ b/Source/HTTP/WinHttp/winhttp_connection.cpp
@@ -74,7 +74,7 @@ Result<std::shared_ptr<WinHttpConnection>> WinHttpConnection::Initialize(
     RETURN_HR_IF(E_INVALIDARG, !call);
 
     http_stl_allocator<WinHttpConnection> a{};
-    auto connection = std::shared_ptr<WinHttpConnection>{ new (a.allocate(1)) WinHttpConnection(hSession, call, proxyType, std::move(securityInformation)), http_alloc_deleter<WinHttpConnection>()  };
+    auto connection = std::shared_ptr<WinHttpConnection>{ new (a.allocate(1)) WinHttpConnection(hSession, call, proxyType, std::move(securityInformation)), http_alloc_deleter<WinHttpConnection>(), a };
     RETURN_IF_FAILED(connection->Initialize());
 
     return connection;

--- a/Source/HTTP/WinHttp/winhttp_provider.cpp
+++ b/Source/HTTP/WinHttp/winhttp_provider.cpp
@@ -13,7 +13,7 @@ NAMESPACE_XBOX_HTTP_CLIENT_BEGIN
 Result<std::shared_ptr<WinHttpProvider>> WinHttpProvider::Initialize()
 {
     http_stl_allocator<WinHttpProvider> a{};
-    auto provider = std::shared_ptr<WinHttpProvider>{ new (a.allocate(1)) WinHttpProvider, http_alloc_deleter<WinHttpProvider>() };
+    auto provider = std::shared_ptr<WinHttpProvider>{ new (a.allocate(1)) WinHttpProvider, http_alloc_deleter<WinHttpProvider>(), a };
 
     RETURN_IF_FAILED(XTaskQueueCreate(XTaskQueueDispatchMode::Immediate, XTaskQueueDispatchMode::Immediate, &provider->m_immediateQueue));
 

--- a/Source/WebSocket/hcwebsocket.cpp
+++ b/Source/WebSocket/hcwebsocket.cpp
@@ -129,7 +129,7 @@ Result<std::shared_ptr<WebSocket>> WebSocket::Initialize()
         ++httpSingleton->m_lastId,
         httpSingleton->m_websocketPerform,
         httpSingleton->m_performEnv.get()
-    }, http_alloc_deleter<WebSocket>{} };
+    }, http_alloc_deleter<WebSocket>{}, a };
 
     return websocket;
 }


### PR DESCRIPTION
When creating a SharedPtr<> from a raw pointer, we need to pass in both a custom deleter and allocator.  Though the object itself is already allocated, std::shared_ptr<> allocates some internal data on top of that.

More details here: https://en.cppreference.com/w/cpp/memory/shared_ptr/shared_ptr.