### PR TITLE
Fix hc_settings.props build customizations

### DIFF
--- a/Build/libHttpClient.141.GDK.C/libHttpClient.141.GDK.C.vcxproj
+++ b/Build/libHttpClient.141.GDK.C/libHttpClient.141.GDK.C.vcxproj
@@ -6,7 +6,6 @@
     <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(libHttpClient.GDK.props))" />
-  <Import Project="$(HCRoot)\libHttpClient.props" />
   <Import Project="$(HCBuildRoot)\libHttpClient.Common\libHttpClient.Common.vcxitems" Label="Shared" />
   <Import Project="$(HCBuildRoot)\libHttpClient.GDK.Shared\libHttpClient.GDK.Shared.vcxitems" Label="Shared" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj
+++ b/Build/libHttpClient.141.Win32.C/libHttpClient.141.Win32.C.vcxproj
@@ -6,7 +6,6 @@
     <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(libHttpClient.Win32.props))" />
-  <Import Project="$(HCRoot)\libHttpClient.props" />
   <Import Project="$(HCBuildRoot)\libHttpClient.Common\libHttpClient.Common.vcxitems" Label="Shared" />
   <Import Project="$(HCBuildRoot)\libHttpClient.XAsync\libHttpClient.XAsync.vcxitems" Label="Shared" />
   <Import Project="$(HCBuildRoot)\libHttpClient.Win32.Shared\libHttpClient.Win32.Shared.vcxitems" Label="Shared" />

--- a/Build/libHttpClient.142.UWP.C/libHttpClient.142.UWP.C.vcxproj
+++ b/Build/libHttpClient.142.UWP.C/libHttpClient.142.UWP.C.vcxproj
@@ -6,7 +6,6 @@
     <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(libHttpClient.UWP.props))" />
-  <Import Project="$(HCRoot)\libHttpClient.props" />
   <Import Project="$(HCBuildRoot)\libHttpClient.Common\libHttpClient.Common.vcxitems" Label="Shared" />
   <Import Project="$(HCBuildRoot)\libHttpClient.XAsync\libHttpClient.XAsync.vcxitems" Label="Shared" />
   <Import Project="$(HCBuildRoot)\libHttpClient.UWP\libHttpClient.UWP.vcxitems" Label="Shared" />

--- a/Build/libHttpClient.143.UWP.C/libHttpClient.143.UWP.C.vcxproj
+++ b/Build/libHttpClient.143.UWP.C/libHttpClient.143.UWP.C.vcxproj
@@ -6,7 +6,6 @@
     <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(libHttpClient.UWP.props))" />
-  <Import Project="$(HCRoot)\libHttpClient.props" />
   <Import Project="$(HCBuildRoot)\libHttpClient.Common\libHttpClient.Common.vcxitems" Label="Shared" />
   <Import Project="$(HCBuildRoot)\libHttpClient.XAsync\libHttpClient.XAsync.vcxitems" Label="Shared" />
   <Import Project="$(HCBuildRoot)\libHttpClient.UWP\libHttpClient.UWP.vcxitems" Label="Shared" />

--- a/Build/libHttpClient.Common/libHttpClient.Common.vcxitems
+++ b/Build/libHttpClient.Common/libHttpClient.Common.vcxitems
@@ -6,6 +6,10 @@
     <ItemsProjectGuid>{673e9758-fafe-4f91-8fc1-addda12c5de5}</ItemsProjectGuid>
   </PropertyGroup>
   <Import Condition="'$(HCPathsImported)' != 'true'" Project="$([MSBuild]::GetPathOfFileAbove(libHttpClient.paths.props)" />
+  <PropertyGroup>
+    <HCSettingsFile>$([MSBuild]::GetPathOfFileAbove(hc_settings.props))</HCSettingsFile>
+  </PropertyGroup>
+  <Import Project="$(HCSettingsFile)" Condition="Exists($(HCSettingsFile))" />
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(HCIncludeDir);$(HCSourceDir);$(HCSourceDir)\Common</AdditionalIncludeDirectories>
@@ -17,6 +21,11 @@
   <ItemDefinitionGroup Condition="'$(HCNoZlib)'=='true'">
     <ClCompile>
       <PreprocessorDefinitions>%(PreprocessorDefinitions);HC_NOZLIB</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(HCNoWebSockets)'=='true'">
+    <ClCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);HC_NOWEBSOCKETS</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
When projects were refactored to support building shared library versions of LHC, the import of libHttpClient.props was removed from many of the libHttpClient projects as it incorrectly pulls in project references to the static lib projects and causes linker errors.  That props file historically served a weird dual purpose: its used by clients of LHC to add references to libHttpClient projects, but it was also imported by libHttpClient projects, defining several customizable properties used to build the libHttpClient lib (see [readme](https://github.com/microsoft/libHttpClient?tab=readme-ov-file#build-customization) for details).  While most of libHttpClient.props is no longer needed by libHttpClient lib projects, we still should be pulling in the client's hc_settings.props customizations.

This PR does two things: 1) update libHttpClient.Common.vcxitems to pull in hc_settings.props and add any build customizations it specifies, and 2) remove libHttpClient.props from the remaining libHttpClient lib projects since several were missed previously.