### PR TITLE
Optimize Linux Builds by Checking for Previously Generated Bins

### DIFF
--- a/Build/libHttpClient.Linux/curl_Linux.bash
+++ b/Build/libHttpClient.Linux/curl_Linux.bash
@@ -24,6 +24,13 @@ done
 pushd "$SCRIPT_DIR"/../../External/curl
 autoreconf -fi "$SCRIPT_DIR"/../../External/curl
 
+if [ -f "$SCRIPT_DIR/../../Out/x64/$CONFIGURATION/libcurl.Linux/libcurl.a" ]; then
+  echo "Previously-built library present at $SCRIPT_DIR/../../Out/x64/$CONFIGURATION/libcurl.Linux/libcurl.a - skipping build"
+  exit 0
+else
+  echo "No previously-built library present at $SCRIPT_DIR/../../Out/x64/$CONFIGURATION/libcurl.Linux/libcurl.a - performing build"
+fi
+
 if [ "$CONFIGURATION" = "Debug" ]; then
     # make libcrypto and libssl
     ./configure --disable-shared --without-zlib --disable-dependency-tracking -with-openssl=/usr/local/ssl --enable-symbol-hiding --enable-debug

--- a/Build/libHttpClient.Linux/openssl_Linux.bash
+++ b/Build/libHttpClient.Linux/openssl_Linux.bash
@@ -42,6 +42,13 @@ if [ ! -d /usr/local/ssl/include/openssl ] ; then
     exit 1
 fi
 
+if [ -f "$SCRIPT_DIR/../../Out/x64/$CONFIGURATION/libcrypto.Linux/libcrypto.a" ]; then
+  echo "Previously-built library present at $SCRIPT_DIR/../../Out/x64/$CONFIGURATION/libcrypto.Linux/libcrypto.a - skipping build"
+  exit 0
+else
+  echo "No previously-built library present at $SCRIPT_DIR/../../Out/x64/$CONFIGURATION/libcrypto.Linux/libcrypto.a - performing build"
+fi
+
 pushd $OPENSSL_SRC
 make clean
 sed -i -e 's/\r$//' Configure


### PR DESCRIPTION
Similar to what we do for iOS OpenSSL builds, check for existing bins before rebuilding the entire project each time the build is invoked.

https://github.com/microsoft/libHttpClient/blob/main/Utilities/XcodeBuildScripts/openssl.bash#L50