### PR TITLE
Linux: Fix compiler warnings about function pointer comparisons and make linux build warning-clean

### DIFF
--- a/Build/libHttpClient.Linux/CMakeLists.txt
+++ b/Build/libHttpClient.Linux/CMakeLists.txt
@@ -168,6 +168,14 @@ target_include_directories(
     "${ZLIB_INCLUDE_DIRS}"
 )
 
+# Turn on compiler warnings for all source files.
+# For zlib, which is external, mask some of the unimportant warnings. This keeps our build output clean without
+# adding friction to taking zlib updates. If new warning show up in updates they should be assessed for impact and
+# disabled if not considered problematic.
+target_compile_options("${PROJECT_NAME}" PRIVATE -Werror)
+set_source_files_properties(${ZLIB_SOURCE_FILES} PROPERTIES COMPILE_OPTIONS "-Wno-implicit-function-declaration")
+
+
 include("../libHttpClient.CMake/GetLibHCFlags.cmake")
 get_libhc_flags(FLAGS FLAGS_DEBUG FLAGS_RELEASE)
 

--- a/Build/libHttpClient.Linux/CMakeLists.txt
+++ b/Build/libHttpClient.Linux/CMakeLists.txt
@@ -175,6 +175,8 @@ target_include_directories(
 target_compile_options("${PROJECT_NAME}" PRIVATE -Werror)
 set_source_files_properties(${ZLIB_SOURCE_FILES} PROPERTIES COMPILE_OPTIONS "-Wno-implicit-function-declaration")
 
+# allow tautological comparisons for static_assert statements verifying CURL_CALL availability
+target_compile_options("${PROJECT_NAME}" PRIVATE -Wno-tautological-compare)
 
 include("../libHttpClient.CMake/GetLibHCFlags.cmake")
 get_libhc_flags(FLAGS FLAGS_DEBUG FLAGS_RELEASE)

--- a/Build/libHttpClient.Linux/CMakeLists.txt
+++ b/Build/libHttpClient.Linux/CMakeLists.txt
@@ -170,13 +170,10 @@ target_include_directories(
 
 # Turn on compiler warnings for all source files.
 # For zlib, which is external, mask some of the unimportant warnings. This keeps our build output clean without
-# adding friction to taking zlib updates. If new warning show up in updates they should be assessed for impact and
+# adding friction to taking zlib updates. If new warnings show up in updates, they should be assessed for impact and
 # disabled if not considered problematic.
 target_compile_options("${PROJECT_NAME}" PRIVATE -Werror)
 set_source_files_properties(${ZLIB_SOURCE_FILES} PROPERTIES COMPILE_OPTIONS "-Wno-implicit-function-declaration")
-
-# allow tautological comparisons for static_assert statements verifying CURL_CALL availability
-target_compile_options("${PROJECT_NAME}" PRIVATE -Wno-tautological-compare)
 
 include("../libHttpClient.CMake/GetLibHCFlags.cmake")
 get_libhc_flags(FLAGS FLAGS_DEBUG FLAGS_RELEASE)

--- a/Source/HTTP/Curl/CurlMulti.cpp
+++ b/Source/HTTP/Curl/CurlMulti.cpp
@@ -269,9 +269,11 @@ HRESULT CurlMulti::Perform() noexcept
         }
 #elif defined(CURL_AT_LEAST_VERSION) && CURL_AT_LEAST_VERSION(7,69,0)
         // On supported non-GDK platforms with libcurl >= 7.69.0, we can call curl_multi_poll directly.
+        static_assert(CURL_CALL(curl_multi_poll) != nullptr, "curl_multi_poll must be unconditionally available");
         result = CURL_CALL(curl_multi_poll)(m_curlMultiHandle, nullptr, 0, POLL_TIMEOUT_MS, &workAvailable);
 #else
         // On supported non-GDK platforms with libcurl < 7.69.0, we must fall back to curl_multi_wait.
+        static_assert(CURL_CALL(curl_multi_wait) != nullptr, "curl_multi_wait must be unconditionally available");
         result = CURL_CALL(curl_multi_wait)(m_curlMultiHandle, nullptr, 0, POLL_TIMEOUT_MS, &workAvailable);
 #endif
 

--- a/Source/HTTP/Curl/CurlMulti.cpp
+++ b/Source/HTTP/Curl/CurlMulti.cpp
@@ -259,7 +259,7 @@ HRESULT CurlMulti::Perform() noexcept
         int workAvailable{ 0 };
 #if HC_PLATFORM == HC_PLATFORM_GDK
         // Try curl_multi_poll first, fall back to curl_multi_wait if not available
-        if (CURL_CALL(curl_multi_poll) != nullptr)
+        if (CURL_CALL(curl_multi_poll))
         {
             result = CURL_CALL(curl_multi_poll)(m_curlMultiHandle, nullptr, 0, POLL_TIMEOUT_MS, &workAvailable);
         }

--- a/Source/HTTP/Curl/CurlMulti.cpp
+++ b/Source/HTTP/Curl/CurlMulti.cpp
@@ -187,8 +187,8 @@ void CALLBACK CurlMulti::TaskQueueCallback(_In_opt_ void* context, _In_ bool can
         if (--multi->m_taskQueueCallbacksPending == 0 && multi->m_cleanupAsyncBlock)
         {
             // If CurlMulti::CleanupAsync was called and there are no remaining task queue callbacks, schedule cleanup now.
-            // We *MUST* schedule the cleanup outside of holding the lock though. Scheduling cleanup may free the CurlMulti 
-            // object memory before we're done using it here and we don't want that to happen while we're holding the lock 
+            // We *MUST* schedule the cleanup outside of holding the lock though. Scheduling cleanup may free the CurlMulti
+            // object memory before we're done using it here and we don't want that to happen while we're holding the lock
             // or still otherwise referencing the CurlMulti object memory
             cleanupAsyncBlock = multi->m_cleanupAsyncBlock;
         }
@@ -259,7 +259,7 @@ HRESULT CurlMulti::Perform() noexcept
         int workAvailable{ 0 };
 #if HC_PLATFORM == HC_PLATFORM_GDK
         // Try curl_multi_poll first, fall back to curl_multi_wait if not available
-        if (CURL_CALL(curl_multi_poll))
+        if (CURL_CALL(curl_multi_poll) != nullptr)
         {
             result = CURL_CALL(curl_multi_poll)(m_curlMultiHandle, nullptr, 0, POLL_TIMEOUT_MS, &workAvailable);
         }
@@ -268,17 +268,10 @@ HRESULT CurlMulti::Perform() noexcept
             result = CURL_CALL(curl_multi_wait)(m_curlMultiHandle, nullptr, 0, POLL_TIMEOUT_MS, &workAvailable);
         }
 #elif defined(CURL_AT_LEAST_VERSION) && CURL_AT_LEAST_VERSION(7,69,0)
-        // Try curl_multi_poll first, fall back to curl_multi_wait if not available
-        // For non-GDK, CURL_CALL expands directly to the symbol
-        if (CURL_CALL(curl_multi_poll))
-        {
-            result = CURL_CALL(curl_multi_poll)(m_curlMultiHandle, nullptr, 0, POLL_TIMEOUT_MS, &workAvailable);
-        }
-        else
-        {
-            result = CURL_CALL(curl_multi_wait)(m_curlMultiHandle, nullptr, 0, POLL_TIMEOUT_MS, &workAvailable);
-        }
+        // On supported non-GDK platforms with libcurl >= 7.69.0, we can call curl_multi_poll directly.
+        result = CURL_CALL(curl_multi_poll)(m_curlMultiHandle, nullptr, 0, POLL_TIMEOUT_MS, &workAvailable);
 #else
+        // On supported non-GDK platforms with libcurl < 7.69.0, we must fall back to curl_multi_wait.
         result = CURL_CALL(curl_multi_wait)(m_curlMultiHandle, nullptr, 0, POLL_TIMEOUT_MS, &workAvailable);
 #endif
 

--- a/Source/HTTP/Curl/CurlMulti.cpp
+++ b/Source/HTTP/Curl/CurlMulti.cpp
@@ -269,11 +269,11 @@ HRESULT CurlMulti::Perform() noexcept
         }
 #elif defined(CURL_AT_LEAST_VERSION) && CURL_AT_LEAST_VERSION(7,69,0)
         // On supported non-GDK platforms with libcurl >= 7.69.0, we can call curl_multi_poll directly.
-        static_assert(CURL_CALL(curl_multi_poll) != nullptr, "curl_multi_poll must be unconditionally available");
+        static_assert(CURL_CALL(curl_multi_poll) == curl_multi_poll, "curl_multi_poll must be unconditionally available");
         result = CURL_CALL(curl_multi_poll)(m_curlMultiHandle, nullptr, 0, POLL_TIMEOUT_MS, &workAvailable);
 #else
         // On supported non-GDK platforms with libcurl < 7.69.0, we must fall back to curl_multi_wait.
-        static_assert(CURL_CALL(curl_multi_wait) != nullptr, "curl_multi_wait must be unconditionally available");
+        static_assert(CURL_CALL(curl_multi_wait) == curl_multi_wait, "curl_multi_wait must be unconditionally available");
         result = CURL_CALL(curl_multi_wait)(m_curlMultiHandle, nullptr, 0, POLL_TIMEOUT_MS, &workAvailable);
 #endif
 


### PR DESCRIPTION
on linux, the CURL_CALL abstraction causes warnings when used in runtime comparisons because the compiler correctly recognizes that it's (1) a dangerous pointer->bool comparison and (2) entirely pointless.

remove the extra runtime CURL_CALL checking on platforms which don't need it and add static_asserts to verify this is safe to do.

bonus, enable the linux build to make warnings errors with minor exceptions for external code.

warning-free code is safer code!