### PR TITLE
Change spinlock implementation in TaskQueue to prevent CPU starvation

### DIFF
--- a/Build/libHttpClient.Apple.C/libHttpClient.xcodeproj/project.pbxproj
+++ b/Build/libHttpClient.Apple.C/libHttpClient.xcodeproj/project.pbxproj
@@ -470,6 +470,7 @@
 		D3DAA84821C0E4090009C7F6 /* TaskQueueP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TaskQueueP.h; sourceTree = "<group>"; };
 		D3DAA84921C0E4090009C7F6 /* TaskQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TaskQueue.cpp; sourceTree = "<group>"; };
 		D3DAA84A21C0E4090009C7F6 /* referenced_ptr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = referenced_ptr.h; sourceTree = "<group>"; };
+		D3DAA84B21C0E4090009C7F6 /* SpinLock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpinLock.h; sourceTree = "<group>"; };
 		D3DAA84B21C0E4090009C7F6 /* StaticArray.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StaticArray.h; sourceTree = "<group>"; };
 		D3DAA84C21C0E4090009C7F6 /* ThreadPool_stl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ThreadPool_stl.cpp; sourceTree = "<group>"; };
 		D3DAA84D21C0E4090009C7F6 /* TaskQueueImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TaskQueueImpl.h; sourceTree = "<group>"; };

--- a/Build/libHttpClient.CMake/GetCommonHCSourceFiles.cmake
+++ b/Build/libHttpClient.CMake/GetCommonHCSourceFiles.cmake
@@ -80,6 +80,7 @@ function(GET_COMMON_HC_SOURCE_FILES
         "${PATH_TO_ROOT}/Source/Task/AtomicVector.h"
         "${PATH_TO_ROOT}/Source/Task/LocklessQueue.h"
         "${PATH_TO_ROOT}/Source/Task/referenced_ptr.h"
+        "${PATH_TO_ROOT}/Source/Task/SpinLock.h"
         "${PATH_TO_ROOT}/Source/Task/StaticArray.h"
         "${PATH_TO_ROOT}/Source/Task/TaskQueue.cpp"
         "${PATH_TO_ROOT}/Source/Task/TaskQueueImpl.h"

--- a/Build/libHttpClient.XAsync/libHttpClient.XAsync.vcxitems
+++ b/Build/libHttpClient.XAsync/libHttpClient.XAsync.vcxitems
@@ -20,6 +20,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\AtomicVector.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\LocklessQueue.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\referenced_ptr.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\SpinLock.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\StaticArray.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\TaskQueueImpl.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\TaskQueueP.h" />

--- a/Build/libHttpClient.XAsync/libHttpClient.XAsync.vcxitems.filters
+++ b/Build/libHttpClient.XAsync/libHttpClient.XAsync.vcxitems.filters
@@ -30,6 +30,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\referenced_ptr.h">
       <Filter>Source\Task</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\SpinLock.h">
+      <Filter>Source\Task</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\StaticArray.h">
       <Filter>Source\Task</Filter>
     </ClInclude>

--- a/Source/Task/SpinLock.h
+++ b/Source/Task/SpinLock.h
@@ -3,6 +3,12 @@
 #include <atomic>
 #include <thread>
 
+#if defined(_WIN32) || defined(__WINDOWS__) 
+#include <intrin.h>
+#elif (defined(_M_IX86) || defined(_M_X64))
+#include <x86intrin.h>
+#endif
+
 //
 // SpinLock: A spinlock implementation based on std::atomic_flag that
 // prevents CPU starvation. SpinLock can be used as a RAII wrapper around

--- a/Source/Task/SpinLock.h
+++ b/Source/Task/SpinLock.h
@@ -1,0 +1,66 @@
+#pragma once
+#include <algorithm>
+#include <atomic>
+#include <thread>
+
+//
+// SpinLock: A spinlock implementation based on std::atomic_flag that
+// prevents CPU starvation. SpinLock can be used as a RAII wrapper around
+// an external flag, or its static Lock API may be used to lock an
+// external flag.
+//
+class SpinLock
+{
+public:
+    SpinLock(_In_ std::atomic_flag& flag) : m_lock(flag)
+    {
+        Lock(m_lock);
+    }
+
+    ~SpinLock()
+    {
+        m_lock.clear(std::memory_order_release);
+    }
+
+    static void Lock(_In_ std::atomic_flag& flag)
+    {
+        unsigned int backoff = 1;
+        constexpr unsigned int maxBackoff = 1024;
+
+        while (flag.test_and_set(std::memory_order_acquire)) {
+            for (unsigned int i = 0; i < backoff; ++i) {
+                cpu_pause();
+            }
+            
+            // Exponential backoff with cap. If we are over the cap yield
+            // this thread.
+
+            backoff = backoff << 1;
+            if (backoff >= maxBackoff)
+            {
+                backoff = maxBackoff;
+                std::this_thread::yield();
+            }
+        }
+    }
+
+private:
+    std::atomic_flag& m_lock;
+
+    static inline void cpu_pause()
+    {
+#if defined(_M_IX86) || defined(_M_X64)
+        // x86/x64: Tells CPU we're spinning
+        // Reduces energy consumption
+        // Helps avoid memory order violations
+        // Maps to PAUSE instruction
+        _mm_pause();
+#elif defined(_M_ARM) || defined(_M_ARM64)
+        // ARM: Yields to other hardware threads
+        __yield();
+#else
+        // Other platforms: No specific CPU hint
+        // Still helps due to compiler barrier
+#endif
+    }
+};


### PR DESCRIPTION
The spinlocks in TaskQueue use a trivial implementation that can cause CPU starvation on single core machines. This change inserts processor hints that a spinlock is happening and implements backoff and a yield to the CPU if the spinlock spins too much.