### PR TITLE
Splitting XAsync source from libHttpClient.Common

### DIFF
--- a/Build/libHttpClient.141.UWP.C/libHttpClient.141.UWP.C.vcxproj
+++ b/Build/libHttpClient.141.UWP.C/libHttpClient.141.UWP.C.vcxproj
@@ -8,6 +8,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(libHttpClient.UWP.props))" />
   <Import Project="$(HCRoot)\libHttpClient.props" />
   <Import Project="$(HCBuildRoot)\libHttpClient.Common\libHttpClient.Common.vcxitems" Label="Shared" />
+  <Import Project="$(HCBuildRoot)\libHttpClient.XAsync\libHttpClient.XAsync.vcxitems" Label="Shared" />
   <Import Project="$(HCBuildRoot)\libHttpClient.UWP\libHttpClient.UWP.vcxitems" Label="Shared" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj
+++ b/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj
@@ -8,6 +8,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(libHttpClient.Win32.props))" />
   <Import Project="$(HCRoot)\libHttpClient.props" />
   <Import Project="$(HCBuildRoot)\libHttpClient.Common\libHttpClient.Common.vcxitems" Label="Shared" />
+  <Import Project="$(HCBuildRoot)\libHttpClient.XAsync\libHttpClient.XAsync.vcxitems" Label="Shared" />
   <Import Project="$(HCBuildRoot)\libHttpClient.Win32\libHttpClient.Win32.vcxitems" Label="Shared" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/Build/libHttpClient.142.UWP.C/libHttpClient.142.UWP.C.vcxproj
+++ b/Build/libHttpClient.142.UWP.C/libHttpClient.142.UWP.C.vcxproj
@@ -8,6 +8,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(libHttpClient.UWP.props))" />
   <Import Project="$(HCRoot)\libHttpClient.props" />
   <Import Project="$(HCBuildRoot)\libHttpClient.Common\libHttpClient.Common.vcxitems" Label="Shared" />
+  <Import Project="$(HCBuildRoot)\libHttpClient.XAsync\libHttpClient.XAsync.vcxitems" Label="Shared" />
   <Import Project="$(HCBuildRoot)\libHttpClient.UWP\libHttpClient.UWP.vcxitems" Label="Shared" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/Build/libHttpClient.142.Win32.C/libHttpClient.142.Win32.C.vcxproj
+++ b/Build/libHttpClient.142.Win32.C/libHttpClient.142.Win32.C.vcxproj
@@ -8,6 +8,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(libHttpClient.Win32.props))" />
   <Import Project="$(HCRoot)\libHttpClient.props" />
   <Import Project="$(HCBuildRoot)\libHttpClient.Common\libHttpClient.Common.vcxitems" Label="Shared" />
+  <Import Project="$(HCBuildRoot)\libHttpClient.XAsync\libHttpClient.XAsync.vcxitems" Label="Shared" />
   <Import Project="$(HCBuildRoot)\libHttpClient.Win32\libHttpClient.Win32.vcxitems" Label="Shared" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/Build/libHttpClient.143.UWP.C/libHttpClient.143.UWP.C.vcxproj
+++ b/Build/libHttpClient.143.UWP.C/libHttpClient.143.UWP.C.vcxproj
@@ -8,6 +8,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(libHttpClient.UWP.props))" />
   <Import Project="$(HCRoot)\libHttpClient.props" />
   <Import Project="$(HCBuildRoot)\libHttpClient.Common\libHttpClient.Common.vcxitems" Label="Shared" />
+  <Import Project="$(HCBuildRoot)\libHttpClient.XAsync\libHttpClient.XAsync.vcxitems" Label="Shared" />
   <Import Project="$(HCBuildRoot)\libHttpClient.UWP\libHttpClient.UWP.vcxitems" Label="Shared" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/Build/libHttpClient.143.Win32.C/libHttpClient.143.Win32.C.vcxproj
+++ b/Build/libHttpClient.143.Win32.C/libHttpClient.143.Win32.C.vcxproj
@@ -8,6 +8,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(libHttpClient.Win32.props))" /> 
   <Import Project="$(HCRoot)\libHttpClient.props"/>
   <Import Project="$(HCBuildRoot)\libHttpClient.Common\libHttpClient.Common.vcxitems" Label="Shared" />
+  <Import Project="$(HCBuildRoot)\libHttpClient.XAsync\libHttpClient.XAsync.vcxitems" Label="Shared" />
   <Import Project="$(HCBuildRoot)\libHttpClient.Win32\libHttpClient.Win32.vcxitems" Label="Shared" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" /> 
 </Project>

--- a/Build/libHttpClient.Common/libHttpClient.Common.vcxitems
+++ b/Build/libHttpClient.Common/libHttpClient.Common.vcxitems
@@ -22,9 +22,6 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\mock.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\pal.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\trace.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\XAsync.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\XAsyncProvider.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\XTaskQueue.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Common\buildver.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Common\EntryList.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Common\pal_internal.h" />
@@ -47,16 +44,6 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Platform\IWebSocketProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Platform\PlatformComponents.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Platform\PlatformTrace.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AtomicVector.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\LocklessQueue.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\referenced_ptr.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\StaticArray.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\TaskQueueImpl.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\TaskQueueP.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\ThreadPool.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.h" />
   </ItemGroup>
   <ItemGroup>
@@ -80,8 +67,6 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Platform\ExternalHttpProvider.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Platform\ExternalWebSocketProvider.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Platform\IHttpProvider.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AsyncLib.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\TaskQueue.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\hcwebsocket.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\websocket_publics.cpp" />
   </ItemGroup>

--- a/Build/libHttpClient.Common/libHttpClient.Common.vcxitems.filters
+++ b/Build/libHttpClient.Common/libHttpClient.Common.vcxitems.filters
@@ -28,9 +28,6 @@
     <Filter Include="Source\Platform">
       <UniqueIdentifier>{2ed98a1f-87b4-463c-848e-55e369f07b82}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Source\Task">
-      <UniqueIdentifier>{644f05fc-5c7c-4fbb-a6bd-e6cd428bef59}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Source\WebSocket">
       <UniqueIdentifier>{7c14843a-f715-4f95-8ff0-d10e8f81724c}</UniqueIdentifier>
     </Filter>
@@ -38,36 +35,6 @@
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Common\Types.h">
       <Filter>Source\Common</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AtomicVector.h">
-      <Filter>Source\Task</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\LocklessQueue.h">
-      <Filter>Source\Task</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\referenced_ptr.h">
-      <Filter>Source\Task</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\StaticArray.h">
-      <Filter>Source\Task</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\TaskQueueImpl.h">
-      <Filter>Source\Task</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\TaskQueueP.h">
-      <Filter>Source\Task</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\ThreadPool.h">
-      <Filter>Source\Task</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h">
-      <Filter>Source\Task</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h">
-      <Filter>Source\Task</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h">
-      <Filter>Source\Task</Filter>
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Common\buildver.h">
       <Filter>Source\Common</Filter>
@@ -153,26 +120,11 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\httpClient\trace.h">
       <Filter>Include\httpClient</Filter>
     </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\XAsync.h">
-      <Filter>Include</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\XAsyncProvider.h">
-      <Filter>Include</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\XTaskQueue.h">
-      <Filter>Include</Filter>
-    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Platform\PlatformTrace.h">
       <Filter>Source\Platform</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AsyncLib.cpp">
-      <Filter>Source\Task</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\TaskQueue.cpp">
-      <Filter>Source\Task</Filter>
-    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Common\pch.cpp">
       <Filter>Source\Common</Filter>
     </ClCompile>

--- a/Build/libHttpClient.UnitTest.TAEF/libHttpClient.UnitTest.TAEF.vcxproj
+++ b/Build/libHttpClient.UnitTest.TAEF/libHttpClient.UnitTest.TAEF.vcxproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(libHttpClient.Win32.props))" />
   <Import Project="$(HCBuildRoot)\libHttpClient.Common\libHttpClient.Common.vcxitems" Label="Shared" />
+  <Import Project="$(HCBuildRoot)\libHttpClient.XAsync\libHttpClient.XAsync.vcxitems" Label="Shared" />
   <Import Project="$(HCBuildRoot)\libHttpClient.UnitTest\libHttpClient.UnitTest.vcxitems" Label="Shared" />
   <PropertyGroup>
     <LinkIncremental>false</LinkIncremental>

--- a/Build/libHttpClient.UnitTest.TE/libHttpClient.UnitTest.TE.vcxproj
+++ b/Build/libHttpClient.UnitTest.TE/libHttpClient.UnitTest.TE.vcxproj
@@ -13,6 +13,7 @@
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(libHttpClient.Win32.props))" />
   <Import Project="$(HCBuildRoot)\libHttpClient.Common\libHttpClient.Common.vcxitems" Label="Shared" />
+  <Import Project="$(HCBuildRoot)\libHttpClient.XAsync\libHttpClient.XAsync.vcxitems" Label="Shared" />
   <Import Project="$(HCBuildRoot)\libHttpClient.UnitTest\libHttpClient.UnitTest.vcxitems" Label="Shared" />
   <ItemDefinitionGroup>
     <ClCompile>

--- a/Build/libHttpClient.XAsync/libHttpClient.XAsync.vcxitems
+++ b/Build/libHttpClient.XAsync/libHttpClient.XAsync.vcxitems
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <MSBuildAllProjects Condition="'$(MSBuildVersion)' == '' Or '$(MSBuildVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <ItemsProjectGuid>{b5118956-53cc-4b24-8807-de8d7d226b40}</ItemsProjectGuid>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectCapability Include="SourceItemsFromImports" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\XAsync.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\XAsyncProvider.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\XTaskQueue.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AtomicVector.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\LocklessQueue.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\referenced_ptr.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\StaticArray.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\TaskQueueImpl.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\TaskQueueP.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\ThreadPool.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AsyncLib.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\TaskQueue.cpp" />
+  </ItemGroup>
+</Project>

--- a/Build/libHttpClient.XAsync/libHttpClient.XAsync.vcxitems.filters
+++ b/Build/libHttpClient.XAsync/libHttpClient.XAsync.vcxitems.filters
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Include">
+      <UniqueIdentifier>{20fed803-c785-4aae-9ed5-b180d011f957}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source">
+      <UniqueIdentifier>{bc9aca80-670c-4283-a0ae-05818cfea369}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source\Task">
+      <UniqueIdentifier>{95aaabf8-b812-4e80-9c98-01020ed72143}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\XAsync.h">
+      <Filter>Include</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\XAsyncProvider.h">
+      <Filter>Include</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Include\XTaskQueue.h">
+      <Filter>Include</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AtomicVector.h">
+      <Filter>Source\Task</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\LocklessQueue.h">
+      <Filter>Source\Task</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\referenced_ptr.h">
+      <Filter>Source\Task</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\StaticArray.h">
+      <Filter>Source\Task</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\TaskQueueImpl.h">
+      <Filter>Source\Task</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\TaskQueueP.h">
+      <Filter>Source\Task</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\ThreadPool.h">
+      <Filter>Source\Task</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h">
+      <Filter>Source\Task</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h">
+      <Filter>Source\Task</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h">
+      <Filter>Source\Task</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AsyncLib.cpp">
+      <Filter>Source\Task</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\TaskQueue.cpp">
+      <Filter>Source\Task</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/Samples/UWP-Http/Http.vcxproj
+++ b/Samples/UWP-Http/Http.vcxproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.root))\Build\libHttpClient.UWP.props" />
   <Import Project="$(HCRoot)\libHttpClient.props" />
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+  <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>

--- a/Samples/UWP-WebSocket/WebSocket.vcxproj
+++ b/Samples/UWP-WebSocket/WebSocket.vcxproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.root))\Build\libHttpClient.UWP.props" />
   <Import Project="$(HCRoot)\libHttpClient.props" />
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+  <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>

--- a/libHttpClient.vs2022.sln
+++ b/libHttpClient.vs2022.sln
@@ -33,8 +33,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "UWP", "UWP", "{AEECE539-001
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libHttpClient.UWP", "Build\libHttpClient.UWP\libHttpClient.UWP.vcxitems", "{47564F2B-9ED7-4527-997A-5D76C36998D1}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libHttpClient.142.UWP.C", "Build\libHttpClient.142.UWP.C\libHttpClient.142.UWP.C.vcxproj", "{53C69CF3-B0B8-4A64-B178-0E9370737F70}"
-EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libssl.Win32", "Build\libssl.Win32\libssl.Win32.vcxitems", "{097E9D46-215E-43AE-B8DF-339EDF537EB6}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libssl.143.Win32", "Build\libssl.143.Win32\libssl.143.Win32.vcxproj", "{AAF08544-8AAA-41A5-A86B-2AF4D8985258}"
@@ -53,29 +51,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Http", "Samples\UWP-Http\Ht
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libHttpClient.143.UWP.C", "Build\libHttpClient.143.UWP.C\libHttpClient.143.UWP.C.vcxproj", "{2E55AA9F-A132-477C-B4FF-B4CD551E4322}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libHttpClient.141.UWP.C", "Build\libHttpClient.141.UWP.C\libHttpClient.141.UWP.C.vcxproj", "{5B498CF9-1803-438F-98FC-25F42759F440}"
-EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WebSocket", "Samples\UWP-WebSocket\WebSocket.vcxproj", "{99542110-3CCD-4525-B607-DB8F6E76AEAC}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Win32WebSocket", "Samples\Win32WebSocket\Win32WebSocket.vcxproj", "{591520A6-680D-4AD7-AACB-8C2C877F8BAE}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WebSocketEchoServer", "Samples\WebSocketEchoServer\WebSocketEchoServer.vcxproj", "{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libHttpClient.141.Win32.C", "Build\libHttpClient.141.Win32.C\libHttpClient.141.Win32.C.vcxproj", "{BEDE280F-17F7-4A09-9F5D-2E02FBB1C490}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libHttpClient.142.Win32.C", "Build\libHttpClient.142.Win32.C\libHttpClient.142.Win32.C.vcxproj", "{961F48EA-33A9-47F1-9C96-715D6094D79B}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libcrypto.141.Win32", "Build\libcrypto.141.Win32\libcrypto.141.Win32.vcxproj", "{EEE4D040-3907-43BD-9CA9-C89F1DB19FCD}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libcrypto.142.Win32", "Build\libcrypto.142.Win32\libcrypto.142.Win32.vcxproj", "{9C459B54-E085-42F3-A671-7F55C2994048}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libssl.141.Win32", "Build\libssl.141.Win32\libssl.141.Win32.vcxproj", "{A5EB6BDD-DD81-4B7B-83A0-A8AE0068FC3F}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libssl.142.Win32", "Build\libssl.142.Win32\libssl.142.Win32.vcxproj", "{23104CDA-C598-4D41-B7FF-70405B2871EC}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libHttpClient.142.GDK.C", "Build\libHttpClient.142.GDK.C\libHttpClient.142.GDK.C.vcxproj", "{66365E18-7B53-44BF-A348-6735058E359E}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libHttpClient.141.GDK.C", "Build\libHttpClient.141.GDK.C\libHttpClient.141.GDK.C.vcxproj", "{78C0122C-6B2D-4054-8C49-448277DD7A7D}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Test", "Test", "{6BBCD917-A163-48D8-9385-3F6135E031FE}"
 EndProject
@@ -84,6 +64,8 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libHttpClient.UnitTest.TAEF", "Build\libHttpClient.UnitTest.TAEF\libHttpClient.UnitTest.TAEF.vcxproj", "{E885BB30-F51E-4BAB-9300-4B303144BB49}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libHttpClient.UnitTest.TE", "Build\libHttpClient.UnitTest.TE\libHttpClient.UnitTest.TE.vcxproj", "{9DD2BA60-6505-493A-8C41-8085C44E9F1F}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libHttpClient.XAsync", "Build\libHttpClient.XAsync\libHttpClient.XAsync.vcxitems", "{B5118956-53CC-4B24-8807-DE8D7D226B40}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -129,24 +111,6 @@ Global
 		{0A6D51A3-0D86-4D0E-9DAA-54BA75E1DA1C}.Release|Gaming.Desktop.x64.Build.0 = Release|Gaming.Desktop.x64
 		{0A6D51A3-0D86-4D0E-9DAA-54BA75E1DA1C}.Release|x64.ActiveCfg = Release|Gaming.Desktop.x64
 		{0A6D51A3-0D86-4D0E-9DAA-54BA75E1DA1C}.Release|x86.ActiveCfg = Release|Gaming.Desktop.x64
-		{53C69CF3-B0B8-4A64-B178-0E9370737F70}.Debug|ARM.ActiveCfg = Debug|ARM
-		{53C69CF3-B0B8-4A64-B178-0E9370737F70}.Debug|ARM.Build.0 = Debug|ARM
-		{53C69CF3-B0B8-4A64-B178-0E9370737F70}.Debug|ARM64.ActiveCfg = Debug|ARM64
-		{53C69CF3-B0B8-4A64-B178-0E9370737F70}.Debug|ARM64.Build.0 = Debug|ARM64
-		{53C69CF3-B0B8-4A64-B178-0E9370737F70}.Debug|Gaming.Desktop.x64.ActiveCfg = Debug|x64
-		{53C69CF3-B0B8-4A64-B178-0E9370737F70}.Debug|x64.ActiveCfg = Debug|x64
-		{53C69CF3-B0B8-4A64-B178-0E9370737F70}.Debug|x64.Build.0 = Debug|x64
-		{53C69CF3-B0B8-4A64-B178-0E9370737F70}.Debug|x86.ActiveCfg = Debug|Win32
-		{53C69CF3-B0B8-4A64-B178-0E9370737F70}.Debug|x86.Build.0 = Debug|Win32
-		{53C69CF3-B0B8-4A64-B178-0E9370737F70}.Release|ARM.ActiveCfg = Release|ARM
-		{53C69CF3-B0B8-4A64-B178-0E9370737F70}.Release|ARM.Build.0 = Release|ARM
-		{53C69CF3-B0B8-4A64-B178-0E9370737F70}.Release|ARM64.ActiveCfg = Release|ARM64
-		{53C69CF3-B0B8-4A64-B178-0E9370737F70}.Release|ARM64.Build.0 = Release|ARM64
-		{53C69CF3-B0B8-4A64-B178-0E9370737F70}.Release|Gaming.Desktop.x64.ActiveCfg = Release|x64
-		{53C69CF3-B0B8-4A64-B178-0E9370737F70}.Release|x64.ActiveCfg = Release|x64
-		{53C69CF3-B0B8-4A64-B178-0E9370737F70}.Release|x64.Build.0 = Release|x64
-		{53C69CF3-B0B8-4A64-B178-0E9370737F70}.Release|x86.ActiveCfg = Release|Win32
-		{53C69CF3-B0B8-4A64-B178-0E9370737F70}.Release|x86.Build.0 = Release|Win32
 		{AAF08544-8AAA-41A5-A86B-2AF4D8985258}.Debug|ARM.ActiveCfg = Debug|ARM
 		{AAF08544-8AAA-41A5-A86B-2AF4D8985258}.Debug|ARM.Build.0 = Debug|ARM
 		{AAF08544-8AAA-41A5-A86B-2AF4D8985258}.Debug|ARM64.ActiveCfg = Debug|ARM64
@@ -248,24 +212,6 @@ Global
 		{2E55AA9F-A132-477C-B4FF-B4CD551E4322}.Release|x64.Build.0 = Release|x64
 		{2E55AA9F-A132-477C-B4FF-B4CD551E4322}.Release|x86.ActiveCfg = Release|Win32
 		{2E55AA9F-A132-477C-B4FF-B4CD551E4322}.Release|x86.Build.0 = Release|Win32
-		{5B498CF9-1803-438F-98FC-25F42759F440}.Debug|ARM.ActiveCfg = Debug|ARM
-		{5B498CF9-1803-438F-98FC-25F42759F440}.Debug|ARM.Build.0 = Debug|ARM
-		{5B498CF9-1803-438F-98FC-25F42759F440}.Debug|ARM64.ActiveCfg = Debug|ARM64
-		{5B498CF9-1803-438F-98FC-25F42759F440}.Debug|ARM64.Build.0 = Debug|ARM64
-		{5B498CF9-1803-438F-98FC-25F42759F440}.Debug|Gaming.Desktop.x64.ActiveCfg = Debug|x64
-		{5B498CF9-1803-438F-98FC-25F42759F440}.Debug|x64.ActiveCfg = Debug|x64
-		{5B498CF9-1803-438F-98FC-25F42759F440}.Debug|x64.Build.0 = Debug|x64
-		{5B498CF9-1803-438F-98FC-25F42759F440}.Debug|x86.ActiveCfg = Debug|Win32
-		{5B498CF9-1803-438F-98FC-25F42759F440}.Debug|x86.Build.0 = Debug|Win32
-		{5B498CF9-1803-438F-98FC-25F42759F440}.Release|ARM.ActiveCfg = Release|ARM
-		{5B498CF9-1803-438F-98FC-25F42759F440}.Release|ARM.Build.0 = Release|ARM
-		{5B498CF9-1803-438F-98FC-25F42759F440}.Release|ARM64.ActiveCfg = Release|ARM64
-		{5B498CF9-1803-438F-98FC-25F42759F440}.Release|ARM64.Build.0 = Release|ARM64
-		{5B498CF9-1803-438F-98FC-25F42759F440}.Release|Gaming.Desktop.x64.ActiveCfg = Release|x64
-		{5B498CF9-1803-438F-98FC-25F42759F440}.Release|x64.ActiveCfg = Release|x64
-		{5B498CF9-1803-438F-98FC-25F42759F440}.Release|x64.Build.0 = Release|x64
-		{5B498CF9-1803-438F-98FC-25F42759F440}.Release|x86.ActiveCfg = Release|Win32
-		{5B498CF9-1803-438F-98FC-25F42759F440}.Release|x86.Build.0 = Release|Win32
 		{99542110-3CCD-4525-B607-DB8F6E76AEAC}.Debug|ARM.ActiveCfg = Debug|ARM
 		{99542110-3CCD-4525-B607-DB8F6E76AEAC}.Debug|ARM.Build.0 = Debug|ARM
 		{99542110-3CCD-4525-B607-DB8F6E76AEAC}.Debug|ARM.Deploy.0 = Debug|ARM
@@ -330,140 +276,6 @@ Global
 		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Release|x64.Build.0 = Release|x64
 		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Release|x86.ActiveCfg = Release|Win32
 		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB}.Release|x86.Build.0 = Release|Win32
-		{BEDE280F-17F7-4A09-9F5D-2E02FBB1C490}.Debug|ARM.ActiveCfg = Debug|ARM
-		{BEDE280F-17F7-4A09-9F5D-2E02FBB1C490}.Debug|ARM.Build.0 = Debug|ARM
-		{BEDE280F-17F7-4A09-9F5D-2E02FBB1C490}.Debug|ARM64.ActiveCfg = Debug|ARM64
-		{BEDE280F-17F7-4A09-9F5D-2E02FBB1C490}.Debug|ARM64.Build.0 = Debug|ARM64
-		{BEDE280F-17F7-4A09-9F5D-2E02FBB1C490}.Debug|Gaming.Desktop.x64.ActiveCfg = Debug|x64
-		{BEDE280F-17F7-4A09-9F5D-2E02FBB1C490}.Debug|x64.ActiveCfg = Debug|x64
-		{BEDE280F-17F7-4A09-9F5D-2E02FBB1C490}.Debug|x64.Build.0 = Debug|x64
-		{BEDE280F-17F7-4A09-9F5D-2E02FBB1C490}.Debug|x86.ActiveCfg = Debug|Win32
-		{BEDE280F-17F7-4A09-9F5D-2E02FBB1C490}.Debug|x86.Build.0 = Debug|Win32
-		{BEDE280F-17F7-4A09-9F5D-2E02FBB1C490}.Release|ARM.ActiveCfg = Release|ARM
-		{BEDE280F-17F7-4A09-9F5D-2E02FBB1C490}.Release|ARM.Build.0 = Release|ARM
-		{BEDE280F-17F7-4A09-9F5D-2E02FBB1C490}.Release|ARM64.ActiveCfg = Release|ARM64
-		{BEDE280F-17F7-4A09-9F5D-2E02FBB1C490}.Release|ARM64.Build.0 = Release|ARM64
-		{BEDE280F-17F7-4A09-9F5D-2E02FBB1C490}.Release|Gaming.Desktop.x64.ActiveCfg = Release|x64
-		{BEDE280F-17F7-4A09-9F5D-2E02FBB1C490}.Release|x64.ActiveCfg = Release|x64
-		{BEDE280F-17F7-4A09-9F5D-2E02FBB1C490}.Release|x64.Build.0 = Release|x64
-		{BEDE280F-17F7-4A09-9F5D-2E02FBB1C490}.Release|x86.ActiveCfg = Release|Win32
-		{BEDE280F-17F7-4A09-9F5D-2E02FBB1C490}.Release|x86.Build.0 = Release|Win32
-		{961F48EA-33A9-47F1-9C96-715D6094D79B}.Debug|ARM.ActiveCfg = Debug|ARM
-		{961F48EA-33A9-47F1-9C96-715D6094D79B}.Debug|ARM.Build.0 = Debug|ARM
-		{961F48EA-33A9-47F1-9C96-715D6094D79B}.Debug|ARM64.ActiveCfg = Debug|ARM64
-		{961F48EA-33A9-47F1-9C96-715D6094D79B}.Debug|ARM64.Build.0 = Debug|ARM64
-		{961F48EA-33A9-47F1-9C96-715D6094D79B}.Debug|Gaming.Desktop.x64.ActiveCfg = Debug|x64
-		{961F48EA-33A9-47F1-9C96-715D6094D79B}.Debug|x64.ActiveCfg = Debug|x64
-		{961F48EA-33A9-47F1-9C96-715D6094D79B}.Debug|x64.Build.0 = Debug|x64
-		{961F48EA-33A9-47F1-9C96-715D6094D79B}.Debug|x86.ActiveCfg = Debug|Win32
-		{961F48EA-33A9-47F1-9C96-715D6094D79B}.Debug|x86.Build.0 = Debug|Win32
-		{961F48EA-33A9-47F1-9C96-715D6094D79B}.Release|ARM.ActiveCfg = Release|ARM
-		{961F48EA-33A9-47F1-9C96-715D6094D79B}.Release|ARM.Build.0 = Release|ARM
-		{961F48EA-33A9-47F1-9C96-715D6094D79B}.Release|ARM64.ActiveCfg = Release|ARM64
-		{961F48EA-33A9-47F1-9C96-715D6094D79B}.Release|ARM64.Build.0 = Release|ARM64
-		{961F48EA-33A9-47F1-9C96-715D6094D79B}.Release|Gaming.Desktop.x64.ActiveCfg = Release|x64
-		{961F48EA-33A9-47F1-9C96-715D6094D79B}.Release|x64.ActiveCfg = Release|x64
-		{961F48EA-33A9-47F1-9C96-715D6094D79B}.Release|x64.Build.0 = Release|x64
-		{961F48EA-33A9-47F1-9C96-715D6094D79B}.Release|x86.ActiveCfg = Release|Win32
-		{961F48EA-33A9-47F1-9C96-715D6094D79B}.Release|x86.Build.0 = Release|Win32
-		{EEE4D040-3907-43BD-9CA9-C89F1DB19FCD}.Debug|ARM.ActiveCfg = Debug|ARM
-		{EEE4D040-3907-43BD-9CA9-C89F1DB19FCD}.Debug|ARM.Build.0 = Debug|ARM
-		{EEE4D040-3907-43BD-9CA9-C89F1DB19FCD}.Debug|ARM64.ActiveCfg = Debug|ARM64
-		{EEE4D040-3907-43BD-9CA9-C89F1DB19FCD}.Debug|ARM64.Build.0 = Debug|ARM64
-		{EEE4D040-3907-43BD-9CA9-C89F1DB19FCD}.Debug|Gaming.Desktop.x64.ActiveCfg = Debug|x64
-		{EEE4D040-3907-43BD-9CA9-C89F1DB19FCD}.Debug|Gaming.Desktop.x64.Build.0 = Debug|x64
-		{EEE4D040-3907-43BD-9CA9-C89F1DB19FCD}.Debug|x64.ActiveCfg = Debug|x64
-		{EEE4D040-3907-43BD-9CA9-C89F1DB19FCD}.Debug|x64.Build.0 = Debug|x64
-		{EEE4D040-3907-43BD-9CA9-C89F1DB19FCD}.Debug|x86.ActiveCfg = Debug|Win32
-		{EEE4D040-3907-43BD-9CA9-C89F1DB19FCD}.Debug|x86.Build.0 = Debug|Win32
-		{EEE4D040-3907-43BD-9CA9-C89F1DB19FCD}.Release|ARM.ActiveCfg = Release|ARM
-		{EEE4D040-3907-43BD-9CA9-C89F1DB19FCD}.Release|ARM.Build.0 = Release|ARM
-		{EEE4D040-3907-43BD-9CA9-C89F1DB19FCD}.Release|ARM64.ActiveCfg = Release|ARM64
-		{EEE4D040-3907-43BD-9CA9-C89F1DB19FCD}.Release|ARM64.Build.0 = Release|ARM64
-		{EEE4D040-3907-43BD-9CA9-C89F1DB19FCD}.Release|Gaming.Desktop.x64.ActiveCfg = Release|x64
-		{EEE4D040-3907-43BD-9CA9-C89F1DB19FCD}.Release|x64.ActiveCfg = Release|x64
-		{EEE4D040-3907-43BD-9CA9-C89F1DB19FCD}.Release|x64.Build.0 = Release|x64
-		{EEE4D040-3907-43BD-9CA9-C89F1DB19FCD}.Release|x86.ActiveCfg = Release|Win32
-		{EEE4D040-3907-43BD-9CA9-C89F1DB19FCD}.Release|x86.Build.0 = Release|Win32
-		{9C459B54-E085-42F3-A671-7F55C2994048}.Debug|ARM.ActiveCfg = Debug|ARM
-		{9C459B54-E085-42F3-A671-7F55C2994048}.Debug|ARM.Build.0 = Debug|ARM
-		{9C459B54-E085-42F3-A671-7F55C2994048}.Debug|ARM64.ActiveCfg = Debug|ARM64
-		{9C459B54-E085-42F3-A671-7F55C2994048}.Debug|ARM64.Build.0 = Debug|ARM64
-		{9C459B54-E085-42F3-A671-7F55C2994048}.Debug|Gaming.Desktop.x64.ActiveCfg = Debug|x64
-		{9C459B54-E085-42F3-A671-7F55C2994048}.Debug|Gaming.Desktop.x64.Build.0 = Debug|x64
-		{9C459B54-E085-42F3-A671-7F55C2994048}.Debug|x64.ActiveCfg = Debug|x64
-		{9C459B54-E085-42F3-A671-7F55C2994048}.Debug|x64.Build.0 = Debug|x64
-		{9C459B54-E085-42F3-A671-7F55C2994048}.Debug|x86.ActiveCfg = Debug|Win32
-		{9C459B54-E085-42F3-A671-7F55C2994048}.Debug|x86.Build.0 = Debug|Win32
-		{9C459B54-E085-42F3-A671-7F55C2994048}.Release|ARM.ActiveCfg = Release|ARM
-		{9C459B54-E085-42F3-A671-7F55C2994048}.Release|ARM.Build.0 = Release|ARM
-		{9C459B54-E085-42F3-A671-7F55C2994048}.Release|ARM64.ActiveCfg = Release|ARM64
-		{9C459B54-E085-42F3-A671-7F55C2994048}.Release|ARM64.Build.0 = Release|ARM64
-		{9C459B54-E085-42F3-A671-7F55C2994048}.Release|Gaming.Desktop.x64.ActiveCfg = Release|x64
-		{9C459B54-E085-42F3-A671-7F55C2994048}.Release|x64.ActiveCfg = Release|x64
-		{9C459B54-E085-42F3-A671-7F55C2994048}.Release|x64.Build.0 = Release|x64
-		{9C459B54-E085-42F3-A671-7F55C2994048}.Release|x86.ActiveCfg = Release|Win32
-		{9C459B54-E085-42F3-A671-7F55C2994048}.Release|x86.Build.0 = Release|Win32
-		{A5EB6BDD-DD81-4B7B-83A0-A8AE0068FC3F}.Debug|ARM.ActiveCfg = Debug|ARM
-		{A5EB6BDD-DD81-4B7B-83A0-A8AE0068FC3F}.Debug|ARM.Build.0 = Debug|ARM
-		{A5EB6BDD-DD81-4B7B-83A0-A8AE0068FC3F}.Debug|ARM64.ActiveCfg = Debug|ARM64
-		{A5EB6BDD-DD81-4B7B-83A0-A8AE0068FC3F}.Debug|ARM64.Build.0 = Debug|ARM64
-		{A5EB6BDD-DD81-4B7B-83A0-A8AE0068FC3F}.Debug|Gaming.Desktop.x64.ActiveCfg = Debug|x64
-		{A5EB6BDD-DD81-4B7B-83A0-A8AE0068FC3F}.Debug|x64.ActiveCfg = Debug|x64
-		{A5EB6BDD-DD81-4B7B-83A0-A8AE0068FC3F}.Debug|x64.Build.0 = Debug|x64
-		{A5EB6BDD-DD81-4B7B-83A0-A8AE0068FC3F}.Debug|x86.ActiveCfg = Debug|Win32
-		{A5EB6BDD-DD81-4B7B-83A0-A8AE0068FC3F}.Debug|x86.Build.0 = Debug|Win32
-		{A5EB6BDD-DD81-4B7B-83A0-A8AE0068FC3F}.Release|ARM.ActiveCfg = Release|ARM
-		{A5EB6BDD-DD81-4B7B-83A0-A8AE0068FC3F}.Release|ARM.Build.0 = Release|ARM
-		{A5EB6BDD-DD81-4B7B-83A0-A8AE0068FC3F}.Release|ARM64.ActiveCfg = Release|ARM64
-		{A5EB6BDD-DD81-4B7B-83A0-A8AE0068FC3F}.Release|ARM64.Build.0 = Release|ARM64
-		{A5EB6BDD-DD81-4B7B-83A0-A8AE0068FC3F}.Release|Gaming.Desktop.x64.ActiveCfg = Release|x64
-		{A5EB6BDD-DD81-4B7B-83A0-A8AE0068FC3F}.Release|x64.ActiveCfg = Release|x64
-		{A5EB6BDD-DD81-4B7B-83A0-A8AE0068FC3F}.Release|x64.Build.0 = Release|x64
-		{A5EB6BDD-DD81-4B7B-83A0-A8AE0068FC3F}.Release|x86.ActiveCfg = Release|Win32
-		{A5EB6BDD-DD81-4B7B-83A0-A8AE0068FC3F}.Release|x86.Build.0 = Release|Win32
-		{23104CDA-C598-4D41-B7FF-70405B2871EC}.Debug|ARM.ActiveCfg = Debug|ARM
-		{23104CDA-C598-4D41-B7FF-70405B2871EC}.Debug|ARM.Build.0 = Debug|ARM
-		{23104CDA-C598-4D41-B7FF-70405B2871EC}.Debug|ARM64.ActiveCfg = Debug|ARM64
-		{23104CDA-C598-4D41-B7FF-70405B2871EC}.Debug|ARM64.Build.0 = Debug|ARM64
-		{23104CDA-C598-4D41-B7FF-70405B2871EC}.Debug|Gaming.Desktop.x64.ActiveCfg = Debug|x64
-		{23104CDA-C598-4D41-B7FF-70405B2871EC}.Debug|x64.ActiveCfg = Debug|x64
-		{23104CDA-C598-4D41-B7FF-70405B2871EC}.Debug|x64.Build.0 = Debug|x64
-		{23104CDA-C598-4D41-B7FF-70405B2871EC}.Debug|x86.ActiveCfg = Debug|Win32
-		{23104CDA-C598-4D41-B7FF-70405B2871EC}.Debug|x86.Build.0 = Debug|Win32
-		{23104CDA-C598-4D41-B7FF-70405B2871EC}.Release|ARM.ActiveCfg = Release|ARM
-		{23104CDA-C598-4D41-B7FF-70405B2871EC}.Release|ARM.Build.0 = Release|ARM
-		{23104CDA-C598-4D41-B7FF-70405B2871EC}.Release|ARM64.ActiveCfg = Release|ARM64
-		{23104CDA-C598-4D41-B7FF-70405B2871EC}.Release|ARM64.Build.0 = Release|ARM64
-		{23104CDA-C598-4D41-B7FF-70405B2871EC}.Release|Gaming.Desktop.x64.ActiveCfg = Release|x64
-		{23104CDA-C598-4D41-B7FF-70405B2871EC}.Release|x64.ActiveCfg = Release|x64
-		{23104CDA-C598-4D41-B7FF-70405B2871EC}.Release|x64.Build.0 = Release|x64
-		{23104CDA-C598-4D41-B7FF-70405B2871EC}.Release|x86.ActiveCfg = Release|Win32
-		{23104CDA-C598-4D41-B7FF-70405B2871EC}.Release|x86.Build.0 = Release|Win32
-		{66365E18-7B53-44BF-A348-6735058E359E}.Debug|ARM.ActiveCfg = Debug|Gaming.Desktop.x64
-		{66365E18-7B53-44BF-A348-6735058E359E}.Debug|ARM64.ActiveCfg = Debug|Gaming.Desktop.x64
-		{66365E18-7B53-44BF-A348-6735058E359E}.Debug|Gaming.Desktop.x64.ActiveCfg = Debug|Gaming.Desktop.x64
-		{66365E18-7B53-44BF-A348-6735058E359E}.Debug|Gaming.Desktop.x64.Build.0 = Debug|Gaming.Desktop.x64
-		{66365E18-7B53-44BF-A348-6735058E359E}.Debug|x64.ActiveCfg = Debug|Gaming.Desktop.x64
-		{66365E18-7B53-44BF-A348-6735058E359E}.Debug|x86.ActiveCfg = Debug|Gaming.Desktop.x64
-		{66365E18-7B53-44BF-A348-6735058E359E}.Release|ARM.ActiveCfg = Release|Gaming.Desktop.x64
-		{66365E18-7B53-44BF-A348-6735058E359E}.Release|ARM64.ActiveCfg = Release|Gaming.Desktop.x64
-		{66365E18-7B53-44BF-A348-6735058E359E}.Release|Gaming.Desktop.x64.ActiveCfg = Release|Gaming.Desktop.x64
-		{66365E18-7B53-44BF-A348-6735058E359E}.Release|Gaming.Desktop.x64.Build.0 = Release|Gaming.Desktop.x64
-		{66365E18-7B53-44BF-A348-6735058E359E}.Release|x64.ActiveCfg = Release|Gaming.Desktop.x64
-		{66365E18-7B53-44BF-A348-6735058E359E}.Release|x86.ActiveCfg = Release|Gaming.Desktop.x64
-		{78C0122C-6B2D-4054-8C49-448277DD7A7D}.Debug|ARM.ActiveCfg = Debug|Gaming.Desktop.x64
-		{78C0122C-6B2D-4054-8C49-448277DD7A7D}.Debug|ARM64.ActiveCfg = Debug|Gaming.Desktop.x64
-		{78C0122C-6B2D-4054-8C49-448277DD7A7D}.Debug|Gaming.Desktop.x64.ActiveCfg = Debug|Gaming.Desktop.x64
-		{78C0122C-6B2D-4054-8C49-448277DD7A7D}.Debug|Gaming.Desktop.x64.Build.0 = Debug|Gaming.Desktop.x64
-		{78C0122C-6B2D-4054-8C49-448277DD7A7D}.Debug|x64.ActiveCfg = Debug|Gaming.Desktop.x64
-		{78C0122C-6B2D-4054-8C49-448277DD7A7D}.Debug|x86.ActiveCfg = Debug|Gaming.Desktop.x64
-		{78C0122C-6B2D-4054-8C49-448277DD7A7D}.Release|ARM.ActiveCfg = Release|Gaming.Desktop.x64
-		{78C0122C-6B2D-4054-8C49-448277DD7A7D}.Release|ARM64.ActiveCfg = Release|Gaming.Desktop.x64
-		{78C0122C-6B2D-4054-8C49-448277DD7A7D}.Release|Gaming.Desktop.x64.ActiveCfg = Release|Gaming.Desktop.x64
-		{78C0122C-6B2D-4054-8C49-448277DD7A7D}.Release|Gaming.Desktop.x64.Build.0 = Release|Gaming.Desktop.x64
-		{78C0122C-6B2D-4054-8C49-448277DD7A7D}.Release|x64.ActiveCfg = Release|Gaming.Desktop.x64
-		{78C0122C-6B2D-4054-8C49-448277DD7A7D}.Release|x86.ActiveCfg = Release|Gaming.Desktop.x64
 		{E885BB30-F51E-4BAB-9300-4B303144BB49}.Debug|ARM.ActiveCfg = Debug|ARM
 		{E885BB30-F51E-4BAB-9300-4B303144BB49}.Debug|ARM.Build.0 = Debug|ARM
 		{E885BB30-F51E-4BAB-9300-4B303144BB49}.Debug|ARM64.ActiveCfg = Debug|ARM64
@@ -510,7 +322,6 @@ Global
 		{8CA3B500-0D89-4DB1-BA8B-98AEB468CA13} = {348C2EBE-5E0D-4008-8E9C-BD2ECF40F4BC}
 		{0A6D51A3-0D86-4D0E-9DAA-54BA75E1DA1C} = {348C2EBE-5E0D-4008-8E9C-BD2ECF40F4BC}
 		{47564F2B-9ED7-4527-997A-5D76C36998D1} = {AEECE539-001A-4CB1-B7A3-6E6FB345D108}
-		{53C69CF3-B0B8-4A64-B178-0E9370737F70} = {AEECE539-001A-4CB1-B7A3-6E6FB345D108}
 		{097E9D46-215E-43AE-B8DF-339EDF537EB6} = {118840A6-8EB2-4D70-B0EE-65EE13E2FEAB}
 		{AAF08544-8AAA-41A5-A86B-2AF4D8985258} = {118840A6-8EB2-4D70-B0EE-65EE13E2FEAB}
 		{D01BF0FD-D450-41DC-BFA4-62468528B91E} = {118840A6-8EB2-4D70-B0EE-65EE13E2FEAB}
@@ -520,18 +331,9 @@ Global
 		{7A3B2F87-A009-408F-8230-4E76CDF6AED4} = {AEECE539-001A-4CB1-B7A3-6E6FB345D108}
 		{2DFBBF3A-6D4B-4FF8-BD01-C9527A1FE0AC} = {7A3B2F87-A009-408F-8230-4E76CDF6AED4}
 		{2E55AA9F-A132-477C-B4FF-B4CD551E4322} = {AEECE539-001A-4CB1-B7A3-6E6FB345D108}
-		{5B498CF9-1803-438F-98FC-25F42759F440} = {AEECE539-001A-4CB1-B7A3-6E6FB345D108}
 		{99542110-3CCD-4525-B607-DB8F6E76AEAC} = {7A3B2F87-A009-408F-8230-4E76CDF6AED4}
 		{591520A6-680D-4AD7-AACB-8C2C877F8BAE} = {2FF76652-3783-4047-8F2B-8777155F1C66}
 		{267629EF-20A2-4FFB-8DC8-A8534E98FCEB} = {2FF76652-3783-4047-8F2B-8777155F1C66}
-		{BEDE280F-17F7-4A09-9F5D-2E02FBB1C490} = {118840A6-8EB2-4D70-B0EE-65EE13E2FEAB}
-		{961F48EA-33A9-47F1-9C96-715D6094D79B} = {118840A6-8EB2-4D70-B0EE-65EE13E2FEAB}
-		{EEE4D040-3907-43BD-9CA9-C89F1DB19FCD} = {118840A6-8EB2-4D70-B0EE-65EE13E2FEAB}
-		{9C459B54-E085-42F3-A671-7F55C2994048} = {118840A6-8EB2-4D70-B0EE-65EE13E2FEAB}
-		{A5EB6BDD-DD81-4B7B-83A0-A8AE0068FC3F} = {118840A6-8EB2-4D70-B0EE-65EE13E2FEAB}
-		{23104CDA-C598-4D41-B7FF-70405B2871EC} = {118840A6-8EB2-4D70-B0EE-65EE13E2FEAB}
-		{66365E18-7B53-44BF-A348-6735058E359E} = {348C2EBE-5E0D-4008-8E9C-BD2ECF40F4BC}
-		{78C0122C-6B2D-4054-8C49-448277DD7A7D} = {348C2EBE-5E0D-4008-8E9C-BD2ECF40F4BC}
 		{8EF7009A-36CF-4D82-9FB7-6D69154893CF} = {6BBCD917-A163-48D8-9385-3F6135E031FE}
 		{E885BB30-F51E-4BAB-9300-4B303144BB49} = {6BBCD917-A163-48D8-9385-3F6135E031FE}
 		{9DD2BA60-6505-493A-8C41-8085C44E9F1F} = {6BBCD917-A163-48D8-9385-3F6135E031FE}
@@ -544,36 +346,25 @@ Global
 		Build\libHttpClient.Common\libHttpClient.Common.vcxitems*{0a6d51a3-0d86-4d0e-9daa-54ba75e1da1c}*SharedItemsImports = 4
 		Build\libHttpClient.GDK\libHttpClient.GDK.vcxitems*{0a6d51a3-0d86-4d0e-9daa-54ba75e1da1c}*SharedItemsImports = 4
 		Build\libcrypto.Win32\libcrypto.Win32.vcxitems*{16aa2ebe-6d49-41b7-a13f-887c12e78715}*SharedItemsImports = 4
-		Build\libssl.Win32\libssl.Win32.vcxitems*{23104cda-c598-4d41-b7ff-70405b2871ec}*SharedItemsImports = 4
 		Build\libHttpClient.Common\libHttpClient.Common.vcxitems*{2e55aa9f-a132-477c-b4ff-b4cd551e4322}*SharedItemsImports = 4
 		Build\libHttpClient.UWP\libHttpClient.UWP.vcxitems*{2e55aa9f-a132-477c-b4ff-b4cd551e4322}*SharedItemsImports = 4
+		Build\libHttpClient.XAsync\libHttpClient.XAsync.vcxitems*{2e55aa9f-a132-477c-b4ff-b4cd551e4322}*SharedItemsImports = 4
 		Build\libHttpClient.UWP\libHttpClient.UWP.vcxitems*{47564f2b-9ed7-4527-997a-5d76c36998d1}*SharedItemsImports = 9
-		Build\libHttpClient.Common\libHttpClient.Common.vcxitems*{53c69cf3-b0b8-4a64-b178-0e9370737f70}*SharedItemsImports = 4
-		Build\libHttpClient.UWP\libHttpClient.UWP.vcxitems*{53c69cf3-b0b8-4a64-b178-0e9370737f70}*SharedItemsImports = 4
-		Build\libHttpClient.Common\libHttpClient.Common.vcxitems*{5b498cf9-1803-438f-98fc-25f42759f440}*SharedItemsImports = 4
-		Build\libHttpClient.UWP\libHttpClient.UWP.vcxitems*{5b498cf9-1803-438f-98fc-25f42759f440}*SharedItemsImports = 4
-		Build\libHttpClient.Common\libHttpClient.Common.vcxitems*{66365e18-7b53-44bf-a348-6735058e359e}*SharedItemsImports = 4
-		Build\libHttpClient.GDK\libHttpClient.GDK.vcxitems*{66365e18-7b53-44bf-a348-6735058e359e}*SharedItemsImports = 4
 		Build\libHttpClient.Common\libHttpClient.Common.vcxitems*{673e9758-fafe-4f91-8fc1-addda12c5de5}*SharedItemsImports = 9
-		Build\libHttpClient.Common\libHttpClient.Common.vcxitems*{78c0122c-6b2d-4054-8c49-448277dd7a7d}*SharedItemsImports = 4
-		Build\libHttpClient.GDK\libHttpClient.GDK.vcxitems*{78c0122c-6b2d-4054-8c49-448277dd7a7d}*SharedItemsImports = 4
 		Build\libHttpClient.GDK\libHttpClient.GDK.vcxitems*{8ca3b500-0d89-4db1-ba8b-98aeb468ca13}*SharedItemsImports = 9
 		Build\libHttpClient.UnitTest\libHttpClient.UnitTest.vcxitems*{8ef7009a-36cf-4d82-9fb7-6d69154893cf}*SharedItemsImports = 9
 		Build\libHttpClient.Common\libHttpClient.Common.vcxitems*{9164c6c9-3872-4922-a3e3-3822622d3e71}*SharedItemsImports = 4
 		Build\libHttpClient.Win32\libHttpClient.Win32.vcxitems*{9164c6c9-3872-4922-a3e3-3822622d3e71}*SharedItemsImports = 4
-		Build\libHttpClient.Common\libHttpClient.Common.vcxitems*{961f48ea-33a9-47f1-9c96-715d6094d79b}*SharedItemsImports = 4
-		Build\libHttpClient.Win32\libHttpClient.Win32.vcxitems*{961f48ea-33a9-47f1-9c96-715d6094d79b}*SharedItemsImports = 4
-		Build\libcrypto.Win32\libcrypto.Win32.vcxitems*{9c459b54-e085-42f3-a671-7f55c2994048}*SharedItemsImports = 4
+		Build\libHttpClient.XAsync\libHttpClient.XAsync.vcxitems*{9164c6c9-3872-4922-a3e3-3822622d3e71}*SharedItemsImports = 4
 		Build\libHttpClient.Common\libHttpClient.Common.vcxitems*{9dd2ba60-6505-493a-8c41-8085c44e9f1f}*SharedItemsImports = 4
 		Build\libHttpClient.UnitTest\libHttpClient.UnitTest.vcxitems*{9dd2ba60-6505-493a-8c41-8085c44e9f1f}*SharedItemsImports = 4
-		Build\libssl.Win32\libssl.Win32.vcxitems*{a5eb6bdd-dd81-4b7b-83a0-a8ae0068fc3f}*SharedItemsImports = 4
+		Build\libHttpClient.XAsync\libHttpClient.XAsync.vcxitems*{9dd2ba60-6505-493a-8c41-8085c44e9f1f}*SharedItemsImports = 4
 		Build\libssl.Win32\libssl.Win32.vcxitems*{aaf08544-8aaa-41a5-a86b-2af4d8985258}*SharedItemsImports = 4
-		Build\libHttpClient.Common\libHttpClient.Common.vcxitems*{bede280f-17f7-4a09-9f5d-2e02fbb1c490}*SharedItemsImports = 4
-		Build\libHttpClient.Win32\libHttpClient.Win32.vcxitems*{bede280f-17f7-4a09-9f5d-2e02fbb1c490}*SharedItemsImports = 4
+		Build\libHttpClient.XAsync\libHttpClient.XAsync.vcxitems*{b5118956-53cc-4b24-8807-de8d7d226b40}*SharedItemsImports = 9
 		Build\libcrypto.Win32\libcrypto.Win32.vcxitems*{d01bf0fd-d450-41dc-bfa4-62468528b91e}*SharedItemsImports = 9
 		Build\libHttpClient.Win32\libHttpClient.Win32.vcxitems*{d980f91b-92bf-4cc4-89fd-1cd99dba870f}*SharedItemsImports = 9
 		Build\libHttpClient.Common\libHttpClient.Common.vcxitems*{e885bb30-f51e-4bab-9300-4b303144bb49}*SharedItemsImports = 4
 		Build\libHttpClient.UnitTest\libHttpClient.UnitTest.vcxitems*{e885bb30-f51e-4bab-9300-4b303144bb49}*SharedItemsImports = 4
-		Build\libcrypto.Win32\libcrypto.Win32.vcxitems*{eee4d040-3907-43bd-9ca9-c89f1db19fcd}*SharedItemsImports = 4
+		Build\libHttpClient.XAsync\libHttpClient.XAsync.vcxitems*{e885bb30-f51e-4bab-9300-4b303144bb49}*SharedItemsImports = 4
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
* XAsync shouldn't be included on GDK so it needs to be split out from libHttpClient.Common
* Also stripped 141/142 projects from vs2022 solution since OneBranch pipelines don't support for building with legacy toolsets in vs2022