### PR TITLE
Fix bug in CurlMulti

### DIFF
--- a/Source/Global/global.cpp
+++ b/Source/Global/global.cpp
@@ -132,6 +132,8 @@ HRESULT CALLBACK http_singleton::CleanupAsyncProvider(XAsyncOp op, const XAsyncP
         performEnvCleanupAsyncBlock->context = data->async;
         performEnvCleanupAsyncBlock->callback = [](XAsyncBlock* async)
         {
+            HC_TRACE_VERBOSE(HTTPCLIENT, "HC_PERFORM_ENV::CleanupAsync Complete");
+
             HC_UNIQUE_PTR<XAsyncBlock> performEnvCleanupAsyncBlock{ async };
             XAsyncBlock* singletonCleanupAsyncBlock = static_cast<XAsyncBlock*>(performEnvCleanupAsyncBlock->context);
 

--- a/Source/Global/perform_env.cpp
+++ b/Source/Global/perform_env.cpp
@@ -532,8 +532,9 @@ HRESULT CALLBACK HC_PERFORM_ENV::CleanupAsyncProvider(XAsyncOp op, const XAsyncP
         env->m_cleanupAsyncBlock = data->async;
         bool scheduleProviderCleanup = env->CanScheduleProviderCleanup();
 
+#if !HC_NOWEBSOCKETS
         HC_TRACE_VERBOSE(HTTPCLIENT, "HC_PERFORM_ENV::CleanupAsyncProvider::Begin: HTTP active=%llu, WebSocket Connecting=%llu, WebSocket Connected=%llu", env->m_activeHttpRequests.size(), env->m_connectingWebSockets.size(), env->m_connectedWebSockets.size());
-
+#endif
         for (auto& activeRequest : env->m_activeHttpRequests)
         {
             XAsyncCancel(activeRequest);
@@ -622,8 +623,9 @@ bool HC_PERFORM_ENV::CanScheduleProviderCleanup()
         return false;
     }
 
+#if !HC_NOWEBSOCKETS
     HC_TRACE_VERBOSE(HTTPCLIENT, "HC_PERFORM_ENV::Cleaning up, HTTP=%llu, WebSocket Connecting=%llu, WebSocket Connected=%llu", m_activeHttpRequests.size(), m_connectingWebSockets.size(), m_connectedWebSockets.size());
-
+#endif
     if (!m_activeHttpRequests.empty())
     {
         // Pending Http Requests

--- a/Source/Global/perform_env.cpp
+++ b/Source/Global/perform_env.cpp
@@ -532,6 +532,8 @@ HRESULT CALLBACK HC_PERFORM_ENV::CleanupAsyncProvider(XAsyncOp op, const XAsyncP
         env->m_cleanupAsyncBlock = data->async;
         bool scheduleProviderCleanup = env->CanScheduleProviderCleanup();
 
+        HC_TRACE_VERBOSE(HTTPCLIENT, "HC_PERFORM_ENV::CleanupAsyncProvider::Begin: HTTP active=%llu, WebSocket Connecting=%llu, WebSocket Connected=%llu", env->m_activeHttpRequests.size(), env->m_connectingWebSockets.size(), env->m_connectedWebSockets.size());
+
         for (auto& activeRequest : env->m_activeHttpRequests)
         {
             XAsyncCancel(activeRequest);
@@ -563,6 +565,8 @@ HRESULT CALLBACK HC_PERFORM_ENV::CleanupAsyncProvider(XAsyncOp op, const XAsyncP
 
 void CALLBACK HC_PERFORM_ENV::ProviderCleanup(void* context, bool /*canceled*/)
 {
+    HC_TRACE_VERBOSE(HTTPCLIENT, "HC_PERFORM_ENV::ProviderCleanup");
+
     HC_UNIQUE_PTR<HC_PERFORM_ENV> env{ static_cast<HC_PERFORM_ENV*>(context) };
     XAsyncBlock* cleanupAsyncBlock{ env->m_cleanupAsyncBlock };
 
@@ -617,7 +621,10 @@ bool HC_PERFORM_ENV::CanScheduleProviderCleanup()
         // HC_PERFORM_ENV::CleanupAsync has not yet been called
         return false;
     }
-    else if (!m_activeHttpRequests.empty())
+
+    HC_TRACE_VERBOSE(HTTPCLIENT, "HC_PERFORM_ENV::Cleaning up, HTTP=%llu, WebSocket Connecting=%llu, WebSocket Connected=%llu", m_activeHttpRequests.size(), m_connectingWebSockets.size(), m_connectedWebSockets.size());
+
+    if (!m_activeHttpRequests.empty())
     {
         // Pending Http Requests
         return false;

--- a/Source/HTTP/Curl/CurlMulti.h
+++ b/Source/HTTP/Curl/CurlMulti.h
@@ -20,7 +20,7 @@ public:
     // Wrapper around curl_multi_add_handle
     HRESULT AddRequest(HC_UNIQUE_PTR<CurlEasyRequest> easyRequest);
 
-    // Asyncronously cleanup and outstanding requests
+    // Asyncronously cleanup any outstanding requests
     static HRESULT CleanupAsync(HC_UNIQUE_PTR<CurlMulti> multi, XAsyncBlock* async);
 
 private:
@@ -33,7 +33,6 @@ private:
     void FailAllRequests(HRESULT hr) noexcept;
 
     static HRESULT CALLBACK CleanupAsyncProvider(XAsyncOp op, const XAsyncProviderData* data);
-    static void CALLBACK TaskQueueTerminated(void* context);
 
     CURLM* m_curlMultiHandle{ nullptr };
     XTaskQueueHandle m_queue{ nullptr };

--- a/Source/HTTP/Curl/CurlProvider.cpp
+++ b/Source/HTTP/Curl/CurlProvider.cpp
@@ -158,9 +158,9 @@ HRESULT CALLBACK CurlProvider::CleanupAsyncProvider(XAsyncOp op, const XAsyncPro
             }
         }
 
-
         {
             std::lock_guard<std::mutex> lock{ provider->m_mutex };
+            HC_TRACE_VERBOSE(HTTPCLIENT, "CurlProvider::CleanupAsyncProvider, cleanupTasksRemaining=%llu", provider->m_cleanupTasksRemaining - 1);
             if (--provider->m_cleanupTasksRemaining == 0)
             {
                 // If there are no pending pending multi cleanups, complete cleanup here
@@ -193,6 +193,8 @@ void CALLBACK CurlProvider::MultiCleanupComplete(_Inout_ struct XAsyncBlock* asy
     CurlProvider* provider{ static_cast<CurlProvider*>(asyncBlock->context) };
 
     std::unique_lock<std::mutex> lock{ provider->m_mutex };
+    HC_TRACE_VERBOSE(HTTPCLIENT, "CurlProvider::MultiCleanupComplete, cleanupTasksRemaining=%llu", provider->m_cleanupTasksRemaining-1);
+
     if (--provider->m_cleanupTasksRemaining == 0)
     {
         // All CurlMultis have finished asyncCleanup. Destroy provider and complete provider's Cleanup XAsyncBlock

--- a/Source/HTTP/WinHttp/winhttp_provider.cpp
+++ b/Source/HTTP/WinHttp/winhttp_provider.cpp
@@ -277,6 +277,8 @@ HRESULT WinHttpProvider::CloseAllConnections()
 
     auto connectionClosedCallback = [&closeContext]()
     {
+        HC_TRACE_VERBOSE(HTTPCLIENT, "WinHttpProvider::Connection Closed, %llu remaining", closeContext.openConnections - 1);
+
         if (--closeContext.openConnections == 0)
         {
             SetEvent(closeContext.connectionsClosedEvent);
@@ -286,6 +288,7 @@ HRESULT WinHttpProvider::CloseAllConnections()
     http_internal_list<std::shared_ptr<WinHttpConnection>> connections;
     {
         std::lock_guard<std::mutex> lock{ m_lock };
+
         for (auto& weakConnection : m_connections)
         {
             auto connection{ weakConnection.lock() };

--- a/Utilities/Pipelines/libHttpClient.CI.yml
+++ b/Utilities/Pipelines/libHttpClient.CI.yml
@@ -117,7 +117,7 @@ jobs:
   - job: iOSBuild
     displayName: libHttpClient iOS Build
     pool:
-      vmImage: internal-macos-10.15
+      vmImage: macOS-13
     timeoutInMinutes: 180
     strategy:
       matrix:


### PR DESCRIPTION
CurlMulti creates a composite work queue and schedules work to that queue as long as there are outstanding HTTP requests.  During cleanup, CurlMulti will terminate its queue, effectively cancelling all ongoing requests.  However, if there are no ongoing requests at the time of cleanup, there is no guarantee that the client will still be dispatching the queue, which is required to fully terminate a queue.  To fix this I've done two things:
1. Only terminate the queue if there are ongoing requests. If there are no ongoing requests, we're guaranteed to have no remaining callbacks pending on the queue, so termination is unnecessary.
2. When terminating the queue, don't await a queue terminated callback.  This avoids a potential race condition where the client stops dispatching the queue after they've gotten a completion callback for the final HTTP request but before they've dispatched the queue terminated callback.

I also added some additional verbose logging to help diagnose future cleanup issues.