### PR TITLE
Fix libcurl config on linux

### DIFF
--- a/Build/libHttpClient.Linux/curl_Linux.bash
+++ b/Build/libHttpClient.Linux/curl_Linux.bash
@@ -26,10 +26,10 @@ autoreconf -fi "$SCRIPT_DIR"/../../External/curl
 
 if [ "$CONFIGURATION" = "Debug" ]; then
     # make libcrypto and libssl
-    ./configure --disable-shared --disable-dependency-tracking -with-openssl=/usr/local/ssl --enable-symbol-hiding --enable-debug
+    ./configure --disable-shared --without-zlib --disable-dependency-tracking -with-openssl=/usr/local/ssl --enable-symbol-hiding --enable-debug
 else
     # make libcrypto and libssl
-    ./configure --disable-shared --disable-dependency-tracking -with-openssl=/usr/local/ssl --enable-symbol-hiding --disable-debug
+    ./configure --disable-shared --without-zlib --disable-dependency-tracking -with-openssl=/usr/local/ssl --enable-symbol-hiding --disable-debug
 fi
 
 make


### PR DESCRIPTION
Build libcurl with --without-zlib flag on linux as its not needed and causes linking errors when linking LHC shared library into title.