### PR TITLE
Add support 16 KB page sizes for Android dynamic build

### DIFF
--- a/Build/libHttpClient.Android/CMakeLists.txt
+++ b/Build/libHttpClient.Android/CMakeLists.txt
@@ -149,5 +149,7 @@ target_set_flags(
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 
+# Support 16KB page sizes on 64-bit devices
+# https://developer.android.com/guide/practices/page-sizes#compile-16-kb-alignment
 set_property(TARGET "${PROJECT_NAME}"
         APPEND_STRING PROPERTY LINK_FLAGS " -Wl,-z,max-page-size=16384")

--- a/Build/libHttpClient.Android/CMakeLists.txt
+++ b/Build/libHttpClient.Android/CMakeLists.txt
@@ -148,3 +148,6 @@ target_set_flags(
 )
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+
+set_property(TARGET "${PROJECT_NAME}"
+        APPEND_STRING PROPERTY LINK_FLAGS " -Wl,-z,max-page-size=16384")


### PR DESCRIPTION
This is a follow up PR for https://github.com/microsoft/libHttpClient/pull/904.

I find the previous PR only works fine for static build of LibHttpclient, and didn't works properly for dynamic build of LibHttpclient. So adding this fix to cover dynamic build