### PR TITLE
Revert Forward Declaration Removal

### DIFF
--- a/Include/httpClient/httpClient.h
+++ b/Include/httpClient/httpClient.h
@@ -116,6 +116,8 @@ STDAPI HCMemGetFunctions(
 // Global APIs
 //
 
+struct HCInitArgs;
+
 /// <summary>
 /// Initializes the library instance.
 /// </summary>


### PR DESCRIPTION
#809 removed the `struct HCInitArgs;` forward declaration in `httpClient/httpClient.h`. This broke `HC_PLATFORM_HEADER_OVERRIDE` flows and created a circular dependency for custom headers. Reverting this change.