### PR TITLE
Adding Header Logic for Response Decompression

### DIFF
--- a/Samples/Win32-Http/main.cpp
+++ b/Samples/Win32-Http/main.cpp
@@ -192,7 +192,7 @@ void DoHttpCall(std::string url, std::string requestBody, bool isJson, std::stri
     std::string method = "GET";
     bool retryAllowed = true;
     std::vector<std::vector<std::string>> headers;
-    std::vector< std::string > header;
+    std::vector<std::string> header;
 
     if (enableGzipResponseCompression) 
     {


### PR DESCRIPTION
Adding logic to check content-encoding header on responses (where response compression is set but endpoint does not support response compression)