### PR TITLE
Fix for Android build on NDK versions 27+

### DIFF
--- a/Build/libHttpClient.Android/CMakeLists.txt
+++ b/Build/libHttpClient.Android/CMakeLists.txt
@@ -88,6 +88,11 @@ if (NOT DEFINED HC_NOZLIB)
     "${PATH_TO_ROOT}/External/zlib"
     "${PATH_TO_ROOT}/External/zlib/contrib/minizip"
  )
+
+ set_source_files_properties(
+     "${PATH_TO_ROOT}/External/zlib/contrib/minizip/ioapi.c"
+     PROPERTIES COMPILE_DEFINITIONS "MINIZIP_FOPEN_NO_64=1"
+ )
 endif()
 
  set(COMMON_INCLUDE_DIRS
@@ -106,6 +111,11 @@ endif()
 set(ANDROID_INCLUDE_DIRS
     "${PATH_TO_ROOT}/External/opensslGeneratedHeaders/android"
     )
+
+add_compile_options(
+    $<$<COMPILE_LANGUAGE:CXX>:-Wno-error=implicit-function-declaration>
+    $<$<COMPILE_LANGUAGE:C>:-Wno-error=implicit-function-declaration>
+)
 
 #########################
 ### Set up static lib ###


### PR DESCRIPTION
* Fixes build issues we're seeing in PlayFab pipelines where we're building with NDK 27+
