### PR TITLE
address compiler warnings

### DIFF
--- a/Source/Task/LocklessQueue.h
+++ b/Source/Task/LocklessQueue.h
@@ -56,8 +56,10 @@
  ******************************************************************************/
 
 // LocklessQueue needs certain alignment.  Disable alignment warning.
+#if _WIN32
 #pragma warning(push)
 #pragma warning(disable: 4324)
+#endif
 
 template <typename TData>
 class alignas(8) LocklessQueue
@@ -868,4 +870,6 @@ private:
     }
 };
 
+#if _WIN32
 #pragma warning(pop)
+#endif

--- a/Source/WebSocket/Websocketpp/websocketpp_websocket.cpp
+++ b/Source/WebSocket/Websocketpp/websocketpp_websocket.cpp
@@ -18,7 +18,7 @@
 
 #ifdef _WIN32
 #pragma warning( push )
-#pragma warning( disable : 4100 4127 4512 4996 4701 4267 )
+#pragma warning( disable : 4100 4127 4512 4996 4701 4267 4244 )
 #define _WEBSOCKETPP_CPP11_STL_
 #define _WEBSOCKETPP_CONSTEXPR_TOKEN_
 #define _SCL_SECURE_NO_WARNINGS
@@ -30,8 +30,6 @@
 #pragma clang diagnostic ignored "-Wdocumentation"
 #pragma clang diagnostic ignored "-Wshorten-64-to-32"
 #endif
-
-#pragma warning(disable: 4244) 
 
 #include <websocketpp/config/asio_client.hpp>
 #include <websocketpp/config/asio_no_tls_client.hpp>


### PR DESCRIPTION
* Fixes unknown-pragma warnings for non-MSC compilers in `LocklessQueue.h`.
* Suppress 64-to-32-bit shortening compiler warning for newer versions of MSC (warning 4244) in `websocketpp_websocket.cpp`.

from https://github.com/microsoft/libHttpClient/pull/861