### PR TITLE
Make LHC Linux Rebuilds faster and more consistent

### DIFF
--- a/Build/libHttpClient.Linux/CMakeLists.txt
+++ b/Build/libHttpClient.Linux/CMakeLists.txt
@@ -23,11 +23,6 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE ${PATH_TO_ROOT}/Out/x64/Release/libHt
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG ${PATH_TO_ROOT}/Out/x64/Debug/libHttpClient.Linux)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE ${PATH_TO_ROOT}/Out/x64/Release/libHttpClient.Linux)
 
-# BINARY_DIR is a temp folder used by cmake itself.
-# Binary folder can be remove freely.
-# See more details: https://cmake.org/cmake/help/v3.4/command/add_subdirectory.html
-set(BINARY_DIR ${PATH_TO_ROOT}/Int/CMake/libHttpClient.Linux)
-
 set(LIBCRYPTO_BINARY_PATH
     ${PATH_TO_ROOT}/Out/x64/${CMAKE_BUILD_TYPE}/libcrypto.Linux/libcrypto.a
 )

--- a/Build/libHttpClient.Linux/curl_Linux.bash
+++ b/Build/libHttpClient.Linux/curl_Linux.bash
@@ -23,15 +23,15 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-pushd "$SCRIPT_DIR"/../../External/curl
-autoreconf -fi "$SCRIPT_DIR"/../../External/curl
-
 if [ -f "$SCRIPT_DIR/../../Out/x64/$CONFIGURATION/libcurl.Linux/libcurl.a" ]; then
   echo "Previously-built library present at $SCRIPT_DIR/../../Out/x64/$CONFIGURATION/libcurl.Linux/libcurl.a - skipping build"
   exit 0
 else
   echo "No previously-built library present at $SCRIPT_DIR/../../Out/x64/$CONFIGURATION/libcurl.Linux/libcurl.a - performing build"
 fi
+
+pushd "$SCRIPT_DIR"/../../External/curl
+autoreconf -fi "$SCRIPT_DIR"/../../External/curl
 
 OPENSSL_INSTALL_DIR="$SCRIPT_DIR/../../Int/x64/$CONFIGURATION/openssl.Linux/"
 

--- a/Build/libHttpClient.Linux/libHttpClient_Linux.bash
+++ b/Build/libHttpClient.Linux/libHttpClient_Linux.bash
@@ -99,7 +99,7 @@ log "CONFIGURATION  = ${CONFIGURATION}"
 log "BUILD SSL      = ${BUILD_SSL}"
 log "BUILD CURL     = ${BUILD_CURL}"
 log "CMakeLists.txt = ${SCRIPT_DIR}"
-log "CMake output   = ${SCRIPT_DIR}/../../Int/CMake/libHttpClient.Linux"
+log "CMake output   = ${SCRIPT_DIR}/../../Int/x64/$CONFIGURATION/libHttpClient.Linux"
 
 if [ "$BUILD_UNREAL_ENGINE_4" = true ]; then
     log "Unreal Compatibility Enabled"
@@ -125,10 +125,10 @@ fi
 MAKE_PARALLELISM="-j$(nproc)" # run Make in parallel to speed up the build process
 if [ "$BUILD_STATIC" = false ]; then
     # make libHttpClient shared
-    cmake -S "$SCRIPT_DIR" -B "$SCRIPT_DIR"/../../Int/CMake/libHttpClient.Linux -D CMAKE_BUILD_TYPE=$CONFIGURATION -D CMAKE_C_COMPILER=$C_COMPILER -D CMAKE_CXX_COMPILER=$CXX_COMPILER -D BUILD_SHARED_LIBS=ON
-    make $MAKE_PARALLELISM -C "$SCRIPT_DIR"/../../Int/CMake/libHttpClient.Linux
+    cmake -S "$SCRIPT_DIR" -B "$SCRIPT_DIR"/../../Int/x64/$CONFIGURATION/libHttpClient.Linux -D CMAKE_BUILD_TYPE=$CONFIGURATION -D CMAKE_C_COMPILER=$C_COMPILER -D CMAKE_CXX_COMPILER=$CXX_COMPILER -D BUILD_SHARED_LIBS=ON
+    make $MAKE_PARALLELISM -C "$SCRIPT_DIR"/../../Int/x64/$CONFIGURATION/libHttpClient.Linux
 else
     # make libHttpClient static
-    cmake -S "$SCRIPT_DIR" -B "$SCRIPT_DIR"/../../Int/CMake/libHttpClient.Linux -D CMAKE_BUILD_TYPE=$CONFIGURATION -D CMAKE_C_COMPILER=$C_COMPILER -D CMAKE_CXX_COMPILER=$CXX_COMPILER -D BUILD_SHARED_LIBS=OFF
-    make $MAKE_PARALLELISM -C "$SCRIPT_DIR"/../../Int/CMake/libHttpClient.Linux
+    cmake -S "$SCRIPT_DIR" -B "$SCRIPT_DIR"/../../Int/x64/$CONFIGURATION/libHttpClient.Linux -D CMAKE_BUILD_TYPE=$CONFIGURATION -D CMAKE_C_COMPILER=$C_COMPILER -D CMAKE_CXX_COMPILER=$CXX_COMPILER -D BUILD_SHARED_LIBS=OFF
+    make $MAKE_PARALLELISM -C "$SCRIPT_DIR"/../../Int/x64/$CONFIGURATION/libHttpClient.Linux
 fi


### PR DESCRIPTION
when rebuilding LHC on linux I noticed two things...

1. the curl build step would take longer than expected when it all had to do was realize there were no libcurl changes and quit early.
2. if I built both Debug and Release back to back, a bunch of LHC source would be rebuilt every time. i.e. building Release would cause any build cache from Debug to be invalidated

the issue with (1) is that we were unnecessarily calling autoreconf even if we didn't intend to build

the issue with (2) was that our cmake build files were being written to the same directory regardless of the configuration and since the configurations are different, the build files are different, and they were stomping on each other.

fixes are simple: don't autoreconf if we don't need to and split the cmake buildfiles output

also cleaned up an unused BINARY_DIR variable in a cmake file