### PR TITLE
Task 53387428: Support dynamic HTTP body sizes in LHC

### DIFF
--- a/Build/libHttpClient.GDK/libHttpClient.GDK.def
+++ b/Build/libHttpClient.GDK/libHttpClient.GDK.def
@@ -57,6 +57,12 @@ EXPORTS
     HCHttpCallResponseSetResponseBodyBytes
     HCHttpCallResponseSetResponseBodyWriteFunction
     HCHttpCallResponseSetStatusCode
+    HCHttpCallRequestSetDynamicSize
+    HCHttpCallRequestAddDynamicBytesWritten
+    HCHttpCallRequestGetDynamicBytesWritten
+    HCHttpCallResponseSetDynamicSize
+    HCHttpCallResponseAddDynamicBytesWritten
+    HCHttpCallResponseGetDynamicBytesWritten
     HCHttpCallSetContext
     HCHttpCallSetTracing
     HCHttpDisableAssertsForSSLValidationInDevSandboxes

--- a/Build/libHttpClient.Win32/libHttpClient.Win32.def
+++ b/Build/libHttpClient.Win32/libHttpClient.Win32.def
@@ -57,6 +57,12 @@ EXPORTS
     HCHttpCallResponseSetResponseBodyBytes
     HCHttpCallResponseSetResponseBodyWriteFunction
     HCHttpCallResponseSetStatusCode
+    HCHttpCallRequestSetDynamicSize
+    HCHttpCallRequestAddDynamicBytesWritten
+    HCHttpCallRequestGetDynamicBytesWritten
+    HCHttpCallResponseSetDynamicSize
+    HCHttpCallResponseAddDynamicBytesWritten
+    HCHttpCallResponseGetDynamicBytesWritten
     HCHttpCallSetContext
     HCHttpCallSetTracing
     HCInitialize

--- a/Include/httpClient/httpClient.h
+++ b/Include/httpClient/httpClient.h
@@ -329,6 +329,29 @@ STDAPI HCHttpCallRequestSetUrl(
     ) noexcept;
 
 /// <summary>
+/// Mark the HTTP call as having a dynamically sized request body and set the size to use for reporting. A custom read callback must be set and
+/// the callback must report the bytes written using HCHttpCallRequestAddDynamicBytesWritten. Unsupported when request gzip compression is enabled.
+/// </summary>
+/// <param name="call">The handle of the HTTP call.</param>
+/// <param name="dynamicBodySize">The length in bytes to use for reporting.</param>
+/// <returns>Result code for this API operation.  Possible values are S_OK, E_INVALIDARG, E_OUTOFMEMORY, or E_FAIL.</returns>
+STDAPI HCHttpCallRequestSetDynamicSize(
+    _In_ HCCallHandle call,
+    _In_ uint64_t dynamicBodySize
+) noexcept;
+
+/// <summary>
+/// Report a custom amount of bytes written in a custom read callback when the body size is dynamic. HCHttpCallRequestSetDynamicSize must be set.
+/// </summary>
+/// <param name="call">The handle of the HTTP call.</param>
+/// <param name="bytesWritten">The number of bytes written.</param>
+/// <returns>Result code for this API operation.  Possible values are S_OK, E_INVALIDARG, E_OUTOFMEMORY, or E_FAIL.</returns>
+STDAPI HCHttpCallRequestAddDynamicBytesWritten(
+    _In_ HCCallHandle call,
+    _In_ uint64_t bytesWritten
+) noexcept;
+
+/// <summary>
 /// Set the request body bytes of the HTTP call. This API operation is mutually exclusive with
 /// HCHttpCallRequestSetRequestBodyReadFunction and will result in any custom read callbacks that were
 /// previously set on this call handle to be ignored.
@@ -387,7 +410,7 @@ enum class HCCompressionLevel : uint32_t
 };
 
 /// <summary>
-/// Enable GZIP compression on the provided body payload.
+/// Enable GZIP compression on the provided body payload. Unsupported when the request body size is dynamic.
 /// </summary>
 /// <param name="call">The handle of the HTTP call.</param>
 /// <param name="level">The desired compression level.</param>
@@ -682,7 +705,11 @@ typedef HRESULT
 /// <param name="writeFunction">The response body write function this call should use.</param>
 /// <param name="context">The context to associate with this write function.</param>
 /// <returns>Result code of this API operation. Possible values are S_OK or E_INVALIDARG.</returns>
-/// <remarks>This must be called prior to calling HCHttpCallPerformAsync.</remarks>
+/// <remarks>
+/// This must be called prior to calling HCHttpCallPerformAsync. When sending a dynamic size request
+/// body, the custom write function must handle an extra call after the last byte is written to send
+/// an empty chunk to signal the end of the request body.
+/// </remarks>
 STDAPI HCHttpCallResponseSetResponseBodyWriteFunction(
     _In_ HCCallHandle call,
     _In_ HCHttpCallResponseBodyWriteFunction writeFunction,

--- a/Include/httpClient/httpClient.h
+++ b/Include/httpClient/httpClient.h
@@ -330,7 +330,8 @@ STDAPI HCHttpCallRequestSetUrl(
 
 /// <summary>
 /// Mark the HTTP call as having a dynamically sized request body and set the size to use for reporting. A custom read callback must be set and
-/// the callback must report the bytes written using HCHttpCallRequestAddDynamicBytesWritten. Unsupported when request gzip compression is enabled.
+/// the callback must report the bytes written using HCHttpCallRequestAddDynamicBytesWritten. The bodySize provided when setting the custom 
+/// callback will be ignored. Unsupported when request gzip compression is enabled.
 /// </summary>
 /// <param name="call">The handle of the HTTP call.</param>
 /// <param name="dynamicBodySize">The length in bytes to use for reporting.</param>

--- a/Include/httpClient/httpClient.h
+++ b/Include/httpClient/httpClient.h
@@ -329,9 +329,8 @@ STDAPI HCHttpCallRequestSetUrl(
     ) noexcept;
 
 /// <summary>
-/// Mark the HTTP call as having a dynamically sized request body and set the size to use for reporting. A custom read callback must be set and
-/// the callback must report the bytes written using HCHttpCallRequestAddDynamicBytesWritten. The bodySize provided when setting the custom 
-/// callback will be ignored. Unsupported when request gzip compression is enabled.
+/// Mark the HTTP call as having a dynamic size request body for progress reporting. Report the bytes written in the custom callback using
+/// HCHttpCallRequestAddDynamicBytesWritten.
 /// </summary>
 /// <param name="call">The handle of the HTTP call.</param>
 /// <param name="dynamicBodySize">The length in bytes to use for reporting.</param>
@@ -342,7 +341,7 @@ STDAPI HCHttpCallRequestSetDynamicSize(
 ) noexcept;
 
 /// <summary>
-/// Report a custom amount of bytes written in a custom read callback when the body size is dynamic. HCHttpCallRequestSetDynamicSize must be set.
+/// Report a custom amount of bytes written when the body size is dynamic. HCHttpCallRequestSetDynamicSize must be set.
 /// </summary>
 /// <param name="call">The handle of the HTTP call.</param>
 /// <param name="bytesWritten">The number of bytes written.</param>
@@ -411,7 +410,7 @@ enum class HCCompressionLevel : uint32_t
 };
 
 /// <summary>
-/// Enable GZIP compression on the provided body payload. Unsupported when the request body size is dynamic.
+/// Enable GZIP compression on the provided body payload.
 /// </summary>
 /// <param name="call">The handle of the HTTP call.</param>
 /// <param name="level">The desired compression level.</param>
@@ -706,11 +705,7 @@ typedef HRESULT
 /// <param name="writeFunction">The response body write function this call should use.</param>
 /// <param name="context">The context to associate with this write function.</param>
 /// <returns>Result code of this API operation. Possible values are S_OK or E_INVALIDARG.</returns>
-/// <remarks>
-/// This must be called prior to calling HCHttpCallPerformAsync. When sending a dynamic size request
-/// body, the custom write function must handle an extra call after the last byte is written to send
-/// an empty chunk to signal the end of the request body.
-/// </remarks>
+/// <remarks>This must be called prior to calling HCHttpCallPerformAsync.</remarks>
 STDAPI HCHttpCallResponseSetResponseBodyWriteFunction(
     _In_ HCCallHandle call,
     _In_ HCHttpCallResponseBodyWriteFunction writeFunction,

--- a/Include/httpClient/httpProvider.h
+++ b/Include/httpClient/httpProvider.h
@@ -347,8 +347,8 @@ STDAPI HCHttpCallResponseGetDynamicBytesWritten(
 //
 
 /// <summary>
-/// Mark the HTTP call as having a dynamic size response body and set the size to use for reporting. A custom write callback must be set and
-/// the callback must report the bytes written using HCHttpCallResponseAddDynamicBytesWritten.
+/// Mark the HTTP call as having a dynamic size response body for progress reporting. Report the bytes written in the custom callback using
+/// HCHttpCallResponseAddDynamicBytesWritten.
 /// </summary>
 /// <param name="call">The handle of the HTTP call.</param>
 /// <param name="dynamicBodySize">The length in bytes of the body being set.</param>
@@ -359,7 +359,7 @@ STDAPI HCHttpCallResponseSetDynamicSize(
 ) noexcept;
 
 /// <summary>
-/// Report a custom amount of bytes written in a custom write callback when the body size is dynamic. HCHttpCallRequestSetDynamicSize must be set.
+/// Report a custom amount of bytes written when the body size is dynamic. HCHttpCallRequestSetDynamicSize must be set.
 /// </summary>
 /// <param name="call">The handle of the HTTP call.</param>
 /// <param name="bytesWritten">The number of bytes written.</param>

--- a/Include/httpClient/httpProvider.h
+++ b/Include/httpClient/httpProvider.h
@@ -151,6 +151,19 @@ STDAPI HCHttpCallRequestGetRequestBodyReadFunction(
     ) noexcept;
 
 /// <summary>
+/// Get the custom bytes written and total body size for an HTTP call with a dynamic body size. Use standard request body info if dynamicBodySize is 0.
+/// </summary>
+/// <param name="call">The handle of the HTTP call.</param>
+/// <param name="dynamicBodySize">The custom size to use for reporting</param>
+/// <param name="dynamicBodyBytesWritten">The custom bytes written to use for reporting</param>
+/// <returns>Result code for this API operation. Possible values are S_OK, E_INVALIDARG, or E_FAIL.</returns>
+STDAPI HCHttpCallRequestGetDynamicBytesWritten(
+    _In_ HCCallHandle call,
+    _Out_ size_t* dynamicBodySize,
+    _Out_ size_t* dynamicBodyBytesWritten
+) noexcept;
+
+/// <summary>
 /// Get the function used by the HTTP call to get progress updates
 /// </summary>
 /// <param name="call">The handle of the HTTP call.</param>
@@ -316,9 +329,45 @@ STDAPI HCHttpCallResponseGetResponseBodyWriteFunction(
     _Out_ void** context
     ) noexcept;
 
+/// <summary>
+/// Get the custom bytes written and total body size for an HTTP call with a dynamic body size. Use standard response body info if dynamicBodySize is 0.
+/// </summary>
+/// <param name="call">The handle of the HTTP call.</param>
+/// <param name="dynamicBodySize">The custom size to use for reporting</param>
+/// <param name="dynamicBodyBytesWritten">The custom bytes written to use for reporting</param>
+/// <returns></returns>
+STDAPI HCHttpCallResponseGetDynamicBytesWritten(
+    _In_ HCCallHandle call,
+    _Out_ size_t* dynamicBodySize,
+    _Out_ size_t* dynamicBodyBytesWritten
+) noexcept;
+
 /////////////////////////////////////////////////////////////////////////////////////////
 // HttpCallResponse Set APIs
 //
+
+/// <summary>
+/// Mark the HTTP call as having a dynamic size response body and set the size to use for reporting. A custom write callback must be set and
+/// the callback must report the bytes written using HCHttpCallResponseAddDynamicBytesWritten.
+/// </summary>
+/// <param name="call">The handle of the HTTP call.</param>
+/// <param name="dynamicBodySize">The length in bytes of the body being set.</param>
+/// <returns>Result code for this API operation.  Possible values are S_OK, E_INVALIDARG, E_OUTOFMEMORY, or E_FAIL.</returns>
+STDAPI HCHttpCallResponseSetDynamicSize(
+    _In_ HCCallHandle call,
+    _In_ uint64_t dynamicBodySize
+) noexcept;
+
+/// <summary>
+/// Report a custom amount of bytes written in a custom write callback when the body size is dynamic. HCHttpCallRequestSetDynamicSize must be set.
+/// </summary>
+/// <param name="call">The handle of the HTTP call.</param>
+/// <param name="bytesWritten">The number of bytes written.</param>
+/// <returns>Result code for this API operation.  Possible values are S_OK, E_INVALIDARG, E_OUTOFMEMORY, or E_FAIL.</returns>
+STDAPI HCHttpCallResponseAddDynamicBytesWritten(
+    _In_ HCCallHandle call,
+    _In_ uint64_t bytesWritten
+) noexcept;
 
 /// <summary>
 /// Set the response body byte buffer of the HTTP call. If a custom write callback was previously set

--- a/Source/HTTP/Curl/CurlEasyRequest.cpp
+++ b/Source/HTTP/Curl/CurlEasyRequest.cpp
@@ -72,6 +72,11 @@ Result<HC_UNIQUE_PTR<CurlEasyRequest>> CurlEasyRequest::Initialize(HCCallHandle 
     uint64_t dynamicBodyBytesWritten{};
     HCHttpCallRequestGetDynamicBytesWritten(hcCall, &dynamicBodySize, &dynamicBodyBytesWritten);
 
+    if (dynamicBodySize > 0)
+    {
+        bodySize = dynamicBodySize;
+    }
+
     bool provideBody = true;
 #if HC_PLATFORM == HC_PLATFORM_GDK
     provideBody = bodySize > 0;

--- a/Source/HTTP/WinHttp/winhttp_connection.cpp
+++ b/Source/HTTP/WinHttp/winhttp_connection.cpp
@@ -242,7 +242,17 @@ HRESULT WinHttpConnection::Initialize()
         void* context{ nullptr };
         RETURN_IF_FAILED(HCHttpCallRequestGetRequestBodyReadFunction(m_call, &requestBodyReadFunction, &m_requestBodySize, &context));
 
-        if (m_requestBodySize > 0)
+        uint64_t dynamicRequestBodySize{};
+        uint64_t dynamicRequestBodyBytesWritten{};
+        RETURN_IF_FAILED(HCHttpCallRequestGetDynamicBytesWritten(m_call, &dynamicRequestBodySize, &dynamicRequestBodyBytesWritten));
+
+        if (dynamicRequestBodySize > 0)
+        {
+            // We will be transfer-encoding the data in chunks since we don't know the size of the data yet.
+            m_requestBodyType = msg_body_type::transfer_encoding_chunked;
+            m_requestBodySize = dynamicRequestBodySize;
+        }
+        else if (m_requestBodySize > 0)
         {
             // While we won't be transfer-encoding the data, we will write it in portions.
             m_requestBodyType = msg_body_type::content_length_chunked;
@@ -531,7 +541,20 @@ void WinHttpConnection::ReportProgress(_In_ WinHttpConnection* pRequestContext, 
         }
         else
         {
-            current = bodySize - pRequestContext->m_responseBodyRemainingToRead;
+            uint64_t dynamicBodySize{};
+            uint64_t dynamicBodyBytesWritten{};
+            HCHttpCallResponseGetDynamicBytesWritten(pRequestContext->m_call, &dynamicBodySize, &dynamicBodyBytesWritten);
+
+            if (dynamicBodySize > 0)
+            {
+                bodySize = dynamicBodySize;
+                current = dynamicBodyBytesWritten;
+            }
+            else
+            {
+                current = bodySize - pRequestContext->m_responseBodyRemainingToRead;
+            }
+
             lastProgressReport = pRequestContext->m_call->downloadLastProgressReport;
             minimumProgressReportIntervalInMs = static_cast<long>(pRequestContext->m_call->downloadMinimumProgressReportInterval * 1000);
         }
@@ -610,13 +633,33 @@ void WinHttpConnection::_multiple_segment_write_data(_In_ WinHttpConnection* pRe
         return;
     }
 
-    // Stop writing chunks after this one if no more data.
-    pRequestContext->m_requestBodyRemainingToWrite -= bytesWritten;
-    if (pRequestContext->m_requestBodyRemainingToWrite == 0)
+    if (pRequestContext->m_requestBodyType == transfer_encoding_chunked)
     {
-        pRequestContext->m_requestBodyType = msg_body_type::no_body;
+        uint64_t dynamicBodySize{};
+        uint64_t dynamicBodyBytesWritten{};
+        HCHttpCallRequestGetDynamicBytesWritten(pRequestContext->m_call, &dynamicBodySize, &dynamicBodyBytesWritten);
+
+        pRequestContext->m_requestBodyRemainingToWrite = dynamicBodySize - dynamicBodyBytesWritten;
+        pRequestContext->m_requestBodyOffset = dynamicBodyBytesWritten;
+        bodySize = dynamicBodySize;
+
+        // Stop writing chunks after this one if we just sent an empty chunk
+        if (bytesWritten == 0)
+        {
+            pRequestContext->m_requestBodyType = msg_body_type::no_body;
+        }
     }
-    pRequestContext->m_requestBodyOffset += bytesWritten;
+    else
+    {
+        pRequestContext->m_requestBodyRemainingToWrite -= bytesWritten;
+        pRequestContext->m_requestBodyOffset += bytesWritten;
+
+        // Stop writing chunks after this one if no more data.
+        if (pRequestContext->m_requestBodyRemainingToWrite == 0)
+        {
+            pRequestContext->m_requestBodyType = msg_body_type::no_body;
+        }
+    }
 
     ReportProgress(pRequestContext, bodySize, true);
 }
@@ -633,7 +676,7 @@ void WinHttpConnection::callback_status_write_complete(
         HC_TRACE_INFORMATION(HTTPCLIENT, "HCHttpCallPerform [ID %llu] [TID %ul] WINHTTP_CALLBACK_STATUS_WRITE_COMPLETE bytesWritten=%d", TO_ULL(HCHttpCallGetId(pRequestContext->m_call)), GetCurrentThreadId(), bytesWritten);
         UNREFERENCED_LOCAL(bytesWritten);
 
-        if (pRequestContext->m_requestBodyType == content_length_chunked)
+        if (pRequestContext->m_requestBodyType == content_length_chunked || pRequestContext->m_requestBodyType == transfer_encoding_chunked)
         {
             _multiple_segment_write_data(pRequestContext);
             return;
@@ -830,7 +873,7 @@ void WinHttpConnection::callback_status_sendrequest_complete(
 
         HC_TRACE_INFORMATION(HTTPCLIENT, "HCHttpCallPerform [ID %llu] [TID %ul] WINHTTP_CALLBACK_STATUS_SENDREQUEST_COMPLETE", TO_ULL(HCHttpCallGetId(pRequestContext->m_call)), GetCurrentThreadId());
 
-        if (pRequestContext->m_requestBodyType == content_length_chunked)
+        if (pRequestContext->m_requestBodyType == content_length_chunked || pRequestContext->m_requestBodyType == transfer_encoding_chunked)
         {
             _multiple_segment_write_data(pRequestContext);
             return;
@@ -1097,7 +1140,14 @@ void WinHttpConnection::callback_status_read_complete(
         if (pRequestContext->m_responseBodySize > 0)
         {
             pRequestContext->m_responseBodyRemainingToRead -= bytesRead;
-            ReportProgress(pRequestContext, pRequestContext->m_responseBodySize, false);
+
+            uint64_t dynamicBodySize{};
+            uint64_t dynamicBodyBytesWritten{};
+            HCHttpCallResponseGetDynamicBytesWritten(pRequestContext->m_call, &dynamicBodySize, &dynamicBodyBytesWritten);
+
+            size_t bodySize = dynamicBodySize > 0 ? dynamicBodySize : pRequestContext->m_responseBodySize;
+
+            ReportProgress(pRequestContext, bodySize, false);
         }
 
         read_next_response_chunk(pRequestContext, bytesRead);
@@ -1408,6 +1458,7 @@ void WinHttpConnection::SendRequest()
     {
         case msg_body_type::no_body: dwTotalLength = 0; break;
         case msg_body_type::content_length_chunked: dwTotalLength = (DWORD)m_requestBodySize; break;
+        case msg_body_type::transfer_encoding_chunked: dwTotalLength = WINHTTP_IGNORE_REQUEST_TOTAL_LENGTH; break;
         default: dwTotalLength = WINHTTP_IGNORE_REQUEST_TOTAL_LENGTH; break;
     }
 

--- a/Source/HTTP/httpcall.h
+++ b/Source/HTTP/httpcall.h
@@ -95,6 +95,11 @@ public:
     std::chrono::steady_clock::time_point downloadLastProgressReport{};
     void* downloadProgressReportFunctionContext{ nullptr };
 
+    // Dynamic size properties
+    uint64_t dynamicRequestBodySize{ 0 };
+    uint64_t dynamicRequestBodyBytesWritten{ 0 };
+    uint64_t dynamicResponseBodySize{ 0 };
+    uint64_t dynamicResponseBodyBytesWritten{ 0 };
 
     static HRESULT CALLBACK ReadRequestBody(
         _In_ HCCallHandle call,

--- a/Source/HTTP/httpcall_request.cpp
+++ b/Source/HTTP/httpcall_request.cpp
@@ -78,11 +78,6 @@ try
     }
     RETURN_IF_PERFORM_CALLED(call);
 
-    if (Compression::Available() && call->compressionLevel != HCCompressionLevel::None)
-    {
-        return E_NOT_SUPPORTED;
-    }
-
     auto httpSingleton = get_http_singleton();
     if (nullptr == httpSingleton)
     {
@@ -92,8 +87,6 @@ try
     call->dynamicRequestBodySize = dynamicBodySize;
 
     if (call->traceCall) { HC_TRACE_INFORMATION(HTTPCLIENT, "HCHttpCallRequestSetDynamicSize [ID %llu]: dynamicBodySize=%llu", TO_ULL(call->id), TO_ULL(dynamicBodySize)); }
-
-    HCHttpCallRequestSetHeader(call, "Transfer-Encoding", "chunked", true);
 
     return S_OK;
 }
@@ -178,7 +171,7 @@ try
     }
     RETURN_IF_PERFORM_CALLED(call);
 
-    if ((!Compression::Available() && level != HCCompressionLevel::None) || call->dynamicRequestBodySize > 0)
+    if (!Compression::Available() && level != HCCompressionLevel::None)
     {
         return E_NOT_SUPPORTED;
     }

--- a/Source/HTTP/httpcall_response.cpp
+++ b/Source/HTTP/httpcall_response.cpp
@@ -27,6 +27,26 @@ try
 }
 CATCH_RETURN()
 
+STDAPI HCHttpCallResponseGetDynamicBytesWritten(
+    _In_ HCCallHandle call,
+    _Out_ size_t* dynamicBodySize,
+    _Out_ size_t* dynamicBodyBytesWritten
+) noexcept
+try
+{
+    if (call == nullptr || dynamicBodySize == nullptr || dynamicBodyBytesWritten == nullptr)
+    {
+        return E_INVALIDARG;
+    }
+
+    *dynamicBodySize = call->dynamicResponseBodySize;
+    *dynamicBodyBytesWritten = call->dynamicResponseBodyBytesWritten;
+
+    return S_OK;
+
+}
+CATCH_RETURN()
+
 STDAPI
 HCHttpCallResponseSetResponseBodyWriteFunction(
     _In_ HCCallHandle call,
@@ -137,6 +157,64 @@ try
     {
         *bufferUsed = call->responseBodyBytes.size();
     }
+    return S_OK;
+}
+CATCH_RETURN()
+
+STDAPI
+HCHttpCallResponseSetDynamicSize(
+    _In_ HCCallHandle call,
+    _In_ uint64_t dynamicBodySize
+) noexcept
+try
+{
+    if (call == nullptr || dynamicBodySize == 0)
+    {
+        return E_INVALIDARG;
+    }
+    RETURN_IF_PERFORM_CALLED(call);
+
+    auto httpSingleton = get_http_singleton();
+    if (nullptr == httpSingleton)
+    {
+        return E_HC_NOT_INITIALISED;
+    }
+
+    call->dynamicResponseBodySize = dynamicBodySize;
+
+    if (call->traceCall) { HC_TRACE_INFORMATION(HTTPCLIENT, "HCHttpCallResponseSetDynamicSize [ID %llu]: dynamicBodySize=%llu", TO_ULL(call->id), TO_ULL(dynamicBodySize)); }
+
+    return S_OK;
+}
+CATCH_RETURN()
+
+STDAPI
+HCHttpCallResponseAddDynamicBytesWritten(
+    _In_ HCCallHandle call,
+    _In_ uint64_t bytesWritten
+) noexcept
+try
+{
+    if (call == nullptr)
+    {
+        return E_INVALIDARG;
+    }
+
+    if (call->dynamicResponseBodySize == 0)
+    {
+        return E_UNEXPECTED;
+    }
+
+    call->dynamicResponseBodyBytesWritten += bytesWritten;
+
+    if (call->dynamicResponseBodyBytesWritten > call->dynamicResponseBodySize)
+    {
+        HC_TRACE_WARNING(HTTPCLIENT, "HCHttpCallResponseAddDynamicBytesWritten [ID %llu]: Reducing excessive bytesWritten=%llu to dynamicBodySize=%llu", TO_ULL(call->id), TO_ULL(call->dynamicResponseBodyBytesWritten), TO_ULL(call->dynamicResponseBodySize));
+        call->dynamicResponseBodyBytesWritten = call->dynamicResponseBodySize;
+    }
+
+    if (call->traceCall) { HC_TRACE_INFORMATION(HTTPCLIENT, "HCHttpCallResponseAddDynamicBytesWritten [ID %llu]: bytesWritten=%llu", TO_ULL(call->id), TO_ULL(bytesWritten)); }
+
     return S_OK;
 }
 CATCH_RETURN()


### PR DESCRIPTION
New APIs to allow reporting custom progress on a dynamic size instead of the actual request/response body size.