### PR TITLE
Replace std::mutex with DefaultUnnamedMutex to avoid named mutex exhaustion

### DIFF
--- a/Include/httpClient/pal.h
+++ b/Include/httpClient/pal.h
@@ -13,6 +13,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <mutex>
 
 #include <httpClient/config.h>
 
@@ -494,3 +495,21 @@ enum class HCWebSocketCloseStatus : uint32_t
 };
 
 }
+
+// Sony PS5 STL library defect: std::mutex without a name parameter creates named mutexes,
+// which have a low limit. Use DefaultUnnamedMutex as a workaround so that mutexes are unnamed
+// by default.
+class DefaultUnnamedMutex : public std::mutex
+{
+public:
+#if __PROSPERO__
+    DefaultUnnamedMutex() noexcept : std::mutex(nullptr) {}
+    ~DefaultUnnamedMutex() noexcept = default;
+    DefaultUnnamedMutex(DefaultUnnamedMutex const&) = delete;
+    DefaultUnnamedMutex& operator=(DefaultUnnamedMutex const&) = delete;
+    void lock() { std::mutex::lock(); }
+    bool try_lock() { return std::mutex::try_lock(); }
+    void unlock() { std::mutex::unlock(); }
+    native_handle_type native_handle() { return std::mutex::native_handle(); }
+#endif
+};

--- a/Include/httpClient/pal.h
+++ b/Include/httpClient/pal.h
@@ -496,20 +496,21 @@ enum class HCWebSocketCloseStatus : uint32_t
 
 }
 
-// Sony PS5 STL library defect: std::mutex without a name parameter creates named mutexes,
-// which have a low limit. Use DefaultUnnamedMutex as a workaround so that mutexes are unnamed
-// by default.
-class DefaultUnnamedMutex : public std::mutex
+// On some platforms, std::mutex default construction creates named mutexes which have a low
+// system-wide limit. Mutex forces unnamed mutex construction on affected platforms.
+#if HC_PLATFORM == HC_PLATFORM_SONY_PLAYSTATION_5
+class Mutex : public std::mutex
 {
 public:
-#if __PROSPERO__
-    DefaultUnnamedMutex() noexcept : std::mutex(nullptr) {}
-    ~DefaultUnnamedMutex() noexcept = default;
-    DefaultUnnamedMutex(DefaultUnnamedMutex const&) = delete;
-    DefaultUnnamedMutex& operator=(DefaultUnnamedMutex const&) = delete;
+    Mutex() noexcept : std::mutex(nullptr) {}
+    ~Mutex() noexcept = default;
+    Mutex(Mutex const&) = delete;
+    Mutex& operator=(Mutex const&) = delete;
     void lock() { std::mutex::lock(); }
     bool try_lock() { return std::mutex::try_lock(); }
     void unlock() { std::mutex::unlock(); }
     native_handle_type native_handle() { return std::mutex::native_handle(); }
-#endif
 };
+#else
+using Mutex = std::mutex;
+#endif

--- a/Include/httpClient/pal.h
+++ b/Include/httpClient/pal.h
@@ -498,7 +498,8 @@ enum class HCWebSocketCloseStatus : uint32_t
 
 // On some platforms, std::mutex default construction creates named mutexes which have a low
 // system-wide limit. DefaultUnnamedMutex forces unnamed mutex construction on affected platforms.
-#if HC_PLATFORM == HC_PLATFORM_SONY_PLAYSTATION_5
+// Define HC_USE_UNNAMED_MUTEX in your platform build props to enable the workaround.
+#if defined(HC_USE_UNNAMED_MUTEX)
 class DefaultUnnamedMutex : public std::mutex
 {
 public:

--- a/Include/httpClient/pal.h
+++ b/Include/httpClient/pal.h
@@ -497,20 +497,20 @@ enum class HCWebSocketCloseStatus : uint32_t
 }
 
 // On some platforms, std::mutex default construction creates named mutexes which have a low
-// system-wide limit. Mutex forces unnamed mutex construction on affected platforms.
+// system-wide limit. DefaultUnnamedMutex forces unnamed mutex construction on affected platforms.
 #if HC_PLATFORM == HC_PLATFORM_SONY_PLAYSTATION_5
-class Mutex : public std::mutex
+class DefaultUnnamedMutex : public std::mutex
 {
 public:
-    Mutex() noexcept : std::mutex(nullptr) {}
-    ~Mutex() noexcept = default;
-    Mutex(Mutex const&) = delete;
-    Mutex& operator=(Mutex const&) = delete;
+    DefaultUnnamedMutex() noexcept : std::mutex(nullptr) {}
+    ~DefaultUnnamedMutex() noexcept = default;
+    DefaultUnnamedMutex(DefaultUnnamedMutex const&) = delete;
+    DefaultUnnamedMutex& operator=(DefaultUnnamedMutex const&) = delete;
     void lock() { std::mutex::lock(); }
     bool try_lock() { return std::mutex::try_lock(); }
     void unlock() { std::mutex::unlock(); }
     native_handle_type native_handle() { return std::mutex::native_handle(); }
 };
 #else
-using Mutex = std::mutex;
+using DefaultUnnamedMutex = std::mutex;
 #endif

--- a/Source/Global/NetworkState.h
+++ b/Source/Global/NetworkState.h
@@ -76,7 +76,7 @@ private:
     static void CALLBACK HttpProviderCleanupComplete(XAsyncBlock* async);
     bool ScheduleCleanup();
 
-    std::mutex m_mutex;
+    DefaultUnnamedMutex m_mutex;
 
     UniquePtr<IHttpProvider> m_httpProvider;
 

--- a/Source/Global/NetworkState.h
+++ b/Source/Global/NetworkState.h
@@ -76,7 +76,7 @@ private:
     static void CALLBACK HttpProviderCleanupComplete(XAsyncBlock* async);
     bool ScheduleCleanup();
 
-    DefaultUnnamedMutex m_mutex;
+    Mutex m_mutex;
 
     UniquePtr<IHttpProvider> m_httpProvider;
 

--- a/Source/Global/NetworkState.h
+++ b/Source/Global/NetworkState.h
@@ -76,7 +76,7 @@ private:
     static void CALLBACK HttpProviderCleanupComplete(XAsyncBlock* async);
     bool ScheduleCleanup();
 
-    Mutex m_mutex;
+    DefaultUnnamedMutex m_mutex;
 
     UniquePtr<IHttpProvider> m_httpProvider;
 

--- a/Source/Global/global.cpp
+++ b/Source/Global/global.cpp
@@ -25,11 +25,11 @@ HRESULT http_singleton::singleton_access(
     _Out_ std::shared_ptr<http_singleton>& singleton
 ) noexcept
 {
-    static std::mutex s_mutex;
+    static DefaultUnnamedMutex s_mutex;
     static std::shared_ptr<http_singleton> s_singleton{ nullptr };
     static uint8_t s_useCount{ 0 };
 
-    std::lock_guard<std::mutex> lock{ s_mutex };
+    std::lock_guard<DefaultUnnamedMutex> lock{ s_mutex };
     switch (mode)
     {
     case singleton_access_mode::create:

--- a/Source/Global/global.cpp
+++ b/Source/Global/global.cpp
@@ -25,11 +25,11 @@ HRESULT http_singleton::singleton_access(
     _Out_ std::shared_ptr<http_singleton>& singleton
 ) noexcept
 {
-    static DefaultUnnamedMutex s_mutex;
+    static Mutex s_mutex;
     static std::shared_ptr<http_singleton> s_singleton{ nullptr };
     static uint8_t s_useCount{ 0 };
 
-    std::lock_guard<DefaultUnnamedMutex> lock{ s_mutex };
+    std::lock_guard<Mutex> lock{ s_mutex };
     switch (mode)
     {
     case singleton_access_mode::create:

--- a/Source/Global/global.cpp
+++ b/Source/Global/global.cpp
@@ -25,11 +25,11 @@ HRESULT http_singleton::singleton_access(
     _Out_ std::shared_ptr<http_singleton>& singleton
 ) noexcept
 {
-    static Mutex s_mutex;
+    static DefaultUnnamedMutex s_mutex;
     static std::shared_ptr<http_singleton> s_singleton{ nullptr };
     static uint8_t s_useCount{ 0 };
 
-    std::lock_guard<Mutex> lock{ s_mutex };
+    std::lock_guard<DefaultUnnamedMutex> lock{ s_mutex };
     switch (mode)
     {
     case singleton_access_mode::create:

--- a/Source/Task/AsyncLib.cpp
+++ b/Source/Task/AsyncLib.cpp
@@ -45,7 +45,7 @@ struct AsyncState
     XAsyncBlock providerAsyncBlock { };
     XAsyncBlock* userAsyncBlock = nullptr;
     XTaskQueueHandle queue = nullptr;
-    std::mutex waitMutex;
+    DefaultUnnamedMutex waitMutex;
     std::condition_variable waitCondition;
     bool waitSatisfied = false;
 

--- a/Source/Task/AsyncLib.cpp
+++ b/Source/Task/AsyncLib.cpp
@@ -45,7 +45,7 @@ struct AsyncState
     XAsyncBlock providerAsyncBlock { };
     XAsyncBlock* userAsyncBlock = nullptr;
     XTaskQueueHandle queue = nullptr;
-    DefaultUnnamedMutex waitMutex;
+    Mutex waitMutex;
     std::condition_variable waitCondition;
     bool waitSatisfied = false;
 

--- a/Source/Task/AsyncLib.cpp
+++ b/Source/Task/AsyncLib.cpp
@@ -45,7 +45,7 @@ struct AsyncState
     XAsyncBlock providerAsyncBlock { };
     XAsyncBlock* userAsyncBlock = nullptr;
     XTaskQueueHandle queue = nullptr;
-    Mutex waitMutex;
+    DefaultUnnamedMutex waitMutex;
     std::condition_variable waitCondition;
     bool waitSatisfied = false;
 

--- a/Source/Task/AtomicVector.h
+++ b/Source/Task/AtomicVector.h
@@ -94,7 +94,7 @@ public:
 
 private:
 
-    std::mutex m_lock;
+    DefaultUnnamedMutex m_lock;
     std::vector<TElement> m_buffers[2];
     std::atomic<uint32_t> m_indexAndRef { 0 };
 };

--- a/Source/Task/AtomicVector.h
+++ b/Source/Task/AtomicVector.h
@@ -94,7 +94,7 @@ public:
 
 private:
 
-    DefaultUnnamedMutex m_lock;
+    Mutex m_lock;
     std::vector<TElement> m_buffers[2];
     std::atomic<uint32_t> m_indexAndRef { 0 };
 };

--- a/Source/Task/AtomicVector.h
+++ b/Source/Task/AtomicVector.h
@@ -94,7 +94,7 @@ public:
 
 private:
 
-    Mutex m_lock;
+    DefaultUnnamedMutex m_lock;
     std::vector<TElement> m_buffers[2];
     std::atomic<uint32_t> m_indexAndRef { 0 };
 };

--- a/Source/Task/TaskQueueImpl.h
+++ b/Source/Task/TaskQueueImpl.h
@@ -114,7 +114,7 @@ private:
     };
 
     std::atomic<uint64_t> m_nextToken{ 0 };
-    std::mutex m_lock;
+    DefaultUnnamedMutex m_lock;
     CallbackRegistration m_buffer1[SUBMIT_CALLBACK_MAX];
     CallbackRegistration m_buffer2[SUBMIT_CALLBACK_MAX];
     CallbackRegistration* m_buffers[2]= { m_buffer1, m_buffer2 };
@@ -149,7 +149,7 @@ private:
 
     std::atomic<uint64_t> m_nextToken{ 0 };
     StaticArray<WaitRegistration, QUEUE_WAIT_MAX> m_callbacks;
-    std::mutex m_lock;
+    DefaultUnnamedMutex m_lock;
 };
 
 class TaskQueuePortImpl: public Api<ApiId::TaskQueuePort, ITaskQueuePort>
@@ -257,12 +257,12 @@ private:
     std::atomic<uint32_t> m_processingSerializedTbCallback{ 0 };
     std::atomic<uint32_t> m_processingCallback{ 0 };
     std::condition_variable m_processingCallbackCv;
-    std::mutex m_lock;
+    DefaultUnnamedMutex m_lock;
     std::unique_ptr<LocklessQueue<QueueEntry>> m_queueList;
     std::unique_ptr<LocklessQueue<QueueEntry>> m_pendingList;
     std::unique_ptr<LocklessQueue<TerminationEntry*>> m_terminationList;
     std::unique_ptr<LocklessQueue<TerminationEntry*>> m_pendingTerminationList;
-    std::mutex m_terminationLock;
+    DefaultUnnamedMutex m_terminationLock;
     OS::WaitTimer m_timer;
     OS::ThreadPool m_threadPool;
     std::atomic<uint64_t> m_timerDue = { UINT64_MAX };
@@ -465,7 +465,7 @@ private:
     struct TerminationData
     {
         bool terminated;
-        std::mutex lock;
+        DefaultUnnamedMutex lock;
         std::condition_variable cv;
     };
 

--- a/Source/Task/TaskQueueImpl.h
+++ b/Source/Task/TaskQueueImpl.h
@@ -114,7 +114,7 @@ private:
     };
 
     std::atomic<uint64_t> m_nextToken{ 0 };
-    DefaultUnnamedMutex m_lock;
+    Mutex m_lock;
     CallbackRegistration m_buffer1[SUBMIT_CALLBACK_MAX];
     CallbackRegistration m_buffer2[SUBMIT_CALLBACK_MAX];
     CallbackRegistration* m_buffers[2]= { m_buffer1, m_buffer2 };
@@ -149,7 +149,7 @@ private:
 
     std::atomic<uint64_t> m_nextToken{ 0 };
     StaticArray<WaitRegistration, QUEUE_WAIT_MAX> m_callbacks;
-    DefaultUnnamedMutex m_lock;
+    Mutex m_lock;
 };
 
 class TaskQueuePortImpl: public Api<ApiId::TaskQueuePort, ITaskQueuePort>
@@ -257,12 +257,12 @@ private:
     std::atomic<uint32_t> m_processingSerializedTbCallback{ 0 };
     std::atomic<uint32_t> m_processingCallback{ 0 };
     std::condition_variable m_processingCallbackCv;
-    DefaultUnnamedMutex m_lock;
+    Mutex m_lock;
     std::unique_ptr<LocklessQueue<QueueEntry>> m_queueList;
     std::unique_ptr<LocklessQueue<QueueEntry>> m_pendingList;
     std::unique_ptr<LocklessQueue<TerminationEntry*>> m_terminationList;
     std::unique_ptr<LocklessQueue<TerminationEntry*>> m_pendingTerminationList;
-    DefaultUnnamedMutex m_terminationLock;
+    Mutex m_terminationLock;
     OS::WaitTimer m_timer;
     OS::ThreadPool m_threadPool;
     std::atomic<uint64_t> m_timerDue = { UINT64_MAX };
@@ -465,7 +465,7 @@ private:
     struct TerminationData
     {
         bool terminated;
-        DefaultUnnamedMutex lock;
+        Mutex lock;
         std::condition_variable cv;
     };
 

--- a/Source/Task/TaskQueueImpl.h
+++ b/Source/Task/TaskQueueImpl.h
@@ -114,7 +114,7 @@ private:
     };
 
     std::atomic<uint64_t> m_nextToken{ 0 };
-    Mutex m_lock;
+    DefaultUnnamedMutex m_lock;
     CallbackRegistration m_buffer1[SUBMIT_CALLBACK_MAX];
     CallbackRegistration m_buffer2[SUBMIT_CALLBACK_MAX];
     CallbackRegistration* m_buffers[2]= { m_buffer1, m_buffer2 };
@@ -149,7 +149,7 @@ private:
 
     std::atomic<uint64_t> m_nextToken{ 0 };
     StaticArray<WaitRegistration, QUEUE_WAIT_MAX> m_callbacks;
-    Mutex m_lock;
+    DefaultUnnamedMutex m_lock;
 };
 
 class TaskQueuePortImpl: public Api<ApiId::TaskQueuePort, ITaskQueuePort>
@@ -257,12 +257,12 @@ private:
     std::atomic<uint32_t> m_processingSerializedTbCallback{ 0 };
     std::atomic<uint32_t> m_processingCallback{ 0 };
     std::condition_variable m_processingCallbackCv;
-    Mutex m_lock;
+    DefaultUnnamedMutex m_lock;
     std::unique_ptr<LocklessQueue<QueueEntry>> m_queueList;
     std::unique_ptr<LocklessQueue<QueueEntry>> m_pendingList;
     std::unique_ptr<LocklessQueue<TerminationEntry*>> m_terminationList;
     std::unique_ptr<LocklessQueue<TerminationEntry*>> m_pendingTerminationList;
-    Mutex m_terminationLock;
+    DefaultUnnamedMutex m_terminationLock;
     OS::WaitTimer m_timer;
     OS::ThreadPool m_threadPool;
     std::atomic<uint64_t> m_timerDue = { UINT64_MAX };
@@ -465,7 +465,7 @@ private:
     struct TerminationData
     {
         bool terminated;
-        Mutex lock;
+        DefaultUnnamedMutex lock;
         std::condition_variable cv;
     };
 

--- a/Source/Task/ThreadPool_stl.cpp
+++ b/Source/Task/ThreadPool_stl.cpp
@@ -220,12 +220,12 @@ namespace OS
 
         std::atomic<uint32_t> m_refs{ 1 };
 
-        std::mutex m_wakeLock;
+        DefaultUnnamedMutex m_wakeLock;
         std::condition_variable m_wake;
         uint32_t m_calls{ 0 };
         bool m_terminate{ false };
 
-        std::mutex m_activeLock;
+        DefaultUnnamedMutex m_activeLock;
         std::condition_variable m_active;
         uint32_t m_activeCalls{ 0 };
 

--- a/Source/Task/ThreadPool_stl.cpp
+++ b/Source/Task/ThreadPool_stl.cpp
@@ -220,12 +220,12 @@ namespace OS
 
         std::atomic<uint32_t> m_refs{ 1 };
 
-        Mutex m_wakeLock;
+        DefaultUnnamedMutex m_wakeLock;
         std::condition_variable m_wake;
         uint32_t m_calls{ 0 };
         bool m_terminate{ false };
 
-        Mutex m_activeLock;
+        DefaultUnnamedMutex m_activeLock;
         std::condition_variable m_active;
         uint32_t m_activeCalls{ 0 };
 

--- a/Source/Task/ThreadPool_stl.cpp
+++ b/Source/Task/ThreadPool_stl.cpp
@@ -220,12 +220,12 @@ namespace OS
 
         std::atomic<uint32_t> m_refs{ 1 };
 
-        DefaultUnnamedMutex m_wakeLock;
+        Mutex m_wakeLock;
         std::condition_variable m_wake;
         uint32_t m_calls{ 0 };
         bool m_terminate{ false };
 
-        DefaultUnnamedMutex m_activeLock;
+        Mutex m_activeLock;
         std::condition_variable m_active;
         uint32_t m_activeCalls{ 0 };
 

--- a/Source/Task/WaitTimer_stl.cpp
+++ b/Source/Task/WaitTimer_stl.cpp
@@ -53,7 +53,7 @@ namespace OS
         TimerEntry const& Peek() const noexcept;
         TimerEntry Pop() noexcept;
 
-        std::mutex m_mutex;
+        DefaultUnnamedMutex m_mutex;
         std::condition_variable m_cv;
         std::vector<TimerEntry> m_queue; // used as a heap
         std::thread m_t;
@@ -64,7 +64,7 @@ namespace OS
     namespace
     {
         std::shared_ptr<TimerQueue> g_timerQueue;
-        std::mutex g_timerQueueMutex;
+        DefaultUnnamedMutex g_timerQueueMutex;
     }
 
     TimerQueue::~TimerQueue()

--- a/Source/Task/WaitTimer_stl.cpp
+++ b/Source/Task/WaitTimer_stl.cpp
@@ -53,7 +53,7 @@ namespace OS
         TimerEntry const& Peek() const noexcept;
         TimerEntry Pop() noexcept;
 
-        DefaultUnnamedMutex m_mutex;
+        Mutex m_mutex;
         std::condition_variable m_cv;
         std::vector<TimerEntry> m_queue; // used as a heap
         std::thread m_t;
@@ -64,7 +64,7 @@ namespace OS
     namespace
     {
         std::shared_ptr<TimerQueue> g_timerQueue;
-        DefaultUnnamedMutex g_timerQueueMutex;
+        Mutex g_timerQueueMutex;
     }
 
     TimerQueue::~TimerQueue()

--- a/Source/Task/WaitTimer_stl.cpp
+++ b/Source/Task/WaitTimer_stl.cpp
@@ -53,7 +53,7 @@ namespace OS
         TimerEntry const& Peek() const noexcept;
         TimerEntry Pop() noexcept;
 
-        Mutex m_mutex;
+        DefaultUnnamedMutex m_mutex;
         std::condition_variable m_cv;
         std::vector<TimerEntry> m_queue; // used as a heap
         std::thread m_t;
@@ -64,7 +64,7 @@ namespace OS
     namespace
     {
         std::shared_ptr<TimerQueue> g_timerQueue;
-        Mutex g_timerQueueMutex;
+        DefaultUnnamedMutex g_timerQueueMutex;
     }
 
     TimerQueue::~TimerQueue()

--- a/Source/WebSocket/hcwebsocket.h
+++ b/Source/WebSocket/hcwebsocket.h
@@ -181,7 +181,7 @@ private:
         void* context{ nullptr };
     };
 
-    std::mutex m_stateMutex;
+    DefaultUnnamedMutex m_stateMutex;
     enum class State
     {
         Initial,

--- a/Source/WebSocket/hcwebsocket.h
+++ b/Source/WebSocket/hcwebsocket.h
@@ -181,7 +181,7 @@ private:
         void* context{ nullptr };
     };
 
-    Mutex m_stateMutex;
+    DefaultUnnamedMutex m_stateMutex;
     enum class State
     {
         Initial,

--- a/Source/WebSocket/hcwebsocket.h
+++ b/Source/WebSocket/hcwebsocket.h
@@ -181,7 +181,7 @@ private:
         void* context{ nullptr };
     };
 
-    DefaultUnnamedMutex m_stateMutex;
+    Mutex m_stateMutex;
     enum class State
     {
         Initial,


### PR DESCRIPTION
This pull request introduces a custom mutex class, `DefaultUnnamedMutex`, to work around a platform STL defect where `std::mutex` default construction creates named mutexes — which have a low system-wide limit. The new class ensures mutexes are unnamed by default, preventing handle exhaustion under heavy concurrency. All `std::mutex` usages are replaced with `DefaultUnnamedMutex` throughout the codebase.


**STL mutex workaround:**

* Added a new `DefaultUnnamedMutex` class in `pal.h` to replace `std::mutex` and avoid named mutexes. (`Include/httpClient/pal.h` [Include/httpClient/pal.hR498-R515](diffhunk://#diff-2e12664cf1c12ab7154f961bed7bc99051a288bc8ec7a6f68582874bd4138f66R498-R515))
* Updated all instances of `std::mutex` to use `DefaultUnnamedMutex` in key classes and structures, including:
  - `NetworkState` (`Source/Global/NetworkState.h` [Source/Global/NetworkState.hL79-R79](diffhunk://#diff-8513a97a323409d961e6a23a15fb1ad9de32617d5b1a8b86e08275e8a59f58c0L79-R79))
  - `http_singleton::singleton_access` (`Source/Global/global.cpp` [Source/Global/global.cppL28-R32](diffhunk://#diff-c257c6b1b740848c5f71ec23a112b9c9730bfc781476be92d74fd880fce7fe6dL28-R32))
  - `AsyncState` (`Source/Task/AsyncLib.cpp` [Source/Task/AsyncLib.cppL48-R48](diffhunk://#diff-a619b18baf7aaf95f0355cebd934e0ead966326e6899dd2f6d4983f63dd81403L48-R48))
  - `AtomicVector` (`Source/Task/AtomicVector.h` [Source/Task/AtomicVector.hL97-R97](diffhunk://#diff-5f56ee0d8966ce4e547b3876c48c4870d3f85871446b921a1125e00c3a90828bL97-R97))
  - `SubmitCallback`, `QueueWaitRegistry`, `TaskQueuePortImpl`, `TaskQueueImpl` (`Source/Task/TaskQueueImpl.h` [[1]](diffhunk://#diff-c1d730bf851c9b07019f0e9e359245e77bc93a8da7d05283fa639eb46e8e73d3L117-R117) [[2]](diffhunk://#diff-c1d730bf851c9b07019f0e9e359245e77bc93a8da7d05283fa639eb46e8e73d3L152-R152) [[3]](diffhunk://#diff-c1d730bf851c9b07019f0e9e359245e77bc93a8da7d05283fa639eb46e8e73d3L260-R265) [[4]](diffhunk://#diff-c1d730bf851c9b07019f0e9e359245e77bc93a8da7d05283fa639eb46e8e73d3L468-R468)
  - `ThreadPool_stl.cpp` and `WaitTimer_stl.cpp` mutexes (`Source/Task/ThreadPool_stl.cpp` [[1]](diffhunk://#diff-7eb492cdcaaa98ea047a6573772338669ca8fd770daa02600152f59fed0f0837L223-R228) `Source/Task/WaitTimer_stl.cpp` [[2]](diffhunk://#diff-7da77f3d1a8e3931004f1e1fc2b2b9732d8af01ff1f78719c4ea3c8ffd4fc547L56-R56) [[3]](diffhunk://#diff-7da77f3d1a8e3931004f1e1fc2b2b9732d8af01ff1f78719c4ea3c8ffd4fc547L67-R67)
  - `WebSocket` state mutex (`Source/WebSocket/hcwebsocket.h` [Source/WebSocket/hcwebsocket.hL184-R184](diffhunk://#diff-792298a7156fe7494e2d61cd97f92bc92d4b58012b1208a573c7bc30e1a04bc7L184-R184))

**General codebase update for thread safety:**

* Ensured that all lock guards and atomic operations now use `DefaultUnnamedMutex` for consistent behavior across platforms. [[1]](diffhunk://#diff-c257c6b1b740848c5f71ec23a112b9c9730bfc781476be92d74fd880fce7fe6dL28-R32) [[2]](diffhunk://#diff-c1d730bf851c9b07019f0e9e359245e77bc93a8da7d05283fa639eb46e8e73d3L260-R265)

**Header and dependency updates:**

* Included `<mutex>` in `pal.h` to support the new mutex class. (`Include/httpClient/pal.h` [Include/httpClient/pal.hR16](diffhunk://#diff-2e12664cf1c12ab7154f961bed7bc99051a288bc8ec7a6f68582874bd4138f66R16))