### PR TITLE
Sometimes XTaskQueueTerminate does not signal the queue is terminated.

### DIFF
--- a/Include/httpClient/pal.h
+++ b/Include/httpClient/pal.h
@@ -145,6 +145,7 @@ typedef void* HANDLE;
 #define E_ABORT                                 _HRESULTYPEDEF_(0x80004004L)
 #define E_FAIL                                  _HRESULTYPEDEF_(0x80004005L)
 #define E_ACCESSDENIED                          _HRESULTYPEDEF_(0x80070005L)
+#define E_HANDLE                                _HRESULTYPEDEF_(0x80070006L)
 #define E_PENDING                               _HRESULTYPEDEF_(0x8000000AL)
 #define E_UNEXPECTED                            _HRESULTYPEDEF_(0x8000FFFFL)
 #define E_POINTER                               _HRESULTYPEDEF_(0x80004003L)

--- a/Source/Common/pch_common.h
+++ b/Source/Common/pch_common.h
@@ -130,6 +130,10 @@ HC_DECLARE_TRACE_AREA(WEBSOCKET);
 #define ASYNC_LIB_TRACE(result, message)            \
     HC_TRACE_ERROR_HR(HTTPCLIENT, result, message); \
 
+// Game runtime specific error symbols we convert to standard
+// values
+#define E_GAMERUNTIME_INVALID_HANDLE E_HANDLE
+
 // Handle tracking for TaskQueue
 #define SYSTEM_HANDLE_DEFINE_HELPERS(a, b)
 #define SystemHandleAssert(h)
@@ -138,6 +142,9 @@ HC_DECLARE_TRACE_AREA(WEBSOCKET);
 
 // We always use unique handles
 #define USE_UNIQUE_HANDLES() (true)
+
+// We don't use runtime iterations
+#define GetCurrentRuntimeIteration() 0
 
 #define CATCH_RETURN() CATCH_RETURN_IMPL(__FILE__, __LINE__)
 

--- a/Source/Task/LocklessQueue.h
+++ b/Source/Task/LocklessQueue.h
@@ -95,7 +95,8 @@ public:
         m_localHeap(*this),
         m_heap(m_localHeap),
         m_activeList(*this),
-        m_blockCache(nullptr)
+        m_blockCache(nullptr),
+        m_sync{}
     {
         m_localHeap.init(blockSize);
         Initialize();
@@ -114,7 +115,8 @@ public:
         m_localHeap(*this),
         m_heap(shared.m_heap),
         m_activeList(*this),
-        m_blockCache(nullptr)
+        m_blockCache(nullptr),
+        m_sync{}
     {
         Initialize();
     }
@@ -280,9 +282,15 @@ public:
     // If the callback returns true, it is taking ownership of the data and the
     // address. If it returns false, the node is placed back on the queue.
     //
-    // This is a lock-free call: if there are interleaving calls to push_back
-    // while this action is in progress final node order is not guaranteed (nodes
-    // this API processes may be interleaved with newly pushed nodes).
+    // This call is not completely lock-free. It does not impact calls to
+    // push or pop items from the queue, but it does guard against multiple
+    // calls to remove_if with a spinlock. This guarantees that all calls to
+    // remove_if "see" all the nodes, but makes the call non-reentrant. Don't
+    // call remove_if from the callback or you will busy wait.
+    //
+    // If there are interleaving calls to push_back while this action is in
+    // progress final node order is not guaranteed (nodes this API processes
+    // may be interleaved with newly pushed nodes).
     //
     template <typename TCallback>
     void remove_if(TCallback callback)
@@ -290,6 +298,8 @@ public:
         LocklessQueue<TData> retain(*this);
         TData entry;
         uint64_t address;
+
+        SpinLock(this);
 
         while (pop_front(entry, address))
         {
@@ -754,7 +764,27 @@ private:
     Heap& m_heap;
     List m_activeList;
     std::atomic<Block*> m_blockCache;
-    
+    std::atomic_flag m_sync;
+
+    // SpinLock - in very specific cases TaskQueue may need to block
+    // other operations. SpinLock can do this, but is not re-entrant.
+    class SpinLock
+    {
+    public:
+        SpinLock(_In_ LocklessQueue<TData>* queue) : m_queue(*queue)
+        {
+            while (m_queue.m_sync.test_and_set());
+        }
+
+        ~SpinLock()
+        {
+            m_queue.m_sync.clear();
+        }
+
+    private:
+        LocklessQueue<TData> m_queue;
+    };
+
     /*
      *
      * Private APIs

--- a/Source/Task/TaskQueueImpl.h
+++ b/Source/Task/TaskQueueImpl.h
@@ -485,7 +485,8 @@ private:
 
 inline ITaskQueue* GetQueue(XTaskQueueHandle handle)
 {
-    if (handle->m_signature != TASK_QUEUE_SIGNATURE)
+    if (handle->m_signature != TASK_QUEUE_SIGNATURE ||
+        handle->m_runtimeIteration != GetCurrentRuntimeIteration())
     {
         SystemHandleAssert(handle);
         ASSERT("Invalid XTaskQueueHandle");

--- a/Source/Task/TaskQueueP.h
+++ b/Source/Task/TaskQueueP.h
@@ -157,18 +157,19 @@ struct ITaskQueue : IApi
         _In_opt_ XTaskQueueTerminatedCallback* callback) = 0;         
 };
 
-// Defines the structure that backs a XTaskQueueHandle.  This structure can never
-// change, nor can its signature.
+// Defines the structure that backs an XTaskQueueHandle.
 struct XTaskQueueObject
 {
     uint32_t m_signature;
+    uint32_t m_runtimeIteration;
     ITaskQueue* m_queue;
 };
 
-// Ditto for backing XTaskQueuePortHandle
+// Defines the structure that backs an XTaskQueuePortObject
 struct XTaskQueuePortObject
 {
     uint32_t m_signature;
+    uint32_t m_runtimeIteration;
     ITaskQueuePort* m_port;
     ITaskQueue* m_queue;
 };

--- a/Tests/UnitTests/Support/TE/UnitTestIncludes_TE.h
+++ b/Tests/UnitTests/Support/TE/UnitTestIncludes_TE.h
@@ -110,6 +110,9 @@ NAMESPACE_XBOX_HTTP_CLIENT_TEST_END
 #define VERIFY_SUCCEEDED(x) \
     xbox::httpclienttest::AssertHelper::AreEqual(S_OK, (HRESULT)x)
 
+#define VERIFY_FAILED(x) \
+    Assert::IsTrue(FAILED((HRESULT)x))
+
 #define VERIFY_FAIL() \
     Assert::Fail()
 

--- a/Tests/UnitTests/Tests/TaskQueueTests.cpp
+++ b/Tests/UnitTests/Tests/TaskQueueTests.cpp
@@ -223,7 +223,7 @@ public:
             XTaskQueueCloseHandle(dups[idx]);
         }
 
-        VERIFY_ARE_EQUAL(E_INVALIDARG, XTaskQueueDuplicateHandle(dups[0], &dups[1]));
+        VERIFY_FAILED(XTaskQueueDuplicateHandle(dups[0], &dups[1]));
         XTaskQueueCloseHandle(queue);
     }
 


### PR DESCRIPTION
Sometimes XTaskQueueTerminate does not actually terminate the queue. If you wait for this to complete it never does.

The problem turned out to be how we are using lockfreequeue::remove_if.  This API works by popping all items off the queue, invoking a callback, and items that the callback returned false for are placed on a temporary queue and later added back.

If two threads are running at the same time, it is possible for T2 to hide items T1 wants, and vice versa.

The fix for this is just to spinlock in remove_if. The duration of time spent inside this is very small, and contention is very rare.

This change also picks up changes form the OS repo that we didn't propagate. The OS code moved to a different HRESULT for bad handles and a "runtime iteration" that allows the runtime to be reloaded.