### PR TITLE
Update httpcall.cpp

### DIFF
--- a/Source/HTTP/httpcall.cpp
+++ b/Source/HTTP/httpcall.cpp
@@ -370,7 +370,7 @@ void HC_CALL::PerformSingleRequestComplete(XAsyncBlock* async)
     if (Compression::Available() && call->compressedResponse == true)
     {
         // Retrieve the value of Content-Encoding response header
-        const char* encodingHeaderValue;
+        const char* encodingHeaderValue = nullptr;
         HCHttpCallResponseGetHeader(call, "Content-Encoding", &encodingHeaderValue);
         
         // Ensure Content-Encoding header exists


### PR DESCRIPTION
ensure encodingHeaderValue is initialized to not set off compiler warnings in Visual Studio