### PR TITLE
Upgrade okhttp to 4.9.2

### DIFF
--- a/Build/libHttpClient.Android/build.gradle
+++ b/Build/libHttpClient.Android/build.gradle
@@ -50,5 +50,5 @@ android {
 }
 
 dependencies {
-    implementation "com.squareup.okhttp3:okhttp:4.9.1"
+    implementation "com.squareup.okhttp3:okhttp:4.9.2"
 }

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -17,7 +17,7 @@ required to debug changes to any libraries licensed under the GNU Lesser General
 
 ---------------------------------------------------------
 
-com.squareup.okhttp3/okhttp 4.9.1 - Apache-2.0
+com.squareup.okhttp3/okhttp 4.9.2 - Apache-2.0
 
 
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -7,7 +7,7 @@
         "maven": {
           "GroupId": "com.squareup.okhttp3",
           "ArtifactId": "okhttp",
-          "Version": "4.9.1"
+          "Version": "4.9.2"
         }
       },
       "DevelopmentDependency": false


### PR DESCRIPTION
Bump okhttp dependency because of component governance issue of CVE-2021-0341

<img width="785" height="295" alt="image" src="https://github.com/user-attachments/assets/382a1554-ad51-41fd-84da-e7ddca4f7fcd" />
