### PR TITLE
Fix the handling of multiple callbacks to be more threadsafe

### DIFF
--- a/Include/httpClient/trace.h
+++ b/Include/httpClient/trace.h
@@ -28,7 +28,7 @@ extern "C"
 //
 // HC_TRACE_BUILD_LEVEL [trace level (0-5)]
 //     controls the maximum level of verbosity that will be built in the
-//     executable. To control verbosity at runtime see TraceArea. Set to 0 to 
+//     executable. To control verbosity at runtime see TraceArea. Set to 0 to
 //     completely disable tracing
 //
 // HC_TRACE_TO_DEBUGGER [0,1]
@@ -151,7 +151,7 @@ enum class HCTraceLevel : uint32_t
 /// <remarks>
 /// This function is implicitly called during HCInitialize. Initialization is reference counted, and
 /// multiple calls to HCTraceInit and HCTraceCleanup are supported as long as
-/// each call to HCTraceInit is paired with exactly one call to HCTraceCleanup. Client callbacks will 
+/// each call to HCTraceInit is paired with exactly one call to HCTraceCleanup. Client callbacks will
 /// all be cleared each time HCTraceCleanup is called.
 /// </remarks>
 STDAPI_(void) HCTraceInit() noexcept;
@@ -185,7 +185,7 @@ STDAPI HCSettingsGetTraceLevel(
 
 /// <summary>
 /// Register callback for tracing so that the client can merge tracing into their
-/// own traces. 
+/// own traces.
 /// </summary>
 typedef void (CALLBACK HCTraceCallback)(
     _In_z_ const char* areaName,
@@ -201,7 +201,7 @@ typedef void (CALLBACK HCTraceCallback)(
 /// </summary>
 /// <param name="callback">Trace callback.</param>
 /// <returns></returns>
-STDAPI_(void) HCTraceSetClientCallback(_In_opt_ HCTraceCallback* callback) noexcept;
+STDAPI_(bool) HCTraceSetClientCallback(_In_opt_ HCTraceCallback* callback) noexcept;
 
 /// <summary>
 /// Sets or unsets if the trace is sent to the debugger.
@@ -352,7 +352,7 @@ typedef struct HCTraceImplArea
 } HCTraceImplArea;
 
 /// <summary>
-/// Set the verbosity level of an trace area. 
+/// Set the verbosity level of an trace area.
 /// </summary>
 /// <param name="area">The trace area.</param>
 /// <param name="verbosity">The verbosity level.</param>
@@ -420,7 +420,7 @@ private:
 };
 
 /// <summary>
-/// HCTraceImplScopeHelper constructor. This should be accessed through macros, such as HC_TRACE_SCOPE, 
+/// HCTraceImplScopeHelper constructor. This should be accessed through macros, such as HC_TRACE_SCOPE,
 /// rather than called directly.
 /// </summary>
 /// <param name="area">The trace area.</param>

--- a/Source/Logger/trace.cpp
+++ b/Source/Logger/trace.cpp
@@ -178,7 +178,7 @@ void TraceMessageToDebugger(
     {
         return;
     }
-    
+
     static size_t const BUFFER_SIZE = 4096;
     char outputBuffer[BUFFER_SIZE] = {};
     FormatTrace(areaName, level, threadId, timestamp, message, outputBuffer);
@@ -199,7 +199,7 @@ void TraceMessageToClient(
     {
         if (traceState.clientCallbacks[i])
         {
-            traceState.clientCallbacks[i](areaName, level, threadId, timestamp, message);
+            traceState.clientCallbacks[i].load()(areaName, level, threadId, timestamp, message);
         }
     }
 }
@@ -237,9 +237,9 @@ STDAPI_(void) HCTraceSetTraceToDebugger(_In_ bool traceToDebugger) noexcept
     GetTraceState().SetTraceToDebugger(traceToDebugger);
 }
 
-STDAPI_(void) HCTraceSetClientCallback(_In_opt_ HCTraceCallback* callback) noexcept
+STDAPI_(bool) HCTraceSetClientCallback(_In_opt_ HCTraceCallback* callback) noexcept
 {
-    GetTraceState().SetClientCallback(callback);
+    return GetTraceState().SetClientCallback(callback);
 }
 
 #if HC_PLATFORM_IS_MICROSOFT
@@ -386,18 +386,20 @@ void TraceState::SetEtwEnabled(_In_ bool etwEnabled) noexcept
 }
 #endif
 
-void TraceState::SetClientCallback(HCTraceCallback* callback) noexcept
+bool TraceState::SetClientCallback(HCTraceCallback* callback) noexcept
 {
     // Try to add a client callback. If MAX_TRACE_CLIENTS have already set callbacks, the callback won't be set
     // and the client will not get trace callbacks.
     for (size_t i = 0; i < MAX_TRACE_CLIENTS; ++i)
     {
-        if (clientCallbacks[i] == nullptr)
+        // the first argument of compare exchange is in/out
+        HCTraceCallback* oldVal = nullptr;
+        if (clientCallbacks[i].compare_exchange_strong(oldVal, callback))
         {
-            clientCallbacks[i] = callback;
-            break;
+            return true;
         }
     }
+    return false;
 }
 
 uint64_t TraceState::GetTimestamp() const noexcept

--- a/Source/Logger/trace_internal.h
+++ b/Source/Logger/trace_internal.h
@@ -13,14 +13,14 @@ public:
     bool IsSetup() const noexcept;
     bool GetTraceToDebugger() noexcept;
     void SetTraceToDebugger(_In_ bool traceToDebugger) noexcept;
-    void SetClientCallback(HCTraceCallback* callback) noexcept;
+    bool SetClientCallback(HCTraceCallback* callback) noexcept;
     uint64_t GetTimestamp() const noexcept;
     bool GetEtwEnabled() const noexcept;
 #if HC_PLATFORM_IS_MICROSOFT
     void SetEtwEnabled(_In_ bool enabled) noexcept;
 #endif
 
-    HCTraceCallback* clientCallbacks[MAX_TRACE_CLIENTS]{};
+    std::atomic<HCTraceCallback*> clientCallbacks[MAX_TRACE_CLIENTS]{};
 
 private:
     std::atomic<uint32_t> m_tracingClients{ 0 };


### PR DESCRIPTION
Use atomic operations to avoid races between multiple calls to `HCTraceSetClientCallback` and `TraceMessageToClient`