### PR TITLE
Limit global symbols on android shared lib

### DIFF
--- a/Build/libHttpClient.Android/CMakeLists.txt
+++ b/Build/libHttpClient.Android/CMakeLists.txt
@@ -89,9 +89,17 @@ if (NOT DEFINED HC_NOZLIB)
     "${PATH_TO_ROOT}/External/zlib/contrib/minizip"
  )
 
+ set(ZLIB_COMPILE_DEFINITIONS "HAVE_UNISTD_H")
+
+ # ftello and fseeko become available on minSdkVersion >= 24
+ if (ANDROID_PLATFORM_LEVEL LESS 24)
+    list(APPEND ZLIB_COMPILE_DEFINITIONS "USE_FILE32API")
+ endif()
+
+
  set_source_files_properties(
-     "${PATH_TO_ROOT}/External/zlib/contrib/minizip/ioapi.c"
-     PROPERTIES COMPILE_DEFINITIONS "MINIZIP_FOPEN_NO_64=1"
+    ${ZLIB_SOURCE_FILES}
+    PROPERTIES COMPILE_DEFINITIONS "${ZLIB_COMPILE_DEFINITIONS}"
  )
 endif()
 
@@ -109,12 +117,7 @@ endif()
     )
 
 set(ANDROID_INCLUDE_DIRS
-    "${PATH_TO_ROOT}/External/opensslGeneratedHeaders/android"
-    )
-
-add_compile_options(
-    $<$<COMPILE_LANGUAGE:CXX>:-Wno-error=implicit-function-declaration>
-    $<$<COMPILE_LANGUAGE:C>:-Wno-error=implicit-function-declaration>
+  "${PATH_TO_ROOT}/External/opensslGeneratedHeaders/android"
 )
 
 #########################
@@ -135,6 +138,25 @@ target_include_directories(
     "${ANDROID_INCLUDE_DIRS}"
     "${ZLIB_INCLUDE_DIRS}"
 )
+
+if (BUILD_SHARED_LIBS)
+  target_link_libraries(
+    "${PROJECT_NAME}"
+    PRIVATE
+      log
+      # Following should be moved to target_link_options when available with cmake 3.13
+      -Wl,--version-script,${CMAKE_CURRENT_SOURCE_DIR}/libHttpClient.Android.map.txt
+      # This causes the linker to emit an error when a version script names a
+      # symbol that is not found, rather than silently ignoring that line.
+      -Wl,--no-undefined-version
+  )
+
+  set_target_properties(
+      "${PROJECT_NAME}"
+      PROPERTIES
+      LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/libHttpClient.Android.map.txt
+  )
+endif()
 
 include("../libHttpClient.CMake/GetLibHCFlags.cmake")
 get_libhc_flags(FLAGS FLAGS_DEBUG FLAGS_RELEASE)

--- a/Build/libHttpClient.Android/build.gradle
+++ b/Build/libHttpClient.Android/build.gradle
@@ -15,6 +15,7 @@ android {
                 }
                 if (project.hasProperty("BUILD_SHARED_LIBS")) {
                     arguments << "-DBUILD_SHARED_LIBS=1"
+                    arguments << "-DANDROID_STL=c++_shared"
                 }
 
                 // Support 16KB page sizes on 64-bit devices

--- a/Build/libHttpClient.Android/libHttpClient.Android.map.txt
+++ b/Build/libHttpClient.Android/libHttpClient.Android.map.txt
@@ -1,0 +1,18 @@
+# The name used here doesn't matter. This is the name of the "version"
+# which matters when the version script is actually used to create multiple
+# versions of the same symbol, but that's not what we're doing.
+# For more info: https://developer.android.com/ndk/guides/symbol-visibility
+LIBHTTPCLIENT {
+  global:
+    # Every symbol named in this section will have "default" (that is, public)
+    # visibility.
+    HC*;
+    XAsync*;
+    XTaskQueue*;
+    Java_com_xbox_httpclient*;
+  local:
+    # Every symbol in this section will have "local" (that is, hidden)
+    # visibility. The wildcard * is used to indicate that all symbols not listed
+    # in the global section should be hidden.
+    *;
+};


### PR DESCRIPTION
This limits the global symbols on libHttpClient.Android.so to what's exposed by the public API