### PR TITLE
Remove magic statics for timerqueue

### DIFF
--- a/Source/Task/WaitTimer_stl.cpp
+++ b/Source/Task/WaitTimer_stl.cpp
@@ -216,7 +216,7 @@ namespace OS
         {
             try
             {
-                auto queue = std::make_shared<TimerQueue>();
+                auto queue = http_allocate_shared<TimerQueue>();
                 if (!queue->Init())
                 {
                     return E_FAIL;


### PR DESCRIPTION
waittimer uses a global timerqueue object.  But timerqueue's dtor destroys a thread, which has allocated resources. This can cause conflicts with other static / global destructors in the system. We should not be using "magic statics" to do complex things like freeing dynamic memory.

This changes the global timerqueue to a shared_ptr. In the destructor for waittimer, it checks the shared pointer usage count and is this is the last wait timer, it will free the global shared pointer. This causes the thread deallocation to happen when the last task queue is closed instead of happening post-main in crt cleanup.

Tested with a repro that exposed the magic static fragility (crash in custom global new operator). Verified all works and no leaks post change (thanks Sebastian Perez-Delgado).