### PR TITLE
Switch to shared library for linux

### DIFF
--- a/Build/libHttpClient.CMake/libHttpClientExports.txt
+++ b/Build/libHttpClient.CMake/libHttpClientExports.txt
@@ -1,0 +1,8 @@
+{
+    global:
+        HC*;
+        XAsync*;
+        XTaskQueue*;
+    local:
+        *;
+};

--- a/Build/libHttpClient.Linux/CMakeLists.txt
+++ b/Build/libHttpClient.Linux/CMakeLists.txt
@@ -2,27 +2,45 @@ cmake_minimum_required(VERSION 3.6)
 
 get_filename_component(PATH_TO_ROOT "../.." ABSOLUTE)
 
-project("libHttpClient.Linux.C")
+project("libHttpClient.Linux")
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)
-set(CMAKE_CXX_FLAGS "-fvisibility=hidden")
-set(CMAKE_C_FLAGS "-fvisibility=hidden")
-set(CMAKE_STATIC_LIBRARY_PREFIX "")
+set(CMAKE_SHARED_LIBRARY_PREFIX "")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS} "-Wl,--version-script=${PATH_TO_ROOT}/Build/libHttpClient.CMake/libHttpClientExports.txt")
 
 ###########################################
 ### Set up paths for source and include ###
 ###########################################
 
 # Set final static libraries output folder
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG ${PATH_TO_ROOT}/Binaries/Debug/x64/libHttpClient.Linux.C)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE ${PATH_TO_ROOT}/Binaries/Release/x64/libHttpClient.Linux.C)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${PATH_TO_ROOT}/Out/x64/Debug/libHttpClient.Linux)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${PATH_TO_ROOT}/Out/x64/Release/libHttpClient.Linux)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG ${PATH_TO_ROOT}/Out/x64/Debug/libHttpClient.Linux)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE ${PATH_TO_ROOT}/Out/x64/Release/libHttpClient.Linux)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG ${PATH_TO_ROOT}/Out/x64/Debug/libHttpClient.Linux)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE ${PATH_TO_ROOT}/Out/x64/Release/libHttpClient.Linux)
 
 # BINARY_DIR is a temp folder used by cmake itself.
 # Binary folder can be remove freely.
 # See more details: https://cmake.org/cmake/help/v3.4/command/add_subdirectory.html
-set(BINARY_DIR ${PATH_TO_ROOT}/Int/CMake/libHttpClient.Linux.C)
+set(BINARY_DIR ${PATH_TO_ROOT}/Int/CMake/libHttpClient.Linux)
+
+set(LIBCRYPTO_BINARY_PATH
+    ${PATH_TO_ROOT}/Out/x64/${CMAKE_BUILD_TYPE}/libcrypto.Linux/libcrypto.a
+)
+message(STATUS "LIBCRYPTO_BINARY_PATH: ${LIBCRYPTO_BINARY_PATH}")
+
+set(LIBSSL_BINARY_PATH
+    ${PATH_TO_ROOT}/Out/x64/${CMAKE_BUILD_TYPE}/libssl.Linux/libssl.a
+)
+message(STATUS "LIBSSL_BINARY_PATH: ${LIBSSL_BINARY_PATH}")
+
+set(LIBCURL_BINARY_PATH
+    ${PATH_TO_ROOT}/Out/x64/${CMAKE_BUILD_TYPE}/libcurl.Linux/libcurl.a
+)
+message(STATUS "LIBCURL_BINARY_PATH: ${LIBCURL_BINARY_PATH}")
 
 include("../libHttpClient.CMake/GetCommonHCSourceFiles.cmake")
 get_common_hc_source_files(
@@ -84,14 +102,20 @@ set(LINUX_INCLUDE_DIRS
     )
 
 #########################
-### Set up static lib ###
+### Set up shared lib ###
 #########################
 
 add_library(
     "${PROJECT_NAME}"
-    STATIC
+    SHARED
     "${COMMON_SOURCE_FILES}"
     "${LINUX_SOURCE_FILES}"
+)
+
+target_link_libraries("${PROJECT_NAME}" 
+    PRIVATE ${LIBCURL_BINARY_PATH}
+    PRIVATE ${LIBSSL_BINARY_PATH}
+    PRIVATE ${LIBCRYPTO_BINARY_PATH} 
 )
 
 target_include_directories(
@@ -111,3 +135,5 @@ target_set_flags(
     "${FLAGS_DEBUG}"
     "${FLAGS_RELEASE}"
 )
+
+export(TARGETS ${PROJECT_NAME} FILE ${PROJECT_NAME}Config.cmake)

--- a/Build/libHttpClient.Linux/README.md
+++ b/Build/libHttpClient.Linux/README.md
@@ -43,18 +43,18 @@ running the following command and re-running the script should fix it.
 sed -i -e 's/\r$//' libHttpClient_Linux.bash
 ```
 
-## curl.bash
+## curl_Linux.bash
 
-libHttpClient for Linux uses cURL 7.81.0. When `curl.bash` is run, it auto generates cURL and places it in `Out/x64/{Configuration}/libcurl.Linux`.
+libHttpClient for Linux uses cURL 7.81.0. When `curl_Linux.bash` is run, it auto generates cURL and places it in `Out/x64/{Configuration}/libcurl.Linux`.
 
 ```
-./curl.bash
+./curl_Linux.bash
 ```
 
 Running the build script with no arguments will generate a Release binary of `libcurl.a`.
 
 ```
-./curl.bash <-c|--config> <Debug|Release>
+./curl_Linux.bash <-c|--config> <Debug|Release>
 ```
 
 Running the build script with the `-c|--config` argument will generate Debug or Release binaries of `libcurl.a`.
@@ -73,17 +73,17 @@ If the bash script fails to run and produces the error:
 ```
 running the following command and re-running the script should fix it.
 ```
-sed -i -e 's/\r$//' curl.bash
+sed -i -e 's/\r$//' curl_Linux.bash
 ```
 
-## openssl.bash
+## openssl_Linux.bash
 
-libHttpClient for Linux uses OpenSSL 1.1.1k. When `openssl.bash` is run, it generates `libssl.a` and `libcrypto.a` and places it in `Out/x64/{Configuration}/{Library}.Linux`.
+libHttpClient for Linux uses OpenSSL 1.1.1k. When `openssl_Linux.bash` is run, it generates `libssl.a` and `libcrypto.a` and places it in `Out/x64/{Configuration}/{Library}.Linux`.
 
 Running the build script with no arguments will generate a Release binary of `libssl.a` and `libcrypto.a`.
 
 ```
-./openssl.bash <-c|--config> <Debug|Release>
+./openssl_Linux.bash <-c|--config> <Debug|Release>
 ```
 
 Running the build script with the `-c|--config` argument will generate Debug or Release binaries of `libssl.a` and `libcrypto.a`.
@@ -100,5 +100,5 @@ If the bash script fails to run and produces the error:
 ```
 running the following command and re-running the script should fix it.
 ```
-sed -i -e 's/\r$//' openssl.bash
+sed -i -e 's/\r$//' openssl_Linux.bash
 ```

--- a/Build/libHttpClient.Linux/README.md
+++ b/Build/libHttpClient.Linux/README.md
@@ -1,6 +1,6 @@
 # Building libHttpClient for Linux
 
-These scripts will be used to build the static library dependencies for libHttpClient and link them against the static library build for libHttpClient.
+These scripts will be used to build the static library dependencies for libHttpClient and link them against the shared library build for libHttpClient.
 
 ## Dependencies 
 
@@ -8,19 +8,19 @@ You will need a Linux machine, a Linux virtual machine, or Windows Subsystem for
 
 ## libHttpClient_Linux.bash
 
-Running `libHttpClient_Linux` can generate a variety of build configurations and binaries for libHttpClient and its dependencies. These binaries will be placed at `Binaries/{Configuration}/x64/{Library}`. Example usage is below.
+Running `libHttpClient_Linux` can generate a variety of build configurations and binaries for libHttpClient and its dependencies. These binaries will be placed at `Out/x64/{Configuration}/{Library}`. Example usage is below.
 
 ```
 ./libHttpClient_Linux.bash
 ```
 
-Running the build script with no arguments will generate a Release binary of `libcurl.a`,`libssl.a`, `libcrypto.a`, and `libHttpClient.a`.
+Running the build script with no arguments will generate a Release binary of `libcurl.a`,`libssl.a`, `libcrypto.a`, and `libHttpClient.Linux.so`.
 
 ```
 ./libHttpClient_Linux.bash <-c|--config> <Debug|Release>
 ```
 
-Running the build script with the `-c|--config` argument will generate  Debug or Release binaries of `libssl.a`, `libcrypto.a`, `libcurl.a` and `libHttpClient.a`.
+Running the build script with the `-c|--config` argument will generate  Debug or Release binaries of `libssl.a`, `libcrypto.a`, `libcurl.a` and `libHttpClient.Linux.so`.
 
 ```
 ./libHttpClient_Linux.bash <-nc|--nocurl>
@@ -45,7 +45,7 @@ sed -i -e 's/\r$//' libHttpClient_Linux.bash
 
 ## curl.bash
 
-libHttpClient for Linux uses cURL 7.81.0. When `curl.bash` is run, it auto generates cURL and places it in `Binaries/{Configuration}/x64/libcurl.Linux`.
+libHttpClient for Linux uses cURL 7.81.0. When `curl.bash` is run, it auto generates cURL and places it in `Out/x64/{Configuration}/libcurl.Linux`.
 
 ```
 ./curl.bash
@@ -59,7 +59,7 @@ Running the build script with no arguments will generate a Release binary of `li
 
 Running the build script with the `-c|--config` argument will generate Debug or Release binaries of `libcurl.a`.
 
-If you choose to use your own version of cURL, you can place your own copy of `libcurl.a` in `Binaries/{Configuration}/x64/libcurl.Linux`.
+If you choose to use your own version of cURL, you can place your own copy of `libcurl.a` in `Out/x64/{Configuration}/libcurl.Linux`.
 
 **libHttpClient for Linux has only been tested against version 7.81.0.**
 
@@ -78,7 +78,7 @@ sed -i -e 's/\r$//' curl.bash
 
 ## openssl.bash
 
-libHttpClient for Linux uses OpenSSL 1.1.1k. When `openssl.bash` is run, it generates `libssl.a` and `libcrypto.a` and places it in `Binaries/{Configuration}/x64/{Library}.Linux`.
+libHttpClient for Linux uses OpenSSL 1.1.1k. When `openssl.bash` is run, it generates `libssl.a` and `libcrypto.a` and places it in `Out/x64/{Configuration}/{Library}.Linux`.
 
 Running the build script with no arguments will generate a Release binary of `libssl.a` and `libcrypto.a`.
 
@@ -88,7 +88,7 @@ Running the build script with no arguments will generate a Release binary of `li
 
 Running the build script with the `-c|--config` argument will generate Debug or Release binaries of `libssl.a` and `libcrypto.a`.
 
-If you choose to use your own version of OpenSSL, you can place your own copies in `Binaries/{Configuration}/x64/{Library}.Linux`.
+If you choose to use your own version of OpenSSL, you can place your own copies in `Out/x64/{Configuration}/{Library}.Linux`.
 
 **libHttpClient for Linux has only been tested against version 1.1.1k**
 

--- a/Build/libHttpClient.Linux/curl_Linux.bash
+++ b/Build/libHttpClient.Linux/curl_Linux.bash
@@ -35,8 +35,8 @@ fi
 make
 
 # copies binaries to final directory
-mkdir -p "$SCRIPT_DIR"/../../Binaries/"$CONFIGURATION"/x64/libcurl.Linux
-cp -R "$PWD"/lib/.libs/* "$SCRIPT_DIR"/../../Binaries/"$CONFIGURATION"/x64/libcurl.Linux
+mkdir -p "$SCRIPT_DIR"/../../Out/x64/"$CONFIGURATION"/libcurl.Linux
+cp -R "$PWD"/lib/.libs/* "$SCRIPT_DIR"/../../Out/x64/"$CONFIGURATION"/libcurl.Linux
 
 make clean
 popd

--- a/Build/libHttpClient.Linux/libHttpClient_Linux.bash
+++ b/Build/libHttpClient.Linux/libHttpClient_Linux.bash
@@ -58,7 +58,7 @@ log "CONFIGURATION  = ${CONFIGURATION}"
 log "BUILD SSL      = ${BUILD_SSL}"
 log "BUILD CURL     = ${BUILD_CURL}"
 log "CMakeLists.txt = ${SCRIPT_DIR}"
-log "CMake output   = ${SCRIPT_DIR}/../../Int/CMake/libHttpClient.Linux.C"
+log "CMake output   = ${SCRIPT_DIR}/../../Int/CMake/libHttpClient.Linux"
 
 # make libcrypto and libssl
 if [ "$BUILD_SSL" = true ]; then
@@ -74,5 +74,5 @@ if [ "$BUILD_CURL" = true ]; then
 fi
 
 # make libHttpClient
-sudo cmake -S "$SCRIPT_DIR" -B "$SCRIPT_DIR"/../../Int/CMake/libHttpClient.Linux.C -D CMAKE_BUILD_TYPE=$CONFIGURATION
-sudo make -C "$SCRIPT_DIR"/../../Int/CMake/libHttpClient.Linux.C
+sudo cmake -S "$SCRIPT_DIR" -B "$SCRIPT_DIR"/../../Int/CMake/libHttpClient.Linux -D CMAKE_BUILD_TYPE=$CONFIGURATION
+sudo make -C "$SCRIPT_DIR"/../../Int/CMake/libHttpClient.Linux

--- a/Build/libHttpClient.Linux/openssl_Linux.bash
+++ b/Build/libHttpClient.Linux/openssl_Linux.bash
@@ -57,11 +57,11 @@ fi
 make CFLAGS="-fvisibility=hidden" CXXFLAGS="-fvisibility=hidden"
 sudo make install
 # copies binaries to final directory
-mkdir -p "$SCRIPT_DIR"/../../Binaries/"$CONFIGURATION"/x64/libcrypto.Linux
-cp -R "$PWD"/libcrypto.a "$SCRIPT_DIR"/../../Binaries/"$CONFIGURATION"/x64/libcrypto.Linux
+mkdir -p "$SCRIPT_DIR"/../../Out/x64/"$CONFIGURATION"/libcrypto.Linux
+cp -R "$PWD"/libcrypto.a "$SCRIPT_DIR"/../../Out/x64/"$CONFIGURATION"/libcrypto.Linux
 
-mkdir -p "$SCRIPT_DIR"/../../Binaries/"$CONFIGURATION"/x64/libssl.Linux
-cp -R "$PWD"/libssl.a "$SCRIPT_DIR"/../../Binaries/"$CONFIGURATION"/x64/libssl.Linux
+mkdir -p "$SCRIPT_DIR"/../../Out/x64/"$CONFIGURATION"/libssl.Linux
+cp -R "$PWD"/libssl.a "$SCRIPT_DIR"/../../Out/x64/"$CONFIGURATION"/libssl.Linux
 
 make clean
 popd


### PR DESCRIPTION
* Change LHC to be a shared library on Linux, exposing only methods specified in libHttpClientExports.txt
* Updates lib name and output paths to be consistent with other platforms