### PR TITLE
Fix subtle race in task queue

### DIFF
--- a/Build/libHttpClient.UnitTest.TAEF/libHttpClient.UnitTest.TAEF.vcxproj
+++ b/Build/libHttpClient.UnitTest.TAEF/libHttpClient.UnitTest.TAEF.vcxproj
@@ -19,9 +19,9 @@
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>USING_TAEF;DASHBOARD_PRINCIPLE_GROUP;_NO_ASYNCRTIMP;INLINE_TEST_METHOD_MARKUP;WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP;UNIT_TEST_SERVICES;HC_NOZLIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAsWinRT>true</CompileAsWinRT>
-      <AdditionalUsingDirectories>$(WindowsSdkDir_10)UnionMetadata;$(VCToolsInstallDir)lib\x86\store\references;%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <AdditionalUsingDirectories>$(WindowsSDK_UnionMetadataPath);$(VCToolsInstallDir)lib\x86\store\references;%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <AdditionalOptions>/GS %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalIncludeDirectories>c:\Program Files (x86)\Windows Kits\10\Testing\Development\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(HCSourceDir)\Task;c:\Program Files (x86)\Windows Kits\10\Testing\Development\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RemoveUnreferencedCodeData Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</RemoveUnreferencedCodeData>
     </ClCompile>
     <Link>

--- a/Build/libHttpClient.UnitTest.TAEF/libHttpClient.UnitTest.TAEF.vcxproj
+++ b/Build/libHttpClient.UnitTest.TAEF/libHttpClient.UnitTest.TAEF.vcxproj
@@ -21,7 +21,7 @@
       <CompileAsWinRT>true</CompileAsWinRT>
       <AdditionalUsingDirectories>$(WindowsSDK_UnionMetadataPath);$(VCToolsInstallDir)lib\x86\store\references;%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <AdditionalOptions>/GS %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalIncludeDirectories>$(HCSourceDir)\Task;c:\Program Files (x86)\Windows Kits\10\Testing\Development\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>c:\Program Files (x86)\Windows Kits\10\Testing\Development\inc;$(HCSourceDir)\Task;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RemoveUnreferencedCodeData Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</RemoveUnreferencedCodeData>
     </ClCompile>
     <Link>

--- a/Build/libHttpClient.UnitTest.TE/libHttpClient.UnitTest.TE.vcxproj
+++ b/Build/libHttpClient.UnitTest.TE/libHttpClient.UnitTest.TE.vcxproj
@@ -19,8 +19,8 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>DASHBOARD_PRINCIPLE_GROUP;_NO_ASYNCRTIMP;UNITTEST_TE;INLINE_TEST_METHOD_MARKUP;WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP;UNIT_TEST_SERVICES;HC_NOZLIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalUsingDirectories>C:\Program Files (x86)\Windows Kits\10\UnionMetadata;C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\lib\store\references;C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\VC\vcpackages;%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalUsingDirectories>$(WindowsSDK_UnionMetadataPath);$(VCIDEInstallDir)\vcpackages;%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(HCSourceDir)\Task;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <CompileAsWinRT>true</CompileAsWinRT>
     </ClCompile>
     <Link>

--- a/Include/XTaskQueue.h
+++ b/Include/XTaskQueue.h
@@ -7,7 +7,6 @@
 
 #pragma once
 #include <stdint.h>
-#include <httpClient/pal.h>
 
 extern "C"
 {

--- a/Source/Common/pch_common.h
+++ b/Source/Common/pch_common.h
@@ -130,6 +130,15 @@ HC_DECLARE_TRACE_AREA(WEBSOCKET);
 #define ASYNC_LIB_TRACE(result, message)            \
     HC_TRACE_ERROR_HR(HTTPCLIENT, result, message); \
 
+// Handle tracking for TaskQueue
+#define SYSTEM_HANDLE_DEFINE_HELPERS(a, b)
+#define SystemHandleAssert(h)
+#define SystemHandleMarkCreated(h)
+#define SystemHandleMarkDestroyed(h)
+
+// We always use unique handles
+#define USE_UNIQUE_HANDLES() (true)
+
 #define CATCH_RETURN() CATCH_RETURN_IMPL(__FILE__, __LINE__)
 
 #define CATCH_RETURN_IMPL(file, line) \

--- a/Source/Task/LocklessQueue.h
+++ b/Source/Task/LocklessQueue.h
@@ -674,7 +674,7 @@ private:
             // Connect all the nodes in the new block. Element zero is
             // the "tail" of this block.
             
-            Address prev{};
+            Address prev = { 0 };
             for (uint32_t index = 0; index < m_blockSize; index++)
             {
                 block->nodes[index].next = prev;
@@ -696,8 +696,8 @@ private:
                 // Initial contruction.  We need to store the block list
                 // and then initialize the free list.
 
-                Address end{};
-                Address a{};
+                Address end = { 0 };
+                Address a = { 0 };
                 a.block = static_cast<uint16_t>(block->id);
 
                 block->nodes[0].next = end;
@@ -732,8 +732,8 @@ private:
 
             // Now add the tail and the head to the free list.
 
-            Address rangeBegin{};
-            Address rangeEnd{};
+            Address rangeBegin { 0 };
+            Address rangeEnd { 0 };
 
             rangeBegin.block = rangeEnd.block = static_cast<uint16_t>(block->id);
             rangeBegin.index = m_blockSize - 1;

--- a/Source/Task/TaskQueueP.h
+++ b/Source/Task/TaskQueueP.h
@@ -72,6 +72,8 @@ struct ITaskQueuePort: IApi
 
     virtual bool __stdcall IsEmpty() = 0;
 
+    virtual void __stdcall WaitForUnwind() = 0;
+
     virtual HRESULT __stdcall SuspendTermination(
         _In_ ITaskQueuePortContext* portContext) = 0;
 

--- a/Source/Task/XTaskQueuePriv.h
+++ b/Source/Task/XTaskQueuePriv.h
@@ -64,3 +64,44 @@ STDAPI_(void) XTaskQueueGlobalSuspend();
 /// 2. The dispatcher will start returing items again.
 /// </summary>
 STDAPI_(void) XTaskQueueGlobalResume();
+
+/// <summary>
+/// Options when duplicating a task queue handle.
+/// </summary>
+enum class XTaskQueueDuplicateOptions
+{
+    /// <summary>
+    /// Default behavior.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// The duplicated queue is a reference to the actual
+    /// queue object, not a duplicated queue handle. References
+    /// work just like fully duplicated handles but they are not
+    /// tracked by the handle tracking infrastructure and do not
+    /// cause an allocation for the handle.
+    /// </summary>
+    Reference
+};
+
+/// <summary>
+/// Increments the refcount on the queue and allows supplying
+/// options as to how the duplicate is performed.
+/// </summary>
+STDAPI XTaskQueueDuplicateHandleWithOptions(
+    _In_ XTaskQueueHandle queueHandle,
+    _In_ XTaskQueueDuplicateOptions options,
+    _Out_ XTaskQueueHandle *duplicatedHandle
+    ) noexcept;
+
+/// <summary>
+/// Returns a handle to the process task queue, or nullptr if there is no
+/// process task queue.  By default, there is a default process task queue
+/// that uses the thread pool for both work and completion ports. This is an
+/// internal variant that takes duplicate options.
+/// </summary>
+STDAPI_(bool) XTaskQueueGetCurrentProcessTaskQueueWithOptions(
+    _In_ XTaskQueueDuplicateOptions options,
+    _Out_ XTaskQueueHandle *queue
+    ) noexcept;

--- a/Source/Task/referenced_ptr.h
+++ b/Source/Task/referenced_ptr.h
@@ -96,13 +96,13 @@ private:
 };
 
 template <typename TInterface>
-bool operator==(referenced_ptr<TInterface>& p, std::nullptr_t)
+bool operator==(referenced_ptr<TInterface>& p, nullptr_t)
 {
     return p.get() == nullptr;
 }
 
 template <typename TInterface>
-bool operator!=(referenced_ptr<TInterface>& p, std::nullptr_t)
+bool operator!=(referenced_ptr<TInterface>& p, nullptr_t)
 {
     return p.get() != nullptr;
 }

--- a/Tests/UnitTests/Tests/AsyncBlockTests.cpp
+++ b/Tests/UnitTests/Tests/AsyncBlockTests.cpp
@@ -225,7 +225,7 @@ private:
         if (opCode == XAsyncOp::Begin)
         {
             // Must run the ctor for the newly allocated memory, and the initial
-            // has already been copied in here so we must rescue it.
+            // value has already been copied in here so we must rescue it.
             FactorialCallData* d = (FactorialCallData*)data->context;
             DWORD value = d->value;
             d = new (data->context) FactorialCallData;

--- a/Tests/UnitTests/Tests/AsyncBlockTests.cpp
+++ b/Tests/UnitTests/Tests/AsyncBlockTests.cpp
@@ -224,7 +224,12 @@ private:
     {
         if (opCode == XAsyncOp::Begin)
         {
+            // Must run the ctor for the newly allocated memory, and the initial
+            // has already been copied in here so we must rescue it.
             FactorialCallData* d = (FactorialCallData*)data->context;
+            DWORD value = d->value;
+            d = new (data->context) FactorialCallData;
+            d->value = value;
 
             // leak a ref on this guy so we don't try to free it. We need
             // to do two addrefs because a new object starts with refcount

--- a/Tests/UnitTests/Tests/AsyncBlockTests.cpp
+++ b/Tests/UnitTests/Tests/AsyncBlockTests.cpp
@@ -4,9 +4,9 @@
 #include "UnitTestIncludes.h"
 #include "XAsync.h"
 #include "XAsyncProvider.h"
-#include "Task\XAsyncProviderPriv.h"
+#include "XAsyncProviderPriv.h"
 #include "XTaskQueue.h"
-#include "Task\XTaskQueuePriv.h"
+#include "XTaskQueuePriv.h"
 
 #define TEST_CLASS_OWNER L"brianpe"
 

--- a/Tests/UnitTests/Tests/LocklessQueueTests.cpp
+++ b/Tests/UnitTests/Tests/LocklessQueueTests.cpp
@@ -2,7 +2,7 @@
 
 #include "pch.h"
 #include "UnitTestIncludes.h"
-#include "Task/LocklessQueue.h"
+#include "LocklessQueue.h"
 
 #define TEST_CLASS_OWNER L"brianpe"
 

--- a/Tests/UnitTests/Tests/TaskQueueTests.cpp
+++ b/Tests/UnitTests/Tests/TaskQueueTests.cpp
@@ -5,7 +5,7 @@
 #include "XTaskQueue.h"
 #include "CallbackThunk.h"
 #include "PumpedTaskQueue.h"
-#include "Task/XTaskQueuePriv.h"
+#include "XTaskQueuePriv.h"
 
 #define TEST_CLASS_OWNER L"brianpe"
 
@@ -215,12 +215,15 @@ public:
         for(int idx = 0; idx < count; idx++)
         {
             VERIFY_SUCCEEDED(XTaskQueueDuplicateHandle(queue, &dups[idx]));
+            VERIFY_IS_TRUE(queue != dups[idx]);
         }
 
         for(int idx = 0; idx < count; idx++)
         {
             XTaskQueueCloseHandle(dups[idx]);
         }
+
+        VERIFY_ARE_EQUAL(E_INVALIDARG, XTaskQueueDuplicateHandle(dups[0], &dups[1]));
         XTaskQueueCloseHandle(queue);
     }
 


### PR DESCRIPTION
The task queue has a narrow race: if a future callback is evaluated just when the task queue is terminated it may get skipped from termination processing. The result is that a call for the future won't be canceled immediately when the task queue terminates.  Instead it will be canceled when its due time occurs.

There is a second possible race as well.  If a new future callback is scheduled and the schedule code is interleaved with a terminate call on another thread, the same thing can occur.

This change fixes both cases. It also fixes up some incorrect macros in the test projects so they can build again.