### PR TITLE
Build fixes for Switch

### DIFF
--- a/Include/httpClient/pal.h
+++ b/Include/httpClient/pal.h
@@ -16,7 +16,7 @@
 
 #include <httpClient/config.h>
 
-#if HC_PLATFORM_IS_MICROSOFT
+#if _WIN32
 
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN

--- a/Source/Common/pal_internal.h
+++ b/Source/Common/pal_internal.h
@@ -9,6 +9,7 @@
 #define MAXUINT UINT_MAX
 #endif
 
+#ifndef _WIN32
 typedef unsigned char BYTE;
 typedef unsigned long DWORD;
 typedef void *PVOID;
@@ -18,3 +19,5 @@ typedef BYTE BOOLEAN;
 typedef BYTE *PBYTE;
 typedef PVOID HANDLE;
 #endif
+#endif
+

--- a/Source/Common/pch_common.h
+++ b/Source/Common/pch_common.h
@@ -9,7 +9,9 @@
 #pragma warning(disable: 4242) 
 
 #ifdef _WIN32
+#ifndef _SCL_SECURE_NO_WARNINGS
 #define _SCL_SECURE_NO_WARNINGS
+#endif
 #define _WINSOCK_DEPRECATED_NO_WARNINGS
 
 // If you wish to build your application for a previous Windows platform, include WinSDKVer.h and

--- a/Source/Common/utils.h
+++ b/Source/Common/utils.h
@@ -173,7 +173,7 @@ public:
 
 static inline int str_icmp(const http_internal_string& left, const http_internal_string& right)
 {
-#if HC_PLATFORM_IS_MICROSOFT
+#if _WIN32
     return _stricmp(left.c_str(), right.c_str());
 #else
     return strcasecmp(left.c_str(), right.c_str());

--- a/Source/HTTP/Curl/CurlEasyRequest.cpp
+++ b/Source/HTTP/Curl/CurlEasyRequest.cpp
@@ -201,7 +201,7 @@ HRESULT CurlEasyRequest::AddHeader(char const* name, char const* value) noexcept
 
 size_t CurlEasyRequest::ReadCallback(char* buffer, size_t size, size_t nitems, void* context) noexcept
 {
-    HC_TRACE_INFORMATION(HTTPCLIENT, "CurlEasyRequest::ReadCallback: reading body data (%llu items of size %llu)", nitems, size);
+    HC_TRACE_INFORMATION(HTTPCLIENT, "CurlEasyRequest::ReadCallback: reading body data (%zu items of size %zu)", nitems, size);
 
     auto request = static_cast<CurlEasyRequest*>(context);
 
@@ -237,7 +237,7 @@ size_t CurlEasyRequest::ReadCallback(char* buffer, size_t size, size_t nitems, v
 
 size_t CurlEasyRequest::WriteHeaderCallback(char* buffer, size_t size, size_t nitems, void* context) noexcept
 {
-    HC_TRACE_INFORMATION(HTTPCLIENT, "CurlEasyRequest::WriteHeaderCallback: received header (%llu items of size %llu)", nitems, size);
+    HC_TRACE_INFORMATION(HTTPCLIENT, "CurlEasyRequest::WriteHeaderCallback: received header (%zu items of size %zu)", nitems, size);
 
     auto request = static_cast<CurlEasyRequest*>(context);
 
@@ -301,7 +301,7 @@ size_t CurlEasyRequest::WriteHeaderCallback(char* buffer, size_t size, size_t ni
 
 size_t CurlEasyRequest::WriteDataCallback(char* buffer, size_t size, size_t nmemb, void* context) noexcept
 {
-    HC_TRACE_INFORMATION(HTTPCLIENT, "CurlEasyRequest::WriteDataCallback: received data (%llu bytes)", nmemb);
+    HC_TRACE_INFORMATION(HTTPCLIENT, "CurlEasyRequest::WriteDataCallback: received data (%zu bytes)", nmemb);
 
     auto request = static_cast<CurlEasyRequest*>(context);
 

--- a/Source/HTTP/httpcall_response.cpp
+++ b/Source/HTTP/httpcall_response.cpp
@@ -199,7 +199,7 @@ try
     call->responseBodyBytes.insert(call->responseBodyBytes.end(), bodyBytes, bodyBytes + bodySize);
     call->responseString.clear();
 
-    if (call->traceCall) { HC_TRACE_INFORMATION(HTTPCLIENT, "HCHttpCallResponseAppendResponseBodyBytes [ID %llu]: bodySize=%zu (total=%llu)", TO_ULL(call->id), bodySize, call->responseBodyBytes.size()); }
+    if (call->traceCall) { HC_TRACE_INFORMATION(HTTPCLIENT, "HCHttpCallResponseAppendResponseBodyBytes [ID %llu]: bodySize=%zu (total=%zu)", TO_ULL(call->id), bodySize, call->responseBodyBytes.size()); }
     return S_OK;
 }
 CATCH_RETURN()

--- a/Source/Logger/trace.cpp
+++ b/Source/Logger/trace.cpp
@@ -73,7 +73,7 @@ void TraceMessageToDebugger(
     uint32_t     fractionMSec = static_cast<uint32_t>(timestamp % 1000);
     std::tm      fmtTime = {};
 
-#if HC_PLATFORM_IS_MICROSOFT
+#if _WIN32
     localtime_s(&fmtTime, &timeTInSec);
 #elif HC_PLATFORM == HC_PLATFORM_SONY_PLAYSTATION_4 || HC_PLATFORM == HC_PLATFORM_SONY_PLAYSTATION_5
     localtime_s(&timeTInSec, &fmtTime);


### PR DESCRIPTION
* Changing some preprocessor guards to support building in a Win32 environment that is a non-Windows HC_PLATFORM. This will be used exclusively for testing purposes