### PR TITLE
Adding BIND_NOW flag to linux binary as recommended by BinSkim

### DIFF
--- a/Build/libHttpClient.Linux/CMakeLists.txt
+++ b/Build/libHttpClient.Linux/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)
 set(CMAKE_SHARED_LIBRARY_PREFIX "")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-set(CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS} "-Wl,--version-script=${PATH_TO_ROOT}/Build/libHttpClient.CMake/libHttpClientExports.txt")
+set(CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS} "-Wl,-z,now,--version-script=${PATH_TO_ROOT}/Build/libHttpClient.CMake/libHttpClientExports.txt")
 
 ###########################################
 ### Set up paths for source and include ###


### PR DESCRIPTION
BinSkim warns on Linux .so with:
https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-ba3011enablebindnow

More detail found:
https://www.redhat.com/en/blog/hardening-elf-binaries-using-relocation-read-only-relro