### PR TITLE
Fix leak due to multiple inheritance + custom deleter

### DIFF
--- a/Source/HTTP/WinHttp/winhttp_provider.cpp
+++ b/Source/HTTP/WinHttp/winhttp_provider.cpp
@@ -13,7 +13,7 @@ NAMESPACE_XBOX_HTTP_CLIENT_BEGIN
 Result<HC_UNIQUE_PTR<WinHttpProvider>> WinHttpProvider::Initialize()
 {
     http_stl_allocator<WinHttpProvider> a{};
-    auto provider = HC_UNIQUE_PTR<WinHttpProvider>{ new (a.allocate(1)) WinHttpProvider, a };
+    auto provider = HC_UNIQUE_PTR<WinHttpProvider>{ new (a.allocate(1)) WinHttpProvider };
 
     RETURN_IF_FAILED(XTaskQueueCreate(XTaskQueueDispatchMode::Immediate, XTaskQueueDispatchMode::Immediate, &provider->m_immediateQueue));
 
@@ -587,5 +587,57 @@ void WinHttpProvider::AppStateChangedCallback(BOOLEAN isSuspended, void* context
     }
 }
 #endif // HC_PLATFORM == HC_PLATFORM_GDK
+
+WinHttp_HttpProvider::WinHttp_HttpProvider(std::shared_ptr<xbox::httpclient::WinHttpProvider> provider) : WinHttpProvider{ std::move(provider) }
+{
+}
+
+HRESULT WinHttp_HttpProvider::PerformAsync(HCCallHandle callHandle, XAsyncBlock* async) noexcept
+{
+    return WinHttpProvider->PerformAsync(callHandle, async);
+}
+
+#if !HC_NOWEBSOCKETS
+WinHttp_WebSocketProvider::WinHttp_WebSocketProvider(std::shared_ptr<xbox::httpclient::WinHttpProvider> provider) : WinHttpProvider{ std::move(provider) }
+{
+}
+
+HRESULT WinHttp_WebSocketProvider::ConnectAsync(
+    String const& uri,
+    String const& subprotocol,
+    HCWebsocketHandle websocketHandle,
+    XAsyncBlock* async
+) noexcept
+{
+    return WinHttpProvider->ConnectAsync(uri, subprotocol, websocketHandle, async);
+}
+
+HRESULT WinHttp_WebSocketProvider::SendAsync(
+    HCWebsocketHandle websocketHandle,
+    const char* message,
+    XAsyncBlock* async
+) noexcept
+{
+    return WinHttpProvider->SendAsync(websocketHandle, message, async);
+}
+
+HRESULT WinHttp_WebSocketProvider::SendBinaryAsync(
+    HCWebsocketHandle websocketHandle,
+    const uint8_t* payloadBytes,
+    uint32_t payloadSize,
+    XAsyncBlock* asyncBlock
+) noexcept
+{
+    return WinHttpProvider->SendBinaryAsync(websocketHandle, payloadBytes, payloadSize, asyncBlock);
+}
+
+HRESULT WinHttp_WebSocketProvider::Disconnect(
+    HCWebsocketHandle websocketHandle,
+    HCWebSocketCloseStatus closeStatus
+) noexcept
+{
+    return WinHttpProvider->Disconnect(websocketHandle, closeStatus);
+}
+#endif // !HC_NOWEBSOCKETS
 
 NAMESPACE_XBOX_HTTP_CLIENT_END

--- a/Source/Platform/GDK/PlatformComponents_GDK.cpp
+++ b/Source/Platform/GDK/PlatformComponents_GDK.cpp
@@ -21,7 +21,7 @@ HRESULT PlatformInitialize(PlatformComponents& components, HCInitArgs* initArgs)
     auto initWinHttpResult = WinHttpProvider::Initialize();
     RETURN_IF_FAILED(initWinHttpResult.hr);
  
-    components.WebSocketProvider = initWinHttpResult.ExtractPayload();
+    components.WebSocketProvider = http_allocate_unique<WinHttp_WebSocketProvider>(initWinHttpResult.ExtractPayload());
 #endif
 
     return S_OK;
@@ -30,14 +30,16 @@ HRESULT PlatformInitialize(PlatformComponents& components, HCInitArgs* initArgs)
 // Test hooks for GDK Suspend/Resume testing
 void HCWinHttpSuspend()
 {
-    //auto httpSingleton = get_http_singleton();
-    //httpSingleton->m_performEnv->winHttpProvider->Suspend();
+    auto httpSingleton = get_http_singleton();
+    auto& winHttpProvider = dynamic_cast<WinHttp_WebSocketProvider*>(&httpSingleton->m_networkState->WebSocketProvider())->WinHttpProvider;
+    winHttpProvider->Suspend();
 }
 
 void HCWinHttpResume()
 {
-    //auto httpSingleton = get_http_singleton();
-    //httpSingleton->m_performEnv->winHttpProvider->Resume();
+    auto httpSingleton = get_http_singleton();
+    auto& winHttpProvider = dynamic_cast<WinHttp_WebSocketProvider*>(&httpSingleton->m_networkState->WebSocketProvider())->WinHttpProvider;
+    winHttpProvider->Resume();
 }
 
 NAMESPACE_XBOX_HTTP_CLIENT_END

--- a/Source/Platform/Win32/PlatformComponents_Win32.cpp
+++ b/Source/Platform/Win32/PlatformComponents_Win32.cpp
@@ -4,56 +4,6 @@
 
 NAMESPACE_XBOX_HTTP_CLIENT_BEGIN
 
-class WinHttp_HttpProvider : public IHttpProvider
-{
-public:
-    WinHttp_HttpProvider(std::shared_ptr<WinHttpProvider> provider);
-
-    HRESULT PerformAsync(
-        HCCallHandle callHandle,
-        XAsyncBlock* async
-    ) noexcept override;
-
-private:
-    std::shared_ptr<WinHttpProvider> m_sharedProvider;
-};
-
-#if !HC_NOWEBSOCKETS
-class WinHttp_WebSocketProvider : public IWebSocketProvider
-{
-public:
-    WinHttp_WebSocketProvider(std::shared_ptr<WinHttpProvider> provider);
-
-    HRESULT ConnectAsync(
-        String const& uri,
-        String const& subprotocol,
-        HCWebsocketHandle websocketHandle,
-        XAsyncBlock* async
-    ) noexcept override;
-
-    HRESULT SendAsync(
-        HCWebsocketHandle websocketHandle,
-        const char* message,
-        XAsyncBlock* async
-    ) noexcept override;
-
-    HRESULT SendBinaryAsync(
-        HCWebsocketHandle websocketHandle,
-        const uint8_t* payloadBytes,
-        uint32_t payloadSize,
-        XAsyncBlock* asyncBlock
-    ) noexcept override;
-
-    HRESULT Disconnect(
-        HCWebsocketHandle websocketHandle,
-        HCWebSocketCloseStatus closeStatus
-    ) noexcept override;
-
-private:
-    std::shared_ptr<WinHttpProvider> m_sharedProvider;
-};
-#endif
-
 HRESULT PlatformInitialize(PlatformComponents& components, HCInitArgs* initArgs)
 {
     // We don't expect initArgs on Win32
@@ -72,57 +22,5 @@ HRESULT PlatformInitialize(PlatformComponents& components, HCInitArgs* initArgs)
 
     return S_OK;
 }
-
-WinHttp_HttpProvider::WinHttp_HttpProvider(std::shared_ptr<WinHttpProvider> provider) : m_sharedProvider{ std::move(provider) }
-{
-}
-
-HRESULT WinHttp_HttpProvider::PerformAsync(HCCallHandle callHandle, XAsyncBlock* async) noexcept
-{
-    return m_sharedProvider->PerformAsync(callHandle, async);
-}
-
-#if !HC_NOWEBSOCKETS
-WinHttp_WebSocketProvider::WinHttp_WebSocketProvider(std::shared_ptr<WinHttpProvider> provider) : m_sharedProvider{ std::move(provider) }
-{
-}
-
-HRESULT WinHttp_WebSocketProvider::ConnectAsync(
-    String const& uri,
-    String const& subprotocol,
-    HCWebsocketHandle websocketHandle,
-    XAsyncBlock* async
-) noexcept
-{
-    return m_sharedProvider->ConnectAsync(uri, subprotocol, websocketHandle, async);
-}
-
-HRESULT WinHttp_WebSocketProvider::SendAsync(
-    HCWebsocketHandle websocketHandle,
-    const char* message,
-    XAsyncBlock* async
-) noexcept
-{
-    return m_sharedProvider->SendAsync(websocketHandle, message, async);
-}
-
-HRESULT WinHttp_WebSocketProvider::SendBinaryAsync(
-    HCWebsocketHandle websocketHandle,
-    const uint8_t* payloadBytes,
-    uint32_t payloadSize,
-    XAsyncBlock* asyncBlock
-) noexcept
-{
-    return m_sharedProvider->SendBinaryAsync(websocketHandle, payloadBytes, payloadSize, asyncBlock);
-}
-
-HRESULT WinHttp_WebSocketProvider::Disconnect(
-    HCWebsocketHandle websocketHandle,
-    HCWebSocketCloseStatus closeStatus
-) noexcept
-{
-    return m_sharedProvider->Disconnect(websocketHandle, closeStatus);
-}
-#endif // !HC_NOWEBSOCKETS
 
 NAMESPACE_XBOX_HTTP_CLIENT_END


### PR DESCRIPTION
* Fixed a leak caused by the combination of multiple inheritance and custom deleters.  The issue is explained in some detail in here: https://stackoverflow.com/questions/73574336/how-to-write-a-custom-deleter-that-works-with-multiple-inheritance.  There is a way to change the deleter to properly free the inherited pointer, but it involves RTTI and some additional overhead.  A simpler fix is to avoid multiple inheritance.
* Restored incomplete Suspend/Resume test hooks on GDK