### PR TITLE
Use parallel make builds to speed up LibHttpClient.Linux build times

### DIFF
--- a/Build/libHttpClient.Linux/curl_Linux.bash
+++ b/Build/libHttpClient.Linux/curl_Linux.bash
@@ -39,7 +39,8 @@ else
     ./configure --disable-shared --with-zlib --disable-dependency-tracking -with-openssl=/usr/local/ssl --enable-symbol-hiding --disable-debug --without-brotli
 fi
 
-make
+MAKE_PARALLELISM="-j$(nproc)" # run Make in parallel to speed up the build process
+make $MAKE_PARALLELISM
 
 # copies binaries to final directory
 mkdir -p "$SCRIPT_DIR"/../../Out/x64/"$CONFIGURATION"/libcurl.Linux

--- a/Build/libHttpClient.Linux/libHttpClient_Linux.bash
+++ b/Build/libHttpClient.Linux/libHttpClient_Linux.bash
@@ -94,12 +94,13 @@ if [ "$BUILD_CURL" = true ]; then
     bash "$SCRIPT_DIR"/curl_Linux.bash -c "$CONFIGURATION"
 fi
 
+MAKE_PARALLELISM="-j$(nproc)" # run Make in parallel to speed up the build process
 if [ "$BUILD_STATIC" = false ]; then
     # make libHttpClient shared
     sudo cmake -S "$SCRIPT_DIR" -B "$SCRIPT_DIR"/../../Int/CMake/libHttpClient.Linux -D CMAKE_BUILD_TYPE=$CONFIGURATION -D CMAKE_C_COMPILER=$C_COMPILER -D CMAKE_CXX_COMPILER=$CXX_COMPILER -D BUILD_SHARED_LIBS=ON
-    sudo make -C "$SCRIPT_DIR"/../../Int/CMake/libHttpClient.Linux
+    sudo make $MAKE_PARALLELISM -C "$SCRIPT_DIR"/../../Int/CMake/libHttpClient.Linux
 else
     # make libHttpClient static
     sudo cmake -S "$SCRIPT_DIR" -B "$SCRIPT_DIR"/../../Int/CMake/libHttpClient.Linux -D CMAKE_BUILD_TYPE=$CONFIGURATION -D CMAKE_C_COMPILER=$C_COMPILER -D CMAKE_CXX_COMPILER=$CXX_COMPILER -D BUILD_SHARED_LIBS=OFF
-    sudo make -C "$SCRIPT_DIR"/../../Int/CMake/libHttpClient.Linux
+    sudo make $MAKE_PARALLELISM -C "$SCRIPT_DIR"/../../Int/CMake/libHttpClient.Linux
 fi

--- a/Build/libHttpClient.Linux/openssl_Linux.bash
+++ b/Build/libHttpClient.Linux/openssl_Linux.bash
@@ -29,15 +29,15 @@ sudo mkdir /usr/local/ssl/lib
 sudo mkdir /usr/local/ssl/include
 sudo mkdir /usr/local/ssl/include/openssl
 
-if [ ! -d /usr/local/ssl ] ; then
+if [ ! -d /usr/local/ssl ] ; then 
     echo "Directory /usr/local/ssl does not exist"
     exit 1
 fi
-if [ ! -d /usr/local/ssl/lib ] ; then
+if [ ! -d /usr/local/ssl/lib ] ; then 
     echo "Directory /usr/local/ssl/lib does not exist"
     exit 1
 fi
-if [ ! -d /usr/local/ssl/include/openssl ] ; then
+if [ ! -d /usr/local/ssl/include/openssl ] ; then 
     echo "Directory /usr/local/ssl/include/openssl does not exist"
     exit 1
 fi
@@ -61,9 +61,7 @@ else
     ./Configure --prefix=/usr/local/ssl --openssldir=/usr/local/ssl linux-x86_64-clang no-shared no-hw
 fi
 
-# run Make in parallel to speed up the build process
-MAKE_PARALLELISM="-j$(nproc)"
-make $MAKE_PARALLELISM CFLAGS="-fvisibility=hidden" CXXFLAGS="-fvisibility=hidden"
+make CFLAGS="-fvisibility=hidden" CXXFLAGS="-fvisibility=hidden"
 sudo make install
 # copies binaries to final directory
 mkdir -p "$SCRIPT_DIR"/../../Out/x64/"$CONFIGURATION"/libcrypto.Linux

--- a/Build/libHttpClient.Linux/openssl_Linux.bash
+++ b/Build/libHttpClient.Linux/openssl_Linux.bash
@@ -29,15 +29,15 @@ sudo mkdir /usr/local/ssl/lib
 sudo mkdir /usr/local/ssl/include
 sudo mkdir /usr/local/ssl/include/openssl
 
-if [ ! -d /usr/local/ssl ] ; then 
+if [ ! -d /usr/local/ssl ] ; then
     echo "Directory /usr/local/ssl does not exist"
     exit 1
 fi
-if [ ! -d /usr/local/ssl/lib ] ; then 
+if [ ! -d /usr/local/ssl/lib ] ; then
     echo "Directory /usr/local/ssl/lib does not exist"
     exit 1
 fi
-if [ ! -d /usr/local/ssl/include/openssl ] ; then 
+if [ ! -d /usr/local/ssl/include/openssl ] ; then
     echo "Directory /usr/local/ssl/include/openssl does not exist"
     exit 1
 fi
@@ -55,10 +55,10 @@ sed -i -e 's/\r$//' Configure
 
 if [ "$CONFIGURATION" = "Debug" ]; then
     # make libcrypto and libssl
-    ./Configure --prefix=/usr/local/ssl --openssldir=/usr/local/ssl linux-x86_64-clang no-shared no-hw -d
+    ./Configure --prefix=/usr/local/ssl --openssldir=/usr/local/ssl linux-x86_64-clang no-shared no-hw no-tests -d
 else
     # make libcrypto and libssl
-    ./Configure --prefix=/usr/local/ssl --openssldir=/usr/local/ssl linux-x86_64-clang no-shared no-hw
+    ./Configure --prefix=/usr/local/ssl --openssldir=/usr/local/ssl linux-x86_64-clang no-shared no-hw no-tests
 fi
 
 make CFLAGS="-fvisibility=hidden" CXXFLAGS="-fvisibility=hidden"

--- a/Build/libHttpClient.Linux/openssl_Linux.bash
+++ b/Build/libHttpClient.Linux/openssl_Linux.bash
@@ -61,8 +61,7 @@ else
     ./Configure --prefix=/usr/local/ssl --openssldir=/usr/local/ssl linux-x86_64-clang no-shared no-hw no-tests
 fi
 
-# run Make in parallel to speed up the build process
-MAKE_PARALLELISM="-j$(nproc)"
+MAKE_PARALLELISM="-j$(nproc)" # run Make in parallel to speed up the build process
 make $MAKE_PARALLELISM CFLAGS="-fvisibility=hidden" CXXFLAGS="-fvisibility=hidden"
 sudo make install
 # copies binaries to final directory

--- a/Build/libHttpClient.Linux/openssl_Linux.bash
+++ b/Build/libHttpClient.Linux/openssl_Linux.bash
@@ -29,15 +29,15 @@ sudo mkdir /usr/local/ssl/lib
 sudo mkdir /usr/local/ssl/include
 sudo mkdir /usr/local/ssl/include/openssl
 
-if [ ! -d /usr/local/ssl ] ; then 
+if [ ! -d /usr/local/ssl ] ; then
     echo "Directory /usr/local/ssl does not exist"
     exit 1
 fi
-if [ ! -d /usr/local/ssl/lib ] ; then 
+if [ ! -d /usr/local/ssl/lib ] ; then
     echo "Directory /usr/local/ssl/lib does not exist"
     exit 1
 fi
-if [ ! -d /usr/local/ssl/include/openssl ] ; then 
+if [ ! -d /usr/local/ssl/include/openssl ] ; then
     echo "Directory /usr/local/ssl/include/openssl does not exist"
     exit 1
 fi
@@ -61,7 +61,9 @@ else
     ./Configure --prefix=/usr/local/ssl --openssldir=/usr/local/ssl linux-x86_64-clang no-shared no-hw
 fi
 
-make CFLAGS="-fvisibility=hidden" CXXFLAGS="-fvisibility=hidden"
+# run Make in parallel to speed up the build process
+MAKE_PARALLELISM="-j$(nproc)"
+make $MAKE_PARALLELISM CFLAGS="-fvisibility=hidden" CXXFLAGS="-fvisibility=hidden"
 sudo make install
 # copies binaries to final directory
 mkdir -p "$SCRIPT_DIR"/../../Out/x64/"$CONFIGURATION"/libcrypto.Linux

--- a/Build/libHttpClient.Linux/openssl_Linux.bash
+++ b/Build/libHttpClient.Linux/openssl_Linux.bash
@@ -61,7 +61,9 @@ else
     ./Configure --prefix=/usr/local/ssl --openssldir=/usr/local/ssl linux-x86_64-clang no-shared no-hw no-tests
 fi
 
-make CFLAGS="-fvisibility=hidden" CXXFLAGS="-fvisibility=hidden"
+# run Make in parallel to speed up the build process
+MAKE_PARALLELISM="-j$(nproc)"
+make $MAKE_PARALLELISM CFLAGS="-fvisibility=hidden" CXXFLAGS="-fvisibility=hidden"
 sudo make install
 # copies binaries to final directory
 mkdir -p "$SCRIPT_DIR"/../../Out/x64/"$CONFIGURATION"/libcrypto.Linux

--- a/Build/libHttpClient.Linux/openssl_Linux.bash
+++ b/Build/libHttpClient.Linux/openssl_Linux.bash
@@ -29,15 +29,15 @@ sudo mkdir /usr/local/ssl/lib
 sudo mkdir /usr/local/ssl/include
 sudo mkdir /usr/local/ssl/include/openssl
 
-if [ ! -d /usr/local/ssl ] ; then
+if [ ! -d /usr/local/ssl ] ; then 
     echo "Directory /usr/local/ssl does not exist"
     exit 1
 fi
-if [ ! -d /usr/local/ssl/lib ] ; then
+if [ ! -d /usr/local/ssl/lib ] ; then 
     echo "Directory /usr/local/ssl/lib does not exist"
     exit 1
 fi
-if [ ! -d /usr/local/ssl/include/openssl ] ; then
+if [ ! -d /usr/local/ssl/include/openssl ] ; then 
     echo "Directory /usr/local/ssl/include/openssl does not exist"
     exit 1
 fi
@@ -55,10 +55,10 @@ sed -i -e 's/\r$//' Configure
 
 if [ "$CONFIGURATION" = "Debug" ]; then
     # make libcrypto and libssl
-    ./Configure --prefix=/usr/local/ssl --openssldir=/usr/local/ssl linux-x86_64-clang no-shared no-hw no-tests -d
+    ./Configure --prefix=/usr/local/ssl --openssldir=/usr/local/ssl linux-x86_64-clang no-shared no-hw -d
 else
     # make libcrypto and libssl
-    ./Configure --prefix=/usr/local/ssl --openssldir=/usr/local/ssl linux-x86_64-clang no-shared no-hw no-tests
+    ./Configure --prefix=/usr/local/ssl --openssldir=/usr/local/ssl linux-x86_64-clang no-shared no-hw
 fi
 
 make CFLAGS="-fvisibility=hidden" CXXFLAGS="-fvisibility=hidden"


### PR DESCRIPTION
Fix some low hanging fruit to speed up linux builds.

Prior we were running all make compilations in sequence. Now make builds openssl, curl, and the core libhttpclient code with a parallelism setting equal to the number of cores on the machine doing the build.

Additionally, specify `no-tests` in the OpenSSL build to avoid building unused OpenSSL tests

In isolated libHttpClient linux builds I'm seeing an 80% reduction in clean build times (5 min -> ~45 secs) on native linux hosts and similar reductions on WSL/crossVM builds (10 min -> ~1:30m)

this is most impactful in the innerdevloop where dev machines have lots of cores. on cloud builds reductions are much more modest. (8min->7min)