### PR TITLE
libHttpClient.Linux: remove problematic hwclock sync

### DIFF
--- a/Build/libHttpClient.Linux/install_dependencies.bash
+++ b/Build/libHttpClient.Linux/install_dependencies.bash
@@ -52,6 +52,5 @@ echo "Installing dependencies..."
 echo "Build dependencies: ${build_dependencies[*]}"
 echo "Library dependencies: ${library_dependencies[*]}"
 
-sudo hwclock --hctosys
 sudo apt-get update
 sudo apt-get -y install "${build_dependencies[@]}" "${library_dependencies[@]}"


### PR DESCRIPTION
libHttpClient linux build have long included a "just-in-case" hwclock sync. I can't say with 1000% certainty but I believe this to be a mitigation for clock drift issues likely most impactful to local WSL dev environments.

removing this hwclock sync because it's not appropriate for cloud builds and for WSL local dev work it's not really a proper mitigation either. WSL doesn't have a hardware RTC so its sort of a convenient noop that some people have suggested has some positive impact but don't quite understand. 

There may be better strategies force WSL clock sync in the future, but I don't believe they should negatively impact the core non-WSL cloud builds or other linux-first dev scenarios