### PR TITLE
libHttpClient.GDK.vcxproj: PDB conflict (C1041) when built with different LibHttpClientIncludeSuffix via AdditionalProperties

### DIFF
--- a/Build/libHttpClient.GDK/libHttpClient.GDK.vcxproj
+++ b/Build/libHttpClient.GDK/libHttpClient.GDK.vcxproj
@@ -18,6 +18,16 @@
     <None Include="libHttpClient.GDK.def" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(libHttpClient.GDK.props))" />
+  <!-- Separate IntDir when building without suffix to avoid PDB conflicts with the default suffixed build -->
+  <PropertyGroup Condition="'$(LibHttpClientIncludeSuffix)' == 'false'">
+    <IntDir>$(HCIntRoot)\$(Platform)\$(Configuration)\$(MSBuildProjectName).nosuffix\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <!-- Allow concurrent PDB writes when solution and ProjectReference builds overlap -->
+      <AdditionalOptions>/FS %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup>
     <Link>
       <ModuleDefinitionFile>$(HCBuildRoot)\$(ProjectName)\$(ProjectName).def</ModuleDefinitionFile>


### PR DESCRIPTION
When libHttpClient.GDK.vcxproj is built from a solution that triggers both the default build (LibHttpClientIncludeSuffix=true) and a ProjectReference build with AdditionalProperties setting LibHttpClientIncludeSuffix=false, MSBuild treats these as separate builds but both use the same IntDir ($(HCIntRoot)\$(Platform)\$(Configuration)\libHttpClient.GDK\). Concurrent CL.EXE instances from each build collide on vc143.pdb, producing:

 error C1041: cannot open program database '...\Int\x64\Release\libHttpClient.GDK\vc143.pdb';
 if multiple CL.EXE write to the same .PDB file, please use /FS

Fix: Two changes:

 1. Separate IntDir when LibHttpClientIncludeSuffix=false so each build variant has its own intermediate directory
 2. Add /FS to ClCompile options as a safety net for concurrent PDB writes
