### PR TITLE
Allocator fixes, sln build configuration fixes

### DIFF
--- a/Source/Platform/GDK/PlatformComponents_GDK.cpp
+++ b/Source/Platform/GDK/PlatformComponents_GDK.cpp
@@ -21,7 +21,8 @@ HRESULT PlatformInitialize(PlatformComponents& components, HCInitArgs* initArgs)
     auto initWinHttpResult = WinHttpProvider::Initialize();
     RETURN_IF_FAILED(initWinHttpResult.hr);
  
-    components.WebSocketProvider = http_allocate_unique<WinHttp_WebSocketProvider>(initWinHttpResult.ExtractPayload());
+    auto winHttpProvider = initWinHttpResult.ExtractPayload();
+    components.WebSocketProvider = http_allocate_unique<WinHttp_WebSocketProvider>(SharedPtr<WinHttpProvider>{ winHttpProvider.release(), std::move(winHttpProvider.get_deleter()), http_stl_allocator<WinHttpProvider>{} });
 #endif
 
     return S_OK;

--- a/Source/Platform/Win32/PlatformComponents_Win32.cpp
+++ b/Source/Platform/Win32/PlatformComponents_Win32.cpp
@@ -13,7 +13,8 @@ HRESULT PlatformInitialize(PlatformComponents& components, HCInitArgs* initArgs)
     auto initWinHttpResult = WinHttpProvider::Initialize();
     RETURN_IF_FAILED(initWinHttpResult.hr);
 
-    std::shared_ptr<WinHttpProvider> sharedProvider{ initWinHttpResult.ExtractPayload() };
+    auto winHttpProvider = initWinHttpResult.ExtractPayload();
+    std::shared_ptr<WinHttpProvider> sharedProvider{ winHttpProvider.release(), std::move(winHttpProvider.get_deleter()), http_stl_allocator<WinHttpProvider>{} };
 
     components.HttpProvider = http_allocate_unique<WinHttp_HttpProvider>(sharedProvider);
 #if !HC_NOWEBSOCKETS

--- a/libHttpClient.vs2022.sln
+++ b/libHttpClient.vs2022.sln
@@ -179,7 +179,6 @@ Global
 		{2DFBBF3A-6D4B-4FF8-BD01-C9527A1FE0AC}.Debug|ARM64.Build.0 = Debug|ARM64
 		{2DFBBF3A-6D4B-4FF8-BD01-C9527A1FE0AC}.Debug|ARM64.Deploy.0 = Debug|ARM64
 		{2DFBBF3A-6D4B-4FF8-BD01-C9527A1FE0AC}.Debug|Gaming.Desktop.x64.ActiveCfg = Debug|x64
-		{2DFBBF3A-6D4B-4FF8-BD01-C9527A1FE0AC}.Debug|Gaming.Desktop.x64.Build.0 = Debug|x64
 		{2DFBBF3A-6D4B-4FF8-BD01-C9527A1FE0AC}.Debug|Gaming.Desktop.x64.Deploy.0 = Debug|x64
 		{2DFBBF3A-6D4B-4FF8-BD01-C9527A1FE0AC}.Debug|x64.ActiveCfg = Debug|x64
 		{2DFBBF3A-6D4B-4FF8-BD01-C9527A1FE0AC}.Debug|x64.Build.0 = Debug|x64
@@ -324,7 +323,6 @@ Global
 		{E35BA8A1-AE7B-4FB5-8200-469B98BC1CA8}.Debug|ARM64.ActiveCfg = Debug|ARM64
 		{E35BA8A1-AE7B-4FB5-8200-469B98BC1CA8}.Debug|ARM64.Build.0 = Debug|ARM64
 		{E35BA8A1-AE7B-4FB5-8200-469B98BC1CA8}.Debug|Gaming.Desktop.x64.ActiveCfg = Debug|x64
-		{E35BA8A1-AE7B-4FB5-8200-469B98BC1CA8}.Debug|Gaming.Desktop.x64.Build.0 = Debug|x64
 		{E35BA8A1-AE7B-4FB5-8200-469B98BC1CA8}.Debug|x64.ActiveCfg = Debug|x64
 		{E35BA8A1-AE7B-4FB5-8200-469B98BC1CA8}.Debug|x64.Build.0 = Debug|x64
 		{E35BA8A1-AE7B-4FB5-8200-469B98BC1CA8}.Debug|x86.ActiveCfg = Debug|Win32
@@ -334,7 +332,6 @@ Global
 		{E35BA8A1-AE7B-4FB5-8200-469B98BC1CA8}.Release|ARM64.ActiveCfg = Release|ARM64
 		{E35BA8A1-AE7B-4FB5-8200-469B98BC1CA8}.Release|ARM64.Build.0 = Release|ARM64
 		{E35BA8A1-AE7B-4FB5-8200-469B98BC1CA8}.Release|Gaming.Desktop.x64.ActiveCfg = Release|x64
-		{E35BA8A1-AE7B-4FB5-8200-469B98BC1CA8}.Release|Gaming.Desktop.x64.Build.0 = Release|x64
 		{E35BA8A1-AE7B-4FB5-8200-469B98BC1CA8}.Release|x64.ActiveCfg = Release|x64
 		{E35BA8A1-AE7B-4FB5-8200-469B98BC1CA8}.Release|x64.Build.0 = Release|x64
 		{E35BA8A1-AE7B-4FB5-8200-469B98BC1CA8}.Release|x86.ActiveCfg = Release|Win32
@@ -346,9 +343,7 @@ Global
 		{A5A6E02A-21BA-4D55-9FB9-7B24DEDD3743}.Debug|Gaming.Desktop.x64.ActiveCfg = Debug|Gaming.Desktop.x64
 		{A5A6E02A-21BA-4D55-9FB9-7B24DEDD3743}.Debug|Gaming.Desktop.x64.Build.0 = Debug|Gaming.Desktop.x64
 		{A5A6E02A-21BA-4D55-9FB9-7B24DEDD3743}.Debug|x64.ActiveCfg = Debug|Gaming.Desktop.x64
-		{A5A6E02A-21BA-4D55-9FB9-7B24DEDD3743}.Debug|x64.Build.0 = Debug|Gaming.Desktop.x64
 		{A5A6E02A-21BA-4D55-9FB9-7B24DEDD3743}.Debug|x86.ActiveCfg = Debug|Gaming.Desktop.x64
-		{A5A6E02A-21BA-4D55-9FB9-7B24DEDD3743}.Debug|x86.Build.0 = Debug|Gaming.Desktop.x64
 		{A5A6E02A-21BA-4D55-9FB9-7B24DEDD3743}.Release|ARM.ActiveCfg = Release|Gaming.Desktop.x64
 		{A5A6E02A-21BA-4D55-9FB9-7B24DEDD3743}.Release|ARM.Build.0 = Release|Gaming.Desktop.x64
 		{A5A6E02A-21BA-4D55-9FB9-7B24DEDD3743}.Release|ARM64.ActiveCfg = Release|Gaming.Desktop.x64
@@ -356,9 +351,7 @@ Global
 		{A5A6E02A-21BA-4D55-9FB9-7B24DEDD3743}.Release|Gaming.Desktop.x64.ActiveCfg = Release|Gaming.Desktop.x64
 		{A5A6E02A-21BA-4D55-9FB9-7B24DEDD3743}.Release|Gaming.Desktop.x64.Build.0 = Release|Gaming.Desktop.x64
 		{A5A6E02A-21BA-4D55-9FB9-7B24DEDD3743}.Release|x64.ActiveCfg = Release|Gaming.Desktop.x64
-		{A5A6E02A-21BA-4D55-9FB9-7B24DEDD3743}.Release|x64.Build.0 = Release|Gaming.Desktop.x64
 		{A5A6E02A-21BA-4D55-9FB9-7B24DEDD3743}.Release|x86.ActiveCfg = Release|Gaming.Desktop.x64
-		{A5A6E02A-21BA-4D55-9FB9-7B24DEDD3743}.Release|x86.Build.0 = Release|Gaming.Desktop.x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
* Fix some stray allocations that weren't properly using the custom allocators
* Fix .sln build configuration so that GDK projects aren't set to build when Platform=x86/x64 and vice versa