### PR TITLE
Fix TAEF test build for ARM64

### DIFF
--- a/Build/libHttpClient.UnitTest.TAEF/libHttpClient.UnitTest.TAEF.vcxproj
+++ b/Build/libHttpClient.UnitTest.TAEF/libHttpClient.UnitTest.TAEF.vcxproj
@@ -26,6 +26,7 @@
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories Condition="'$(Platform)'=='x64'">C:\Program Files (x86)\Windows Kits\10\Testing\Development\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="'$(Platform)'=='ARM64'">C:\Program Files (x86)\Windows Kits\10\Testing\Development\lib\arm64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalLibraryDirectories Condition="'$(Platform)'=='Win32'">C:\Program Files (x86)\Windows Kits\10\Testing\Development\lib\x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>Wex.Common.lib;Msxml6.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
Could not build TAEF tests for ARM64 as Wex.Common.Lib could not be found. Fixed path in vcxproj file.