### PR TITLE
Make x64 and ARM64 set HCPlatform to GDK in platform_select.props

### DIFF
--- a/platform_select.props
+++ b/platform_select.props
@@ -19,7 +19,7 @@
         <HCPlatform>XDK</HCPlatform>
       </PropertyGroup>
     </When>
-    <When Condition="'$(Platform)'=='Gaming.Desktop.x64' OR '$(Platform)'=='Gaming.Xbox.XboxOne.x64' OR '$(Platform)'=='Gaming.Xbox.Scarlett.x64'">
+    <When Condition="'$(Platform)'=='Gaming.Desktop.x64' OR '$(Platform)'=='Gaming.Xbox.XboxOne.x64' OR '$(Platform)'=='Gaming.Xbox.Scarlett.x64' OR '$(Platform)' == 'x64' OR '$(Platform)' == 'ARM64'">
       <PropertyGroup>
         <HCPlatform>GDK</HCPlatform>
       </PropertyGroup>


### PR DESCRIPTION
Need to treat Windows x64 and ARM64 builds as HCPlatform=GDK. 