### PR TITLE
Fix local reference table overflow for Android 32bit device

### DIFF
--- a/Source/WebSocket/Android/AndroidWebSocketProvider.cpp
+++ b/Source/WebSocket/Android/AndroidWebSocketProvider.cpp
@@ -79,16 +79,27 @@ struct HttpClientWebSocket
         const jstring headerName = env->NewStringUTF(name);
         if (HadException(env) || !headerName)
         {
+            if (headerName)
+            {
+                env->DeleteLocalRef(headerName);
+            }
             return E_UNEXPECTED;
         }
 
         const jstring headerValue = env->NewStringUTF(value);
         if (HadException(env) || !headerValue)
         {
+            if (headerValue)
+            {
+                env->DeleteLocalRef(headerValue);
+            }
             return E_UNEXPECTED;
         }
 
         env->CallVoidMethod(m_webSocket, m_addHeader, headerName, headerValue);
+        env->DeleteLocalRef(headerName);
+        env->DeleteLocalRef(headerValue);
+
         if (HadException(env))
         {
             return E_UNEXPECTED;
@@ -113,16 +124,27 @@ struct HttpClientWebSocket
         const jstring javaUri = env->NewStringUTF(uri.c_str());
         if (HadException(env) || !javaUri)
         {
+            if (javaUri)
+            {
+                env->DeleteLocalRef(javaUri);
+            }
             return E_UNEXPECTED;
         }
 
         const jstring javaSubProtocol = env->NewStringUTF(subProtocol.c_str());
         if (HadException(env) || !javaSubProtocol)
         {
+            if (javaSubProtocol)
+            {
+                env->DeleteLocalRef(javaSubProtocol);
+            }
             return E_UNEXPECTED;
         }
 
         env->CallVoidMethod(m_webSocket, m_connect, javaUri, javaSubProtocol);
+        env->DeleteLocalRef(javaUri);
+        env->DeleteLocalRef(javaSubProtocol);
+
         if (HadException(env))
         {
             return E_UNEXPECTED;
@@ -151,6 +173,8 @@ struct HttpClientWebSocket
         }
 
         const jboolean result = env->CallBooleanMethod(m_webSocket, m_sendMessage, javaMessage);
+        env->DeleteLocalRef(javaMessage);
+
         if (HadException(env))
         {
             return E_UNEXPECTED;
@@ -180,10 +204,15 @@ struct HttpClientWebSocket
         const jobject buffer = env->NewDirectByteBuffer(const_cast<uint8_t*>(data), static_cast<jlong>(dataSize));
         if (HadException(env) || !buffer)
         {
+            if (buffer)
+            {
+                env->DeleteLocalRef(buffer);
+            }
             return E_UNEXPECTED;
         }
 
         const jboolean result = env->CallBooleanMethod(m_webSocket, m_sendBinaryMessage, buffer);
+        env->DeleteLocalRef(buffer);
         if (HadException(env))
         {
             return E_UNEXPECTED;
@@ -337,7 +366,9 @@ private:
             return nullptr;
         }
 
-        return env->NewGlobalRef(localRef);
+        jobject globalRef = env->NewGlobalRef(localRef);
+        env->DeleteLocalRef(localRef);
+        return globalRef;
     }
 
     static bool HadException(JNIEnv* env)


### PR DESCRIPTION
I am seeing the program crash at `JNI ERROR (app bug): local reference table overflow (max=512)` when running a bunch of tests on Arm7 Android devices, and I don't see this crash on 64 bit devices.

Copilot tells me it's because "On 32-bit Android, the local reference table size is limited to 512 entries by default, On 64-bit Android, the limit is much higher (sometimes ~5120)". I am not sure the architecture difference behind here, but DeleteLocalRef is the right fix after seeing this crash https://stackoverflow.com/questions/26685491/jni-error-app-bug-local-reference-table-overflow-max-512.

Verification: I don't see crash any more on x64 and Arm7