### PR TITLE
Expose perform count for telemetry

### DIFF
--- a/Build/libHttpClient.GDK/libHttpClient.GDK.def
+++ b/Build/libHttpClient.GDK/libHttpClient.GDK.def
@@ -14,6 +14,7 @@ EXPORTS
     HCHttpCallGetContext
     HCHttpCallGetId
     HCHttpCallGetRequestUrl
+    HCHttpCallGetPerformCount
     HCHttpCallPerformAsync
     HCHttpCallRequestEnableGzipCompression
     HCHttpCallRequestGetHeader

--- a/Build/libHttpClient.Win32/libHttpClient.Win32.def
+++ b/Build/libHttpClient.Win32/libHttpClient.Win32.def
@@ -14,6 +14,7 @@ EXPORTS
     HCHttpCallGetContext
     HCHttpCallGetId
     HCHttpCallGetRequestUrl
+    HCHttpCallGetPerformCount
     HCHttpCallPerformAsync
     HCHttpCallRequestEnableGzipCompression
     HCHttpCallRequestGetHeader

--- a/Include/httpClient/httpClient.h
+++ b/Include/httpClient/httpClient.h
@@ -310,6 +310,18 @@ STDAPI HCHttpCallGetRequestUrl(
     _Outptr_result_z_ const char** url
     ) noexcept;
 
+/// <summary>
+/// Gets the number of times the HTTP call has been performed.
+/// </summary>
+/// <param name="call">The handle of the HTTP call.</param>
+/// <param name="performCount">The number of times the HTTP call has been performed.</param>
+/// <returns>Result code for this API operation.  Possible values are S_OK, E_INVALIDARG, or E_FAIL.</returns>
+/// <remarks>This should only be called after calling HCHttpCallPerformAsync when the HTTP task is completed.</remarks>
+STDAPI HCHttpCallGetPerformCount(
+    _In_ HCCallHandle call,
+    _Out_ uint32_t* performCount
+) noexcept;
+
 /////////////////////////////////////////////////////////////////////////////////////////
 // HttpCallRequest Set APIs
 //

--- a/Source/HTTP/httpcall.h
+++ b/Source/HTTP/httpcall.h
@@ -32,6 +32,7 @@ public:
 
     // Entry point for HCHttpCallPerformAsync
     HRESULT PerformAsync(XAsyncBlock* async) noexcept;
+    uint32_t GetPerformCount() const noexcept { return m_iterationNumber; }
 
     // Request ID for logging
     const uint64_t id;

--- a/Source/HTTP/httpcall_publics.cpp
+++ b/Source/HTTP/httpcall_publics.cpp
@@ -137,3 +137,15 @@ try
     return S_OK;
 }
 CATCH_RETURN()
+
+STDAPI HCHttpCallGetPerformCount(
+    _In_ HCCallHandle call,
+    _Out_ uint32_t* performCount
+) noexcept
+try
+{
+    RETURN_HR_IF(E_INVALIDARG, !call || !performCount);
+    *performCount = call->GetPerformCount();
+    return S_OK;
+}
+CATCH_RETURN()


### PR DESCRIPTION
Until now, iterationNumber has only been used for delay calculations and tracing. New telemetry in upper layers includes reporting retry counts for some calls and it may also be included for future telemetry as well.