### PR TITLE
Fix crash when last websocket handle is closed while sending a message

### DIFF
--- a/Source/Global/perform_env.cpp
+++ b/Source/Global/perform_env.cpp
@@ -383,7 +383,7 @@ struct HC_PERFORM_ENV::ActiveWebSocketContext
     }
 
     HC_PERFORM_ENV* const env{};
-    HC_UNIQUE_PTR<HC_WEBSOCKET_OBSERVER> websocketObserver;
+    xbox::httpclient::ObserverPtr websocketObserver;
 };
 
 HRESULT HC_PERFORM_ENV::WebSocketConnectAsyncShim(

--- a/Source/HTTP/XMLHttp/xmlhttp_http_task.cpp
+++ b/Source/HTTP/XMLHttp/xmlhttp_http_task.cpp
@@ -39,7 +39,7 @@ void CALLBACK xmlhttp_http_task::PerformAsyncHandler(
 ) noexcept
 {
     assert(context == nullptr);
-    assert(env == nullptr);
+    assert(env != nullptr);
     UNREFERENCED_PARAMETER(context);
     UNREFERENCED_PARAMETER(env);
 

--- a/Source/WebSocket/WinRT/winrt_websocket.cpp
+++ b/Source/WebSocket/WinRT/winrt_websocket.cpp
@@ -455,6 +455,7 @@ struct SendMessageCallbackContext
 {
     std::shared_ptr<websocket_outgoing_message> nextMessage;
     std::shared_ptr<winrt_websocket_impl> websocketTask;
+    std::shared_ptr<HC_WEBSOCKET> websocketHandle;
 };
 
 HRESULT WebsockSendMessageDoWork(
@@ -592,6 +593,7 @@ void MessageWebSocketSendMessage(
     std::shared_ptr<SendMessageCallbackContext> callbackContext = http_allocate_shared<SendMessageCallbackContext>();
     callbackContext->nextMessage = msg;
     callbackContext->websocketTask = websocketTask;
+    callbackContext->websocketHandle = websocketTask->m_websocketHandle->shared_from_this();
     void* rawContext = shared_ptr_cache::store<SendMessageCallbackContext>(callbackContext);
     if (rawContext == nullptr)
     {

--- a/Source/WebSocket/WinRT/winrt_websocket.cpp
+++ b/Source/WebSocket/WinRT/winrt_websocket.cpp
@@ -455,7 +455,7 @@ struct SendMessageCallbackContext
 {
     std::shared_ptr<websocket_outgoing_message> nextMessage;
     std::shared_ptr<winrt_websocket_impl> websocketTask;
-    std::shared_ptr<HC_WEBSOCKET> websocketHandle;
+    std::shared_ptr<xbox::httpclient::WebSocket> websocket;
 };
 
 HRESULT WebsockSendMessageDoWork(
@@ -593,7 +593,7 @@ void MessageWebSocketSendMessage(
     std::shared_ptr<SendMessageCallbackContext> callbackContext = http_allocate_shared<SendMessageCallbackContext>();
     callbackContext->nextMessage = msg;
     callbackContext->websocketTask = websocketTask;
-    callbackContext->websocketHandle = websocketTask->m_websocketHandle->shared_from_this();
+    callbackContext->websocket = websocketTask->m_websocketHandle->websocket->shared_from_this();
     void* rawContext = shared_ptr_cache::store<SendMessageCallbackContext>(callbackContext);
     if (rawContext == nullptr)
     {

--- a/Source/WebSocket/WinRT/winrt_websocket.cpp
+++ b/Source/WebSocket/WinRT/winrt_websocket.cpp
@@ -455,7 +455,21 @@ struct SendMessageCallbackContext
 {
     std::shared_ptr<websocket_outgoing_message> nextMessage;
     std::shared_ptr<winrt_websocket_impl> websocketTask;
-    std::shared_ptr<xbox::httpclient::WebSocket> websocket;
+
+    SendMessageCallbackContext(
+        std::shared_ptr<websocket_outgoing_message> msg,
+        std::shared_ptr<winrt_websocket_impl> task
+    ) noexcept :
+        nextMessage{ std::move(msg) },
+        websocketTask{ std::move(task) }
+    {
+        websocketTask->m_websocketHandle->AddRef();
+    }
+
+    ~SendMessageCallbackContext() noexcept
+    {
+        websocketTask->m_websocketHandle->Release();
+    }
 };
 
 HRESULT WebsockSendMessageDoWork(
@@ -590,10 +604,9 @@ void MessageWebSocketSendMessage(
         return;
     }
 
-    std::shared_ptr<SendMessageCallbackContext> callbackContext = http_allocate_shared<SendMessageCallbackContext>();
-    callbackContext->nextMessage = msg;
-    callbackContext->websocketTask = websocketTask;
-    callbackContext->websocket = websocketTask->m_websocketHandle->websocket->shared_from_this();
+    std::shared_ptr<SendMessageCallbackContext> callbackContext =
+        http_allocate_shared<SendMessageCallbackContext>(msg, websocketTask);
+
     void* rawContext = shared_ptr_cache::store<SendMessageCallbackContext>(callbackContext);
     if (rawContext == nullptr)
     {

--- a/Source/WebSocket/hcwebsocket.cpp
+++ b/Source/WebSocket/hcwebsocket.cpp
@@ -31,12 +31,12 @@ int HC_WEBSOCKET_OBSERVER::Release() noexcept
     int count = --m_refCount;
     if (count == 0)
     {
-        HC_UNIQUE_PTR<HC_WEBSOCKET_OBSERVER> reclaim{ this };
+        xbox::httpclient::ObserverPtr reclaim{ this };
     }
     return count;
 }
 
-HC_UNIQUE_PTR<HC_WEBSOCKET_OBSERVER> HC_WEBSOCKET_OBSERVER::Initialize(
+xbox::httpclient::ObserverPtr HC_WEBSOCKET_OBSERVER::Initialize(
     _In_ std::shared_ptr<xbox::httpclient::WebSocket> websocket,
     _In_opt_ HCWebSocketMessageFunction messageFunc,
     _In_opt_ HCWebSocketBinaryMessageFunction binaryMessageFunc,
@@ -46,7 +46,7 @@ HC_UNIQUE_PTR<HC_WEBSOCKET_OBSERVER> HC_WEBSOCKET_OBSERVER::Initialize(
 )
 {
     http_stl_allocator<HC_WEBSOCKET_OBSERVER> a{};
-    HC_UNIQUE_PTR<HC_WEBSOCKET_OBSERVER> observer{ new (a.allocate(1)) HC_WEBSOCKET_OBSERVER{ std::move(websocket) } };
+    xbox::httpclient::ObserverPtr observer{ new (a.allocate(1)) HC_WEBSOCKET_OBSERVER{ std::move(websocket) } };
 
     observer->m_messageFunc = messageFunc;
     observer->m_binaryMessageFunc = binaryMessageFunc;
@@ -186,7 +186,7 @@ struct WebSocket::ConnectContext
         }
     }
 
-    HC_UNIQUE_PTR<HC_WEBSOCKET_OBSERVER> observer{ nullptr };
+    xbox::httpclient::ObserverPtr observer;
     XAsyncBlock* const clientAsyncBlock;
     XAsyncBlock internalAsyncBlock;
     WebSocketCompletionResult result{};
@@ -195,7 +195,7 @@ struct WebSocket::ConnectContext
 // Context for Provider event callbacks. Ensure's lifetime as long as the WebSocket is connected (until CloseFunc is called)
 struct WebSocket::ProviderContext
 {
-    HC_UNIQUE_PTR<HC_WEBSOCKET_OBSERVER> observer{ nullptr };
+    xbox::httpclient::ObserverPtr observer;
 };
 
 HRESULT WebSocket::ConnectAsync(
@@ -276,7 +276,9 @@ void CALLBACK WebSocket::ConnectComplete(XAsyncBlock* async)
     {
         // Connect was sucessful. Allocate ProviderContext to ensure WebSocket lifetime until it is reclaimed in WebSocket::CloseFunc
         ws->m_state = State::Connected;
-        ws->m_providerContext = new (http_stl_allocator<ProviderContext>{}.allocate(1)) ProviderContext{ std::move(context->observer) };
+        ws->m_providerContext = new (http_stl_allocator<ProviderContext>{}.allocate(1)) ProviderContext{
+            std::move(context->observer)
+        };
     }
     else
     {

--- a/Source/WebSocket/hcwebsocket.cpp
+++ b/Source/WebSocket/hcwebsocket.cpp
@@ -21,6 +21,21 @@ HC_WEBSOCKET_OBSERVER::~HC_WEBSOCKET_OBSERVER()
     websocket->UnregisterEventCallbacks(m_handlerToken);
 }
 
+int HC_WEBSOCKET_OBSERVER::AddRef() noexcept
+{
+    return ++m_refCount;
+}
+
+int HC_WEBSOCKET_OBSERVER::Release() noexcept
+{
+    int count = --m_refCount;
+    if (count == 0)
+    {
+        HC_UNIQUE_PTR<HC_WEBSOCKET_OBSERVER> reclaim{ this };
+    }
+    return count;
+}
+
 HC_UNIQUE_PTR<HC_WEBSOCKET_OBSERVER> HC_WEBSOCKET_OBSERVER::Initialize(
     _In_ std::shared_ptr<xbox::httpclient::WebSocket> websocket,
     _In_opt_ HCWebSocketMessageFunction messageFunc,

--- a/Source/WebSocket/hcwebsocket.h
+++ b/Source/WebSocket/hcwebsocket.h
@@ -32,6 +32,8 @@ struct HC_WEBSOCKET_OBSERVER
 {
 public: 
     virtual ~HC_WEBSOCKET_OBSERVER();
+    int AddRef() noexcept;
+    int Release() noexcept;
 
     static HC_UNIQUE_PTR<HC_WEBSOCKET_OBSERVER> Initialize(
         _In_ std::shared_ptr<xbox::httpclient::WebSocket> WebSocket,
@@ -44,7 +46,6 @@ public:
 
     void SetBinaryMessageFragmentEventFunction(HCWebSocketBinaryMessageFragmentFunction binaryFragmentFunc);
 
-    std::atomic<int> refCount{ 1 };
     std::shared_ptr<xbox::httpclient::WebSocket> const websocket;
 
 private:
@@ -55,6 +56,7 @@ private:
     static void CALLBACK BinaryMessageFragmentFunc(HCWebsocketHandle handle, const uint8_t* payloadBytes, uint32_t payloadSize, bool isLastFragment, void* functionContext);
     static void CALLBACK CloseFunc(HCWebsocketHandle handle, HCWebSocketCloseStatus status, void* context);
 
+    std::atomic<int> m_refCount{ 1 };
     HCWebSocketMessageFunction m_messageFunc{ nullptr };
     HCWebSocketBinaryMessageFunction m_binaryMessageFunc{ nullptr };
     HCWebSocketBinaryMessageFragmentFunction m_binaryFragmentFunc{ nullptr };

--- a/Source/WebSocket/websocket_publics.cpp
+++ b/Source/WebSocket/websocket_publics.cpp
@@ -146,7 +146,7 @@ try
     }
 
     HC_TRACE_INFORMATION(WEBSOCKET, "HCWebSocketDuplicateHandle [ID %llu]", TO_ULL(handle->websocket->id));
-    ++handle->refCount;
+    handle->AddRef();
 
     return handle;
 }
@@ -160,12 +160,7 @@ try
     RETURN_HR_IF(E_INVALIDARG, !handle);
 
     HC_TRACE_INFORMATION(WEBSOCKET, "HCWebSocketCloseHandle [ID %llu]", TO_ULL(handle->websocket->id));
-    int refCount = --handle->refCount;
-    if (refCount <= 0)
-    {
-        ASSERT(refCount == 0); // should only fire at 0
-        HC_UNIQUE_PTR<HC_WEBSOCKET_OBSERVER> reclaim{ handle };
-    }
+    handle->Release();
 
     return S_OK;
 }


### PR DESCRIPTION
`HCWebSocketSendMessageAsync` and similar were not ensuring that the `HC_WEBSOCKET_OBSERVER` was kept alive until they completed, but store a pointer to it for use in the completion callbacks.

This change switches to properly using reference counting to manage the observer lifetime