### PR TITLE
fix crash when large buffers are sent through HCTrace

### DIFF
--- a/Source/HTTP/Curl/CurlEasyRequest.cpp
+++ b/Source/HTTP/Curl/CurlEasyRequest.cpp
@@ -113,7 +113,7 @@ Result<HC_UNIQUE_PTR<CurlEasyRequest>> CurlEasyRequest::Initialize(HCCallHandle 
     RETURN_IF_FAILED(HCHttpCallRequestGetTimeout(hcCall, &timeoutSeconds));
     RETURN_IF_FAILED(easyRequest->SetOpt<long>(CURLOPT_TIMEOUT_MS, timeoutSeconds * 1000));
 
-    RETURN_IF_FAILED(easyRequest->SetOpt<long>(CURLOPT_VERBOSE, 1)); // verbose logging (0 off, 1 on)
+    RETURN_IF_FAILED(easyRequest->SetOpt<long>(CURLOPT_VERBOSE, 0)); // verbose logging (0 off, 1 on)
     RETURN_IF_FAILED(easyRequest->SetOpt<long>(CURLOPT_HEADER, 0)); // do not write headers to the write callback
     RETURN_IF_FAILED(easyRequest->SetOpt<char*>(CURLOPT_ERRORBUFFER, easyRequest->m_errorBuffer));
 
@@ -354,7 +354,7 @@ int CurlEasyRequest::DebugCallback(CURL* /*curlHandle*/, curl_infotype type, cha
         size -= 1;
     }
 
-    HC_TRACE_INFORMATION(HTTPCLIENT, "CURL %10s - %.*s", event, size, data);
+    HC_TRACE_VERBOSE(HTTPCLIENT, "CURL %10s - %.*s", event, size, data);
 
     return CURLE_OK;
 }

--- a/Source/Logger/trace.cpp
+++ b/Source/Logger/trace.cpp
@@ -280,9 +280,9 @@ STDAPI_(void) HCTraceImplMessage_v(
 
     char message[4096] = {};
 
-    auto result = vsprintf_s(message, format, varArgs);
+    auto result = _vsnprintf_s(message, sizeof(message), _TRUNCATE, format, varArgs);
 
-    if (result < 0)
+    if (result < 0 && strlen(message) != sizeof(message) - 1)
     {
         return;
     }

--- a/Source/Logger/trace.cpp
+++ b/Source/Logger/trace.cpp
@@ -41,16 +41,12 @@ int sprintf_s(char* buffer, size_t size, _Printf_format_string_ char const* form
     return result;
 }
 
-#if !HC_PLATFORM_IS_PLAYSTATION
 template<size_t SIZE>
 int vstprintf_s(char(&buffer)[SIZE], _Printf_format_string_ char const* format, va_list varArgs) noexcept
 {
     return vsnprintf(buffer, SIZE, format, varArgs);
 }
-#endif
-#endif
-
-#if HC_PLATFORM_IS_MICROSOFT || HC_PLATFORM_IS_PLAYSTATION
+#else
 template<size_t SIZE>
 int vstprintf_s(char(&buffer)[SIZE], _Printf_format_string_ char const* format, va_list varArgs) noexcept
 {

--- a/Source/Logger/trace.cpp
+++ b/Source/Logger/trace.cpp
@@ -280,9 +280,10 @@ STDAPI_(void) HCTraceImplMessage_v(
 
     char message[4096] = {};
 
-    auto result = _vsnprintf_s(message, sizeof(message), _TRUNCATE, format, varArgs);
+    _set_errno(0);
+    _vsnprintf_s(message, _TRUNCATE, format, varArgs);
 
-    if (result < 0 && strlen(message) != sizeof(message) - 1)
+    if (errno != 0)
     {
         return;
     }

--- a/Source/Logger/trace.cpp
+++ b/Source/Logger/trace.cpp
@@ -43,11 +43,27 @@ int sprintf_s(char* buffer, size_t size, _Printf_format_string_ char const* form
 
 #if !HC_PLATFORM_IS_PLAYSTATION
 template<size_t SIZE>
-int vsprintf_s(char(&buffer)[SIZE], _Printf_format_string_ char const* format, va_list varArgs) noexcept
+int vstprintf_s(char(&buffer)[SIZE], _Printf_format_string_ char const* format, va_list varArgs) noexcept
 {
     return vsnprintf(buffer, SIZE, format, varArgs);
 }
 #endif
+#endif
+
+#if HC_PLATFORM_IS_MICROSOFT || HC_PLATFORM_IS_PLAYSTATION
+template<size_t SIZE>
+int vstprintf_s(char(&buffer)[SIZE], _Printf_format_string_ char const* format, va_list varArgs) noexcept
+{
+    _set_errno(0);
+    _vsnprintf_s(buffer, _TRUNCATE, format, varArgs);
+
+    if (errno != 0)
+    {
+        return -1;
+    }
+
+    return 0;
+}
 #endif
 
 #if HC_PLATFORM_IS_MICROSOFT
@@ -280,10 +296,9 @@ STDAPI_(void) HCTraceImplMessage_v(
 
     char message[4096] = {};
 
-    _set_errno(0);
-    _vsnprintf_s(message, _TRUNCATE, format, varArgs);
+    auto result = vstprintf_s(message, format, varArgs);
 
-    if (errno != 0)
+    if (result < 0)
     {
         return;
     }


### PR DESCRIPTION
HCTraceImplMessage_v used to call vsnprintf, this changes the new safe call to the equivalent of that which allows truncating of large logs. There's an unfortunate difference between the two functions though, where vsnprintf would return the number of characters written even when the message was truncated, _vsnprintf_s for some reason returns -1 in that case. So now there's an additional check to avoid throwing valid logs away when the -1 is from truncating rather than an actual error.