### PR TITLE
Remove Linux Static Lib Prefix

### DIFF
--- a/Build/libHttpClient.Linux/CMakeLists.txt
+++ b/Build/libHttpClient.Linux/CMakeLists.txt
@@ -6,6 +6,7 @@ project("libHttpClient.Linux")
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)
+set(CMAKE_STATIC_LIBRARY_PREFIX "")
 set(CMAKE_SHARED_LIBRARY_PREFIX "")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS} "-Wl,-z,now,--version-script=${PATH_TO_ROOT}/Build/libHttpClient.CMake/libHttpClientExports.txt")


### PR DESCRIPTION
When reverting the static lib removal that occurred in #800, in #818 , we forgot to remove the extra static lib prefix in CMake, which resulted Linux libs being generated as `liblibHttpClient.Linux.a`.