### PR TITLE
Fixes to the GDK props file

### DIFF
--- a/Build/libHttpClient.GDK.props
+++ b/Build/libHttpClient.GDK.props
@@ -80,6 +80,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">

--- a/Build/libHttpClient.GDK.props
+++ b/Build/libHttpClient.GDK.props
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <!-- GDK Build without install props files overrides VCTargetsPath and a few other properties so it needs to be included before the default props -->
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), libHttpClient.gdk.bwoi.props))\libHttpClient.gdk.bwoi.props" />
+  <Import Project="libHttpClient.gdk.bwoi.props" />
 
   <!-- Include the Default MS props -->
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/Build/libHttpClient.GDK.props
+++ b/Build/libHttpClient.GDK.props
@@ -28,6 +28,9 @@
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
   </PropertyGroup>
 
+  <!-- GDK Build without install props files overrides VCTargetsPath and a few other properties so it needs to be included before the default props -->
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), libHttpClient.gdk.bwoi.props))\libHttpClient.gdk.bwoi.props" />
+
   <!-- Include the Default MS props -->
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
 


### PR DESCRIPTION
* Import GDK bwoi props file prior to using VCTargetsPath as that gets changed when 'GDKUseBWOI' is set
* Define _DEBUG macro for debug builds to avoid linker errors when building XSAPI