### PR TITLE
Fix cleanup race in CurlMulti that leads to a crash

### DIFF
--- a/Source/HTTP/Curl/CurlMulti.cpp
+++ b/Source/HTTP/Curl/CurlMulti.cpp
@@ -99,7 +99,10 @@ HRESULT CALLBACK CurlMulti::CleanupAsyncProvider(XAsyncOp op, const XAsyncProvid
         bool cleanupImmediately = multi->m_taskQueueCallbacksPending == 0;
         XTaskQueueHandle queue = multi->m_queue;
 
-        // Release the lock before going any further because the multi may be destroyed before Begin completes
+        // Release the lock before going any further because both cleanup paths can lead to DoWork being scheduled and run before
+        // XAsyncOp::Begin completes and releases the lock naturally. Because DoWork destroys the CurlMulti object, its no longer
+        // safe to access the multi object after this point.
+        multi = nullptr; // Set to null to avoid accidental use after this point
         lock.unlock();
 
         if (cleanupImmediately)
@@ -116,7 +119,7 @@ HRESULT CALLBACK CurlMulti::CleanupAsyncProvider(XAsyncOp op, const XAsyncProvid
     case XAsyncOp::DoWork:
     {
         assert(multi->m_easyRequests.empty());
-        HC_UNIQUE_PTR<CurlMulti> reclaim{ static_cast<CurlMulti*>(multi) };
+        HC_UNIQUE_PTR<CurlMulti> reclaim{ multi };
 
         // Ensure CurlMulti is destroyed (and thus curl_multi_cleanup is called) before completing asyncBlock
         reclaim.reset();
@@ -151,29 +154,40 @@ void CurlMulti::ScheduleTaskQueueCallback(std::unique_lock<std::mutex>&& lock, u
 void CALLBACK CurlMulti::TaskQueueCallback(_In_opt_ void* context, _In_ bool canceled) noexcept
 {
     assert(context);
-    auto multi = static_cast<CurlMulti*>(context);
+    XAsyncBlock* cleanupAsyncBlock{ nullptr };
 
-    if (!canceled)
     {
-        HRESULT hr = multi->Perform();
-        if (FAILED(hr))
+        auto multi = static_cast<CurlMulti*>(context);
+
+        if (!canceled)
         {
-            HC_TRACE_ERROR_HR(HTTPCLIENT, hr, "CurlMulti::Perform failed. Failing all active requests.");
-            multi->FailAllRequests(hr);
+            HRESULT hr = multi->Perform();
+            if (FAILED(hr))
+            {
+                HC_TRACE_ERROR_HR(HTTPCLIENT, hr, "CurlMulti::Perform failed. Failing all active requests.");
+                multi->FailAllRequests(hr);
+            }
+        }
+        else
+        {
+            multi->FailAllRequests(E_ABORT);
+        }
+
+        std::unique_lock<std::mutex> lock{ multi->m_mutex };
+        if (--multi->m_taskQueueCallbacksPending == 0 && multi->m_cleanupAsyncBlock)
+        {
+            // If CurlMulti::CleanupAsync was called and there are no remaining task queue callbacks, schedule cleanup now.
+            // We *MUST* schedule the cleanup outside of holding the lock though. Scheduling cleanup may free the CurlMulti 
+            // object memory before we're done using it here and we don't want that to happen while we're holding the lock 
+            // or still otherwise referencing the CurlMulti object memory
+            cleanupAsyncBlock = multi->m_cleanupAsyncBlock;
         }
     }
-    else
-    {
-        multi->FailAllRequests(E_ABORT);
-    }
 
-    std::unique_lock<std::mutex> lock{ multi->m_mutex };
-    if (--multi->m_taskQueueCallbacksPending == 0 && multi->m_cleanupAsyncBlock)
+    if (cleanupAsyncBlock)
     {
-        // If CurlMulti::CleanupAsync was called and there are no remaining task queue callbacks, schedule cleanup now
-        // Release the lock before going any further because the multi may be destroyed before this method returns
-        lock.unlock();
-        HRESULT hr = XAsyncSchedule(multi->m_cleanupAsyncBlock, 0);
+        // Must not reference CurlMulti object memory or hold CurlMulti object lock when scheduling this work.
+        HRESULT hr = XAsyncSchedule(cleanupAsyncBlock, 0);
         if (FAILED(hr))
         {
             HC_TRACE_ERROR_HR(HTTPCLIENT, hr, "CurlMulti::TaskQueueCallback: Failed to schedule CleanupAsyncProvider!");


### PR DESCRIPTION
* Remove race condition between CurlMulti::CleanupAsyncProvider Begin releasing the CurlMulti mutex and CurlMulti::CleanupAsyncProvider DoWork deleting the CurlMulti.  The fix is to simply release the mutex in Begin prior to scheduling DoWork.
* Remove an extraneous case in CurlMulti::Perform where cleanup could be scheduled with a perform callback still pending. This should have been removed as part of [this](https://github.com/microsoft/libHttpClient/commit/e048d58ba951540a7f4e71e19e8c40f02fc77a8e) commit but was missed.  I believe that having that block may cause the cleanup provider to be scheduled multiple times, and could cause a double delete depending on the timing between scheduling and executing of the cleanup provider.