### PR TITLE
Fixing linking issues on MacOS Framework

### DIFF
--- a/Build/libHttpClient.Apple.C/libHttpClient.xcodeproj/project.pbxproj
+++ b/Build/libHttpClient.Apple.C/libHttpClient.xcodeproj/project.pbxproj
@@ -1618,6 +1618,10 @@
 				);
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
+				OTHER_LDFLAGS = (
+					"$(BUILT_PRODUCTS_DIR)/openssl/lib/libssl.a",
+					"$(BUILT_PRODUCTS_DIR)/openssl/lib/libcrypto.a",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.microsoft.libHttpClientFramework-mac";
 				SKIP_INSTALL = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1646,6 +1650,10 @@
 					"@loader_path/Frameworks",
 				);
 				MTL_FAST_MATH = YES;
+				OTHER_LDFLAGS = (
+					"$(BUILT_PRODUCTS_DIR)/openssl/lib/libssl.a",
+					"$(BUILT_PRODUCTS_DIR)/openssl/lib/libcrypto.a",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.microsoft.libHttpClientFramework-mac";
 				SKIP_INSTALL = YES;
 				VERSIONING_SYSTEM = "apple-generic";


### PR DESCRIPTION
Currently libHttpClient Mac OS framework is having linking issues when building for Intel silicon-based Macs, this issue does not happen on Apple Silicon. 

After some investigation it seems to be required to still link against libcrypto and libssl libs which we are already building from source. This is a small change to add 2 extra linker flags that allow to link against these 2 libs.

Below is an example of the errors that were happening before:

`ld: Undefined symbols:
  _SSL_CTX_ctrl, referenced from:
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      ...
  _SSL_CTX_free, referenced from:
      asio::ssl::context::~context() in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _SSL_CTX_get_default_passwd_cb_userdata, referenced from:
      asio::ssl::context::~context() in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _SSL_CTX_get_ex_data, referenced from:
      asio::ssl::context::~context() in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::~context() in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::do_set_verify_callback(asio::ssl::detail::verify_callback_base*, std::__1::error_code&) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::do_set_verify_callback(asio::ssl::detail::verify_callback_base*, std::__1::error_code&) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::verify_callback_function(int, x509_store_ctx_st*) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::verify_callback_function(int, x509_store_ctx_st*) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _SSL_CTX_get_verify_callback, referenced from:
      asio::ssl::context::set_verify_mode(int, std::__1::error_code&) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _SSL_CTX_get_verify_mode, referenced from:
      asio::ssl::context::do_set_verify_callback(asio::ssl::detail::verify_callback_base*, std::__1::error_code&) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _SSL_CTX_new, referenced from:
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      ...
  _SSL_CTX_set_default_passwd_cb_userdata, referenced from:
      asio::ssl::context::~context() in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _SSL_CTX_set_default_verify_paths, referenced from:
      asio::ssl::context::set_default_verify_paths(std::__1::error_code&) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _SSL_CTX_set_ex_data, referenced from:
      asio::ssl::context::~context() in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::do_set_verify_callback(asio::ssl::detail::verify_callback_base*, std::__1::error_code&) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _SSL_CTX_set_options, referenced from:
      asio::ssl::context::set_options(long, std::__1::error_code&) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _SSL_CTX_set_verify, referenced from:
      asio::ssl::context::set_verify_mode(int, std::__1::error_code&) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::do_set_verify_callback(asio::ssl::detail::verify_callback_base*, std::__1::error_code&) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _SSL_accept, referenced from:
      asio::ssl::detail::engine::do_accept(void*, unsigned long) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _SSL_connect, referenced from:
      asio::ssl::detail::engine::do_connect(void*, unsigned long) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _SSL_ctrl, referenced from:
      wspp_websocket_impl::connect(XAsyncBlock*)::'lambda'(std::__1::weak_ptr<void>, asio::ssl::stream<asio::basic_stream_socket<asio::ip::tcp>>&)::operator()(std::__1::weak_ptr<void>, asio::ssl::stream<asio::basic_stream_socket<asio::ip::tcp>>&) const in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::detail::engine::engine(ssl_ctx_st*) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::detail::engine::engine(ssl_ctx_st*) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::detail::engine::engine(ssl_ctx_st*) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      websocketpp::transport::asio::tls_socket::connection::pre_init(std::__1::function<void (std::__1::error_code const&)>) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _SSL_free, referenced from:
      asio::ssl::detail::engine::~engine() in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _SSL_get_SSL_CTX, referenced from:
      asio::ssl::context::verify_callback_function(int, x509_store_ctx_st*) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _SSL_get_error, referenced from:
      asio::ssl::detail::engine::perform(int (asio::ssl::detail::engine::*)(void*, unsigned long), void*, unsigned long, std::__1::error_code&, unsigned long*) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _SSL_get_ex_data, referenced from:
      asio::ssl::detail::engine::~engine() in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::detail::engine::~engine() in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _SSL_get_ex_data_X509_STORE_CTX_idx, referenced from:
      asio::ssl::context::verify_callback_function(int, x509_store_ctx_st*) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _SSL_get_shutdown, referenced from:
      asio::ssl::detail::engine::map_error_code(std::__1::error_code&) const in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::detail::engine::perform(int (asio::ssl::detail::engine::*)(void*, unsigned long), void*, unsigned long, std::__1::error_code&, unsigned long*) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _SSL_new, referenced from:
      asio::ssl::detail::engine::engine(ssl_ctx_st*) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _SSL_read, referenced from:
      asio::ssl::detail::engine::do_read(void*, unsigned long) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _SSL_set_bio, referenced from:
      asio::ssl::detail::engine::engine(ssl_ctx_st*) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _SSL_set_ex_data, referenced from:
      asio::ssl::detail::engine::~engine() in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _SSL_shutdown, referenced from:
      asio::ssl::detail::engine::do_shutdown(void*, unsigned long) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::detail::engine::do_shutdown(void*, unsigned long) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _SSL_write, referenced from:
      asio::ssl::detail::engine::do_write(void*, unsigned long) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
  _TLS_client_method, referenced from:
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      ...
  _TLS_method, referenced from:
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      ...
  _TLS_server_method, referenced from:
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      asio::ssl::context::context(asio::ssl::context_base::method) in libHttpClient.a[x86_64][31](websocketpp_websocket.o)
      ...
clang: error: linker command failed with exit code 1 (use -v to see invocation)
`