### PR TITLE
Fix local reference table overflow for Android 32bit device

### DIFF
--- a/Source/WebSocket/Android/AndroidWebSocketProvider.cpp
+++ b/Source/WebSocket/Android/AndroidWebSocketProvider.cpp
@@ -85,10 +85,14 @@ struct HttpClientWebSocket
         const jstring headerValue = env->NewStringUTF(value);
         if (HadException(env) || !headerValue)
         {
+            env->DeleteLocalRef(headerName);
             return E_UNEXPECTED;
         }
 
         env->CallVoidMethod(m_webSocket, m_addHeader, headerName, headerValue);
+        env->DeleteLocalRef(headerName);
+        env->DeleteLocalRef(headerValue);
+
         if (HadException(env))
         {
             return E_UNEXPECTED;
@@ -119,10 +123,14 @@ struct HttpClientWebSocket
         const jstring javaSubProtocol = env->NewStringUTF(subProtocol.c_str());
         if (HadException(env) || !javaSubProtocol)
         {
+            env->DeleteLocalRef(javaUri);
             return E_UNEXPECTED;
         }
 
         env->CallVoidMethod(m_webSocket, m_connect, javaUri, javaSubProtocol);
+        env->DeleteLocalRef(javaUri);
+        env->DeleteLocalRef(javaSubProtocol);
+
         if (HadException(env))
         {
             return E_UNEXPECTED;
@@ -149,6 +157,7 @@ struct HttpClientWebSocket
         {
             return E_UNEXPECTED;
         }
+        env->DeleteLocalRef(javaMessage);
 
         const jboolean result = env->CallBooleanMethod(m_webSocket, m_sendMessage, javaMessage);
         if (HadException(env))
@@ -188,6 +197,7 @@ struct HttpClientWebSocket
         {
             return E_UNEXPECTED;
         }
+        env->DeleteLocalRef(buffer);
 
         return result ? S_OK : E_FAIL;
     }
@@ -337,7 +347,9 @@ private:
             return nullptr;
         }
 
-        return env->NewGlobalRef(localRef);
+        jobject globalRef = env->NewGlobalRef(localRef);
+        env->DeleteLocalRef(localRef);
+        return globalRef;
     }
 
     static bool HadException(JNIEnv* env)

--- a/Source/WebSocket/Android/AndroidWebSocketProvider.cpp
+++ b/Source/WebSocket/Android/AndroidWebSocketProvider.cpp
@@ -79,13 +79,20 @@ struct HttpClientWebSocket
         const jstring headerName = env->NewStringUTF(name);
         if (HadException(env) || !headerName)
         {
+            if (headerName)
+            {
+                env->DeleteLocalRef(headerName);
+            }
             return E_UNEXPECTED;
         }
 
         const jstring headerValue = env->NewStringUTF(value);
         if (HadException(env) || !headerValue)
         {
-            env->DeleteLocalRef(headerName);
+            if (headerValue)
+            {
+                env->DeleteLocalRef(headerValue);
+            }
             return E_UNEXPECTED;
         }
 
@@ -117,13 +124,20 @@ struct HttpClientWebSocket
         const jstring javaUri = env->NewStringUTF(uri.c_str());
         if (HadException(env) || !javaUri)
         {
+            if (javaUri)
+            {
+                env->DeleteLocalRef(javaUri);
+            }
             return E_UNEXPECTED;
         }
 
         const jstring javaSubProtocol = env->NewStringUTF(subProtocol.c_str());
         if (HadException(env) || !javaSubProtocol)
         {
-            env->DeleteLocalRef(javaUri);
+            if (javaSubProtocol)
+            {
+                env->DeleteLocalRef(javaSubProtocol);
+            }
             return E_UNEXPECTED;
         }
 
@@ -157,9 +171,10 @@ struct HttpClientWebSocket
         {
             return E_UNEXPECTED;
         }
-        env->DeleteLocalRef(javaMessage);
 
         const jboolean result = env->CallBooleanMethod(m_webSocket, m_sendMessage, javaMessage);
+        env->DeleteLocalRef(javaMessage);
+
         if (HadException(env))
         {
             return E_UNEXPECTED;
@@ -189,15 +204,19 @@ struct HttpClientWebSocket
         const jobject buffer = env->NewDirectByteBuffer(const_cast<uint8_t*>(data), static_cast<jlong>(dataSize));
         if (HadException(env) || !buffer)
         {
+            if (buffer)
+            {
+                env->DeleteLocalRef(buffer);
+            }
             return E_UNEXPECTED;
         }
 
         const jboolean result = env->CallBooleanMethod(m_webSocket, m_sendBinaryMessage, buffer);
+        env->DeleteLocalRef(buffer);
         if (HadException(env))
         {
             return E_UNEXPECTED;
         }
-        env->DeleteLocalRef(buffer);
 
         return result ? S_OK : E_FAIL;
     }


### PR DESCRIPTION
I am seeing the program crash at `JNI ERROR (app bug): local reference table overflow (max=512)` when running a bunch of tests on Arm7 Android devices, and I don't see this crash on 64 bit devices.

Copilot tells me it's because "On 32-bit Android, the local reference table size is limited to 512 entries by default, On 64-bit Android, the limit is much higher (sometimes ~5120)". I am not sure the architecture difference behind here, but DeleteLocalRef is the right fix after seeing this crash https://stackoverflow.com/questions/26685491/jni-error-app-bug-local-reference-table-overflow-max-512.

Verification: I don't see crash any more on x64 and Arm7