### PR TITLE
Fix msvc C4067 warns

### DIFF
--- a/Source/HTTP/Curl/CurlMulti.cpp
+++ b/Source/HTTP/Curl/CurlMulti.cpp
@@ -257,7 +257,7 @@ HRESULT CurlMulti::Perform() noexcept
     {
         // Reschedule Perform if there are still running requests
         int workAvailable{ 0 };
-#if HC_PLATFORM == HC_PLATFORM_GDK || CURL_AT_LEAST_VERSION(7,66,0)
+#if HC_PLATFORM == HC_PLATFORM_GDK || (defined(CURL_AT_LEAST_VERSION) && CURL_AT_LEAST_VERSION(7,66,0))
         // Try curl_multi_poll first, fall back to curl_multi_wait if not available
         // For non-GDK, CURL_CALL expands directly to the symbol
         if (CURL_CALL(curl_multi_poll))

--- a/Source/HTTP/Curl/CurlMulti.cpp
+++ b/Source/HTTP/Curl/CurlMulti.cpp
@@ -257,8 +257,17 @@ HRESULT CurlMulti::Perform() noexcept
     {
         // Reschedule Perform if there are still running requests
         int workAvailable{ 0 };
-#if HC_PLATFORM == HC_PLATFORM_GDK || \
-    (defined(CURL_AT_LEAST_VERSION) && (CURL_AT_LEAST_VERSION(7,66,0)))
+#if HC_PLATFORM == HC_PLATFORM_GDK
+        // Try curl_multi_poll first, fall back to curl_multi_wait if not available
+        if (CURL_CALL(curl_multi_poll))
+        {
+            result = CURL_CALL(curl_multi_poll)(m_curlMultiHandle, nullptr, 0, POLL_TIMEOUT_MS, &workAvailable);
+        }
+        else
+        {
+            result = CURL_CALL(curl_multi_wait)(m_curlMultiHandle, nullptr, 0, POLL_TIMEOUT_MS, &workAvailable);
+        }
+#elif defined(CURL_AT_LEAST_VERSION) && CURL_AT_LEAST_VERSION(7,69,0)
         // Try curl_multi_poll first, fall back to curl_multi_wait if not available
         // For non-GDK, CURL_CALL expands directly to the symbol
         if (CURL_CALL(curl_multi_poll))

--- a/Source/HTTP/Curl/CurlMulti.cpp
+++ b/Source/HTTP/Curl/CurlMulti.cpp
@@ -257,7 +257,8 @@ HRESULT CurlMulti::Perform() noexcept
     {
         // Reschedule Perform if there are still running requests
         int workAvailable{ 0 };
-#if HC_PLATFORM == HC_PLATFORM_GDK || (defined(CURL_AT_LEAST_VERSION) && CURL_AT_LEAST_VERSION(7,66,0))
+#if HC_PLATFORM == HC_PLATFORM_GDK || \
+    (defined(CURL_AT_LEAST_VERSION) && (CURL_AT_LEAST_VERSION(7,66,0)))
         // Try curl_multi_poll first, fall back to curl_multi_wait if not available
         // For non-GDK, CURL_CALL expands directly to the symbol
         if (CURL_CALL(curl_multi_poll))


### PR DESCRIPTION
Fix this warning
```
28>D:\a\_work\1\s\external\libHttpClient\Source\HTTP\Curl\CurlMulti.cpp(260,60): warning C4067: unexpected tokens following preprocessor directive - expected a newline [D:\a\_work\1\s\external\libHttpClientGDKBuild\libhttpclient_gamecore.vcxproj] CurlProvider.cpp
```