### PR TITLE
Update curl_Linux.bash to support Ubuntu22 builds

### DIFF
--- a/Build/libHttpClient.Linux/curl_Linux.bash
+++ b/Build/libHttpClient.Linux/curl_Linux.bash
@@ -33,10 +33,10 @@ fi
 
 if [ "$CONFIGURATION" = "Debug" ]; then
     # make libcrypto and libssl
-    ./configure --disable-shared --without-zlib --disable-dependency-tracking -with-openssl=/usr/local/ssl --enable-symbol-hiding --enable-debug
+    ./configure --disable-shared --with-zlib --disable-dependency-tracking -with-openssl=/usr/local/ssl --enable-symbol-hiding --enable-debug --without-brotli
 else
     # make libcrypto and libssl
-    ./configure --disable-shared --without-zlib --disable-dependency-tracking -with-openssl=/usr/local/ssl --enable-symbol-hiding --disable-debug
+    ./configure --disable-shared --with-zlib --disable-dependency-tracking -with-openssl=/usr/local/ssl --enable-symbol-hiding --disable-debug --without-brotli
 fi
 
 make

--- a/Utilities/Pipelines/libHttpClient.CI.yml
+++ b/Utilities/Pipelines/libHttpClient.CI.yml
@@ -137,7 +137,7 @@ jobs:
   - job: LinuxBuild
     displayName: libHttpClient Linux Build
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
     timeoutInMinutes: 180
     strategy:
       matrix:


### PR DESCRIPTION
Update Linux Build Script to be compatible with Ubuntu 22. DevOps deprecated Ubuntu20 which was the previous build target for libhttpclient. Modified build script to be compatible with Ubuntu 22.