### PR TITLE
Ignore unknown pragmas on apple

### DIFF
--- a/Include/httpClient/pal.h
+++ b/Include/httpClient/pal.h
@@ -5,7 +5,7 @@
 #endif
 
 #pragma once
-#if HC_PLATFORM != HC_PLATFORM_ANDROID && HC_PLATFORM != HC_PLATFORM_LINUX
+#if HC_PLATFORM != HC_PLATFORM_ANDROID && HC_PLATFORM != HC_PLATFORM_LINUX && !HC_PLATFORM_IS_APPLE
 #pragma warning(disable: 4062) // enumerator 'identifier' in switch of enum 'enumeration' is not handled
 #pragma warning(disable: 4702) // unreachable code
 #endif


### PR DESCRIPTION
These two pragmas are unknown in XCode. While xcode can normally handle this and treat it as only a warning, systems that build with warnings as errors will fail to build. Add a check to ignore these two pragmas if the platform is Apple (macOS or iOS)