### PR TITLE
Apple frameworks: stamp CFBundleShortVersionString from $(MARKETING_VERSION)

### DIFF
--- a/Build/libHttpClient.Apple.C/libHttpClient.xcodeproj/project.pbxproj
+++ b/Build/libHttpClient.Apple.C/libHttpClient.xcodeproj/project.pbxproj
@@ -1757,6 +1757,7 @@
 				OTHER_CFLAGS = "-fembed-bitcode-marker";
 				PRODUCT_NAME = HttpClient;
 				SDKROOT = macosx;
+				MARKETING_VERSION = 1.0;
 			};
 			name = Debug;
 		};
@@ -1815,6 +1816,7 @@
 				OTHER_CFLAGS = "-fembed-bitcode";
 				PRODUCT_NAME = HttpClient;
 				SDKROOT = macosx;
+				MARKETING_VERSION = 1.0;
 			};
 			name = Release;
 		};

--- a/Utilities/FrameworkResources/Info_NOWEBSOCKETS_iOS.plist
+++ b/Utilities/FrameworkResources/Info_NOWEBSOCKETS_iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Utilities/FrameworkResources/Info_NOWEBSOCKETS_macOS.plist
+++ b/Utilities/FrameworkResources/Info_NOWEBSOCKETS_macOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Utilities/FrameworkResources/Info_iOS.plist
+++ b/Utilities/FrameworkResources/Info_iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Utilities/FrameworkResources/Info_mac.plist
+++ b/Utilities/FrameworkResources/Info_mac.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>


### PR DESCRIPTION
## Summary

Today, when libHttpClient's Apple framework targets are built with `xcodebuild MARKETING_VERSION=X.Y.Z` on the command line, the produced framework still ships with `CFBundleShortVersionString=1.0` in its `Info.plist`. The reason: the static plist files have `1.0` written as a literal, not as a `$(MARKETING_VERSION)` reference, so Xcode has nothing to substitute. This PR replaces the literals with the variable so xcodebuild's CLI override actually flows through to the framework.

## What changes

The same one-line edit in four files — only `CFBundleShortVersionString`:

- `Utilities/FrameworkResources/Info_iOS.plist`
- `Utilities/FrameworkResources/Info_mac.plist`
- `Utilities/FrameworkResources/Info_NOWEBSOCKETS_iOS.plist`
- `Utilities/FrameworkResources/Info_NOWEBSOCKETS_macOS.plist`

```diff
 <key>CFBundleShortVersionString</key>
-<string>1.0</string>
+<string>$(MARKETING_VERSION)</string>
```

`CFBundleVersion` is already wired to `$(CURRENT_PROJECT_VERSION)` in these files, so this is a one-line nudge per plist.

## Local verification

```bash
xcodebuild -workspace Build/libHttpClient.Apple.C/libHttpClient.xcworkspace \
           -scheme libHttpClientFramework_iOS -sdk iphonesimulator -configuration Release \
           MARKETING_VERSION=2.3.1 CURRENT_PROJECT_VERSION=2.3.1 build

/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' \
  <DerivedData>/Build/Products/Release-iphonesimulator/HttpClient.framework/Info.plist
```

Before this PR: `1.0`. After this PR: `2.3.1`.
