### PR TITLE
Skip Manual Decompression for macOS and iOS 

### DIFF
--- a/Source/HTTP/httpcall.cpp
+++ b/Source/HTTP/httpcall.cpp
@@ -369,23 +369,30 @@ void HC_CALL::PerformSingleRequestComplete(XAsyncBlock* async)
     // Decompress Response Bytes 
     if (Compression::Available() && call->compressedResponse == true)
     {
-        // Retrieve the value of Content=Encoding response header
+        // Retrieve the value of Content-Encoding response header
         const char* encodingHeaderValue;
         HCHttpCallResponseGetHeader(call, "Content-Encoding", &encodingHeaderValue);
         
+        // Ensure Content-Encoding header exists
         if (encodingHeaderValue != nullptr)
         {
+            // Check that the response was compressed using gzip
             if (std::strcmp(encodingHeaderValue, "gzip") == 0)
             {
-                http_internal_vector<uint8_t> uncompressedResponseBodyBuffer;
+                // Added Check for Mac + iOS
+                // Attempt to decompress only if gzip header is present (NSData is already decompressed therefore responseBodyBytes will not contain a gzip header)
+                if (call->responseBodyBytes.size() > 2 && (call->responseBodyBytes[0] == 0x1f && call->responseBodyBytes[1] == 0x8b))
+                {
+                    http_internal_vector<uint8_t> uncompressedResponseBodyBuffer;
 
-                Compression::DecompressFromGzip(
-                    call->responseBodyBytes.data(),
-                    call->responseBodyBytes.size(),
-                    uncompressedResponseBodyBuffer);
+                    Compression::DecompressFromGzip(
+                        call->responseBodyBytes.data(),
+                        call->responseBodyBytes.size(),
+                        uncompressedResponseBodyBuffer);
 
-                call->responseBodyBytes.resize(uncompressedResponseBodyBuffer.size());
-                call->responseBodyBytes = std::move(uncompressedResponseBodyBuffer);
+                    call->responseBodyBytes.resize(uncompressedResponseBodyBuffer.size());
+                    call->responseBodyBytes = std::move(uncompressedResponseBodyBuffer);
+                }
             }
         }
     }


### PR DESCRIPTION
Adding check to correctly handle gzip decompression on macOS and iOS. Checking gzip header to ensure data is not already decompressed. NSData sourced from responses is already uncompressed (both in cases where Content-Encoding: gzip and Content-Encoding: deflate) therefore manual decompression is not needed in httpcall.cpp.

Changes tested within PlayFab C SDK testapps. iOS and macOS test apps are now fully passing.