### PR TITLE
Fix HC_CALL use-after-free in WinHttpConnection

### DIFF
--- a/Source/HTTP/WinHttp/winhttp_connection.cpp
+++ b/Source/HTTP/WinHttp/winhttp_connection.cpp
@@ -35,7 +35,7 @@ WinHttpConnection::WinHttpConnection(
     XPlatSecurityInformation&& securityInformation
 ) :
     m_hSession{ hSession },
-    m_call{ call },
+    m_call{ HCHttpCallDuplicateHandle(call) },
     m_proxyType{ proxyType },
     m_securityInformation{ std::move(securityInformation) },
     m_winHttpWebSocketExports{ WinHttpProvider::GetWinHttpWebSocketExports() }
@@ -70,6 +70,8 @@ WinHttpConnection::~WinHttpConnection()
     {
         WinHttpCloseHandle(m_hConnection);
     }
+
+    HCHttpCallCloseHandle(m_call);
 }
 
 Result<std::shared_ptr<WinHttpConnection>> WinHttpConnection::Initialize(

--- a/Source/HTTP/WinHttp/winhttp_connection.h
+++ b/Source/HTTP/WinHttp/winhttp_connection.h
@@ -283,7 +283,7 @@ private:
     HINTERNET m_hConnection = nullptr;
     HINTERNET m_hRequest = nullptr;
 
-    HCCallHandle m_call; // non-owning
+    HCCallHandle m_call; // ref-counted, released in destructor
     Uri m_uri;
     XAsyncBlock* m_asyncBlock = nullptr; // non-owning
     XPlatSecurityInformation const m_securityInformation{};


### PR DESCRIPTION
WinHttpConnection stored m_call as a raw non-owning HCCallHandle. After complete_task() calls XAsyncComplete(), the caller may close the HC_CALL, but outstanding WinHttp callbacks (e.g. WINHTTP_CALLBACK_STATUS_HANDLE_CLOSING) still access m_call for trace logging, causing a use-after-free.

Fix: take a refcount on m_call via HCHttpCallDuplicateHandle in the constructor and release it with HCHttpCallCloseHandle in the destructor, after WinHttp handles are closed. This matches the existing ownership pattern used for m_websocketCall.