### PR TITLE
add static option to libHC linux

### DIFF
--- a/Build/libHttpClient.Linux/CMakeLists.txt
+++ b/Build/libHttpClient.Linux/CMakeLists.txt
@@ -100,23 +100,35 @@ set(LINUX_SOURCE_FILES
 set(LINUX_INCLUDE_DIRS
     "${PATH_TO_ROOT}/External/opensslGeneratedHeaders/linux"
     )
+if (BUILD_SHARED_LIBS)
+    #########################
+    ### Set up shared lib ###
+    #########################
 
-#########################
-### Set up shared lib ###
-#########################
+    add_library(
+        "${PROJECT_NAME}"
+        SHARED
+        "${COMMON_SOURCE_FILES}"
+        "${LINUX_SOURCE_FILES}"
+    )
 
-add_library(
-    "${PROJECT_NAME}"
-    SHARED
-    "${COMMON_SOURCE_FILES}"
-    "${LINUX_SOURCE_FILES}"
-)
+    target_link_libraries("${PROJECT_NAME}" 
+        PRIVATE ${LIBCURL_BINARY_PATH}
+        PRIVATE ${LIBSSL_BINARY_PATH}
+        PRIVATE ${LIBCRYPTO_BINARY_PATH} 
+    )
+else()
+    #########################
+    ### Set up static lib ###
+    #########################
 
-target_link_libraries("${PROJECT_NAME}" 
-    PRIVATE ${LIBCURL_BINARY_PATH}
-    PRIVATE ${LIBSSL_BINARY_PATH}
-    PRIVATE ${LIBCRYPTO_BINARY_PATH} 
-)
+    add_library(
+        "${PROJECT_NAME}"
+        STATIC
+        "${COMMON_SOURCE_FILES}"
+        "${LINUX_SOURCE_FILES}"
+    )
+endif()
 
 target_include_directories(
     "${PROJECT_NAME}"

--- a/Build/libHttpClient.Linux/README.md
+++ b/Build/libHttpClient.Linux/README.md
@@ -23,6 +23,12 @@ Running the build script with no arguments will generate a Release binary of `li
 Running the build script with the `-c|--config` argument will generate  Debug or Release binaries of `libssl.a`, `libcrypto.a`, `libcurl.a` and `libHttpClient.Linux.so`.
 
 ```
+./libHttpClient_Linux.bash <-st|--static>
+```
+
+Running the build script with the `-st|--static` will generate `libHttpClient.Linux.a` instead of `libHttpClient.Linux.so`. Use this flag if you wish to make a static lib of libHttpClient.
+
+```
 ./libHttpClient_Linux.bash <-nc|--nocurl>
 ```
 

--- a/Build/libHttpClient.Linux/README.md
+++ b/Build/libHttpClient.Linux/README.md
@@ -26,7 +26,7 @@ Running the build script with the `-c|--config` argument will generate  Debug or
 ./libHttpClient_Linux.bash <-st|--static>
 ```
 
-Running the build script with the `-st|--static` will generate `libHttpClient.Linux.a` instead of `libHttpClient.Linux.so`. Use this flag if you wish to make a static lib of libHttpClient.
+Running the build script with the `-st|--static` argument will generate a static lib of libHttpClient.
 
 ```
 ./libHttpClient_Linux.bash <-nc|--nocurl>

--- a/Build/libHttpClient.Linux/libHttpClient_Linux.bash
+++ b/Build/libHttpClient.Linux/libHttpClient_Linux.bash
@@ -83,9 +83,8 @@ if [ "$BUILD_STATIC" = false ]; then
     # make libHttpClient static
     sudo cmake -S "$SCRIPT_DIR" -B "$SCRIPT_DIR"/../../Int/CMake/libHttpClient.Linux -D CMAKE_BUILD_TYPE=$CONFIGURATION -D BUILD_SHARED_LIBS=YES
     sudo make -C "$SCRIPT_DIR"/../../Int/CMake/libHttpClient.Linux
-    else
-    # make libHttpClient Shared
+else
+    # make libHttpClient shared
     sudo cmake -S "$SCRIPT_DIR" -B "$SCRIPT_DIR"/../../Int/CMake/libHttpClient.Linux -D CMAKE_BUILD_TYPE=$CONFIGURATION
     sudo make -C "$SCRIPT_DIR"/../../Int/CMake/libHttpClient.Linux
 fi
-

--- a/Build/libHttpClient.Linux/libHttpClient_Linux.bash
+++ b/Build/libHttpClient.Linux/libHttpClient_Linux.bash
@@ -11,6 +11,7 @@ POSITIONAL_ARGS=()
 CONFIGURATION="Release"
 BUILD_CURL=true
 BUILD_SSL=true
+BUILD_STATIC=false
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -29,6 +30,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     -sg|--skipaptget)
       DO_APTGET=false
+      shift
+      ;;
+    -st|--static)
+      BUILD_STATIC=true
       shift
       ;;
     -*|--*)
@@ -74,6 +79,13 @@ if [ "$BUILD_CURL" = true ]; then
     bash "$SCRIPT_DIR"/curl_Linux.bash -c "$CONFIGURATION"
 fi
 
-# make libHttpClient
-sudo cmake -S "$SCRIPT_DIR" -B "$SCRIPT_DIR"/../../Int/CMake/libHttpClient.Linux -D CMAKE_BUILD_TYPE=$CONFIGURATION
-sudo make -C "$SCRIPT_DIR"/../../Int/CMake/libHttpClient.Linux
+if [ "$BUILD_STATIC" = false ]; then
+    # make libHttpClient static
+    sudo cmake -S "$SCRIPT_DIR" -B "$SCRIPT_DIR"/../../Int/CMake/libHttpClient.Linux -D CMAKE_BUILD_TYPE=$CONFIGURATION -D BUILD_SHARED_LIBS=YES
+    sudo make -C "$SCRIPT_DIR"/../../Int/CMake/libHttpClient.Linux
+    else
+    # make libHttpClient Shared
+    sudo cmake -S "$SCRIPT_DIR" -B "$SCRIPT_DIR"/../../Int/CMake/libHttpClient.Linux -D CMAKE_BUILD_TYPE=$CONFIGURATION
+    sudo make -C "$SCRIPT_DIR"/../../Int/CMake/libHttpClient.Linux
+fi
+

--- a/Utilities/Pipelines/Tasks/linux-build.yml
+++ b/Utilities/Pipelines/Tasks/linux-build.yml
@@ -18,7 +18,13 @@ steps:
       arguments: '-c ${{ parameters.configuration }}'
 
   - task: Bash@3
-    displayName: 'Build libHttpClient'
+    displayName: 'Build libHttpClient Static'
+    inputs:
+      filePath: './Build/libHttpClient.Linux/libHttpClient_Linux.bash'
+      arguments: '-c ${{ parameters.configuration }} -nc -ns -st'
+
+  - task: Bash@3
+    displayName: 'Build libHttpClient Shared'
     inputs:
       filePath: './Build/libHttpClient.Linux/libHttpClient_Linux.bash'
       arguments: '-c ${{ parameters.configuration }} -nc -ns'


### PR DESCRIPTION
This is necessary for projects that want to consume the Linux library but not as a so.