### PR TITLE
iOS build via CMake

### DIFF
--- a/Build/libHttpClient.iOS.CMake/CMakeLists.txt
+++ b/Build/libHttpClient.iOS.CMake/CMakeLists.txt
@@ -48,6 +48,7 @@ set(COMMON_SOURCE_FILES
 set(IOS_SOURCE_FILES
     # Task
     "${PATH_TO_ROOT}/Source/Task/ThreadPool_stl.cpp"
+    "${PATH_TO_ROOT}/Source/Task/WaitTimer_stl.cpp"
     "${PATH_TO_ROOT}/Source/Task/iOS/ios_WaitTimer.mm"
     "${PATH_TO_ROOT}/Source/Task/iOS/ios_WaitTimer_target.mm"
     "${PATH_TO_ROOT}/Source/Task/iOS/ios_WaitTimer_target.h"

--- a/Build/libHttpClient.iOS.CMake/CMakeLists.txt
+++ b/Build/libHttpClient.iOS.CMake/CMakeLists.txt
@@ -95,5 +95,20 @@ target_include_directories(
     "${COMMON_INCLUDE_DIRS}"
     )
 
+set_target_properties(
+    "${PROJECT_NAME}"
+    PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+    )
+
+set(IOS_MM_SOURCE_FILES
+    "${PATH_TO_ROOT}/Source/Task/iOS/ios_WaitTimer.mm"
+    "${PATH_TO_ROOT}/Source/Task/iOS/ios_WaitTimer_target.mm"
+    "${PATH_TO_ROOT}/Source/HTTP/Apple/http_apple.mm"
+    "${PATH_TO_ROOT}/Source/Common/Apple/utils_apple.mm"
+    )
+set_source_files_properties(${IOS_MM_SOURCE_FILES} PROPERTIES COMPILE_FLAGS "-fobjc-arc")
+
 message(STATUS "CMAKE_SYSTEM_VERSION='${CMAKE_SYSTEM_VERSION}'")
 message(STATUS "CMAKE_SYSTEM_NAME='${CMAKE_SYSTEM_NAME}'")

--- a/Build/libHttpClient.iOS.CMake/CMakeLists.txt
+++ b/Build/libHttpClient.iOS.CMake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.14)
 
 get_filename_component(PATH_TO_ROOT "../.." ABSOLUTE)
 

--- a/Build/libHttpClient.iOS.CMake/CMakeLists.txt
+++ b/Build/libHttpClient.iOS.CMake/CMakeLists.txt
@@ -1,0 +1,99 @@
+cmake_minimum_required(VERSION 3.6)
+
+get_filename_component(PATH_TO_ROOT "../.." ABSOLUTE)
+
+project("libHttpClient.iOS")
+
+set(HC_WEBSOCKETS FALSE)
+
+add_definitions(-D_NO_ASYNCRTIMP -D_NO_PPLXIMP -D_NO_XSAPIIMP -DXSAPI_BUILD)
+
+if(HC_WEBSOCKETS)
+    message(STATUS "websockets usage is on")
+else()
+    message(STATUS "websockets usage is off")
+    add_definitions(-DHC_NOWEBSOCKETS)
+endif()
+
+###########################################
+### Set up paths for source and include ###
+###########################################
+
+include("../libHttpClient.CMake/GetCommonHCSourceFiles.cmake")
+get_common_hc_source_files(
+    PUBLIC_SOURCE_FILES
+    HC_COMMON_SOURCE_FILES
+    GLOBAL_SOURCE_FILES
+    PLATFORM_SOURCE_FILES
+    WEBSOCKET_SOURCE_FILES
+    TASK_SOURCE_FILES
+    MOCK_SOURCE_FILES
+    HTTP_SOURCE_FILES
+    LOGGER_SOURCE_FILES
+    "${PATH_TO_ROOT}"
+    )
+
+set(COMMON_SOURCE_FILES
+    "${PUBLIC_SOURCE_FILES}"
+    "${HC_COMMON_SOURCE_FILES}"
+    "${GLOBAL_SOURCE_FILES}"
+    "${PLATFORM_SOURCE_FILES}"
+    "${WEBSOCKET_SOURCE_FILES}"
+    "${MOCK_SOURCE_FILES}"
+    "${HTTP_SOURCE_FILES}"
+    "${LOGGER_SOURCE_FILES}"
+    "${TASK_SOURCE_FILES}"
+    )
+
+set(IOS_SOURCE_FILES
+    # Task
+    "${PATH_TO_ROOT}/Source/Task/ThreadPool_stl.cpp"
+    "${PATH_TO_ROOT}/Source/Task/WaitTimer_stl.cpp"
+    "${PATH_TO_ROOT}/Source/Task/iOS/ios_WaitTimer.mm"
+    "${PATH_TO_ROOT}/Source/Task/iOS/ios_WaitTimer_target.mm"
+    "${PATH_TO_ROOT}/Source/Task/iOS/ios_WaitTimer_target.h"
+    "${PATH_TO_ROOT}/Source/Task/iOS/ios_WaitTimerImpl.h"
+    # HTTP
+    "${PATH_TO_ROOT}/Source/HTTP/Apple/http_apple.mm"
+    "${PATH_TO_ROOT}/Source/HTTP/Apple/http_apple.h"
+    # Common
+    "${PATH_TO_ROOT}/Source/Common/Apple/utils_apple.mm"
+    "${PATH_TO_ROOT}/Source/Common/Apple/utils_apple.h"
+    # Platform
+    "${PATH_TO_ROOT}/Source/Platform/Apple/PlatformComponents_Apple.cpp"
+    "${PATH_TO_ROOT}/Source/Platform/Apple/PlatformTrace_Apple.cpp"
+    )
+
+set(COMMON_INCLUDE_DIRS
+    "${PATH_TO_ROOT}/"
+    "${PATH_TO_ROOT}/Source/"
+    "${PATH_TO_ROOT}/Source/Common"
+    "${PATH_TO_ROOT}/Source/HTTP"
+    "${PATH_TO_ROOT}/Source/Logger"
+    "${PATH_TO_ROOT}/Source/Platform"
+    "${PATH_TO_ROOT}/Source/Task"
+    "${PATH_TO_ROOT}/Source/WebSocket"
+    "${PATH_TO_ROOT}/Include"
+    "${PATH_TO_ROOT}/Include/httpClient"
+    )
+
+#########################
+### Set up static lib ###
+#########################
+
+set(ALL_SOURCE_FILES ${COMMON_SOURCE_FILES} ${IOS_SOURCE_FILES})
+list(SORT ALL_SOURCE_FILES)
+
+add_library(
+    "${PROJECT_NAME}"
+    ${ALL_SOURCE_FILES}
+    )
+
+target_include_directories(
+    "${PROJECT_NAME}"
+    PRIVATE
+    "${COMMON_INCLUDE_DIRS}"
+    )
+
+message(STATUS "CMAKE_SYSTEM_VERSION='${CMAKE_SYSTEM_VERSION}'")
+message(STATUS "CMAKE_SYSTEM_NAME='${CMAKE_SYSTEM_NAME}'")

--- a/Build/libHttpClient.iOS.CMake/CMakeLists.txt
+++ b/Build/libHttpClient.iOS.CMake/CMakeLists.txt
@@ -48,7 +48,6 @@ set(COMMON_SOURCE_FILES
 set(IOS_SOURCE_FILES
     # Task
     "${PATH_TO_ROOT}/Source/Task/ThreadPool_stl.cpp"
-    "${PATH_TO_ROOT}/Source/Task/WaitTimer_stl.cpp"
     "${PATH_TO_ROOT}/Source/Task/iOS/ios_WaitTimer.mm"
     "${PATH_TO_ROOT}/Source/Task/iOS/ios_WaitTimer_target.mm"
     "${PATH_TO_ROOT}/Source/Task/iOS/ios_WaitTimer_target.h"

--- a/Build/libHttpClient.iOS.CMake/CMakeLists.txt
+++ b/Build/libHttpClient.iOS.CMake/CMakeLists.txt
@@ -6,7 +6,7 @@ project("libHttpClient.iOS")
 
 set(HC_WEBSOCKETS FALSE)
 
-add_definitions(-D_NO_ASYNCRTIMP -D_NO_PPLXIMP -D_NO_XSAPIIMP -DXSAPI_BUILD)
+add_definitions(-D_NO_ASYNCRTIMP -D_NO_PPLXIMP -D_NO_XSAPIIMP -DXSAPI_BUILD -DHC_LINK_STATIC=1)
 
 if(HC_WEBSOCKETS)
     message(STATUS "websockets usage is on")

--- a/Source/Task/iOS/ios_WaitTimer.mm
+++ b/Source/Task/iOS/ios_WaitTimer.mm
@@ -100,7 +100,7 @@ WaitTimer::~WaitTimer() noexcept
 
 HRESULT WaitTimer::Initialize(_In_opt_ void* context, _In_ WaitTimerCallback* callback) noexcept
 {
-    if (m_impl != nullptr || callback == nullptr)
+    if (m_impl.load() != nullptr || callback == nullptr)
     {
         ASSERT(false);
         return E_UNEXPECTED;
@@ -127,12 +127,12 @@ void WaitTimer::Terminate() noexcept
 
 void WaitTimer::Start(_In_ uint64_t dueTime) noexcept
 {
-    m_impl->Start(dueTime);
+    m_impl.load()->Start(dueTime);
 }
 
 void WaitTimer::Cancel() noexcept
 {
-    m_impl->Cancel();
+    m_impl.load()->Cancel();
 }
 
 uint64_t WaitTimer::GetCurrentTime() noexcept

--- a/Source/Task/iOS/ios_WaitTimer.mm
+++ b/Source/Task/iOS/ios_WaitTimer.mm
@@ -27,9 +27,6 @@ namespace
     }
 }
 
-namespace OS
-{
-
 WaitTimerImpl::WaitTimerImpl()
 : m_context(nullptr),
   m_callback(nullptr),
@@ -145,5 +142,3 @@ uint64_t WaitTimer::GetDueTime(_In_ uint32_t msFromNow) noexcept
     auto deadline = Clock::now() + std::chrono::milliseconds(msFromNow);
     return DueTimeFromDeadline(deadline);
 }
-
-} // namespace OS

--- a/Source/Task/iOS/ios_WaitTimer.mm
+++ b/Source/Task/iOS/ios_WaitTimer.mm
@@ -43,7 +43,7 @@ WaitTimerImpl::~WaitTimerImpl()
     }
 }
 
-HRESULT WaitTimerImpl::Initialize(_In_opt_ void* context, _In_ WaitTimerCallback* callback){
+HRESULT WaitTimerImpl::Initialize(_In_opt_ void* context, _In_ OS::WaitTimerCallback* callback){
     m_context = context;
     m_callback = callback;
     m_target = [ios_WaitTimer_target new];
@@ -95,7 +95,7 @@ WaitTimer::~WaitTimer() noexcept
     Terminate();
 }
 
-HRESULT WaitTimer::Initialize(_In_opt_ void* context, _In_ WaitTimerCallback* callback) noexcept
+HRESULT OS::WaitTimer::Initialize(_In_opt_ void* context, _In_ OS::WaitTimerCallback* callback) noexcept
 {
     if (m_impl != nullptr || callback == nullptr)
     {

--- a/Source/Task/iOS/ios_WaitTimer.mm
+++ b/Source/Task/iOS/ios_WaitTimer.mm
@@ -27,6 +27,9 @@ namespace
     }
 }
 
+namespace OS
+{
+
 WaitTimerImpl::WaitTimerImpl()
 : m_context(nullptr),
   m_callback(nullptr),
@@ -142,3 +145,5 @@ uint64_t WaitTimer::GetDueTime(_In_ uint32_t msFromNow) noexcept
     auto deadline = Clock::now() + std::chrono::milliseconds(msFromNow);
     return DueTimeFromDeadline(deadline);
 }
+
+} // namespace OS

--- a/Source/Task/iOS/ios_WaitTimer.mm
+++ b/Source/Task/iOS/ios_WaitTimer.mm
@@ -27,6 +27,9 @@ namespace
     }
 }
 
+namespace OS
+{
+
 WaitTimerImpl::WaitTimerImpl()
 : m_context(nullptr),
   m_callback(nullptr),
@@ -43,7 +46,7 @@ WaitTimerImpl::~WaitTimerImpl()
     }
 }
 
-HRESULT WaitTimerImpl::Initialize(_In_opt_ void* context, _In_ OS::WaitTimerCallback* callback){
+HRESULT WaitTimerImpl::Initialize(_In_opt_ void* context, _In_ WaitTimerCallback* callback){
     m_context = context;
     m_callback = callback;
     m_target = [ios_WaitTimer_target new];
@@ -95,7 +98,7 @@ WaitTimer::~WaitTimer() noexcept
     Terminate();
 }
 
-HRESULT OS::WaitTimer::Initialize(_In_opt_ void* context, _In_ OS::WaitTimerCallback* callback) noexcept
+HRESULT WaitTimer::Initialize(_In_opt_ void* context, _In_ WaitTimerCallback* callback) noexcept
 {
     if (m_impl != nullptr || callback == nullptr)
     {
@@ -142,3 +145,5 @@ uint64_t WaitTimer::GetDueTime(_In_ uint32_t msFromNow) noexcept
     auto deadline = Clock::now() + std::chrono::milliseconds(msFromNow);
     return DueTimeFromDeadline(deadline);
 }
+
+} // namespace OS

--- a/Source/Task/iOS/ios_WaitTimerImpl.h
+++ b/Source/Task/iOS/ios_WaitTimerImpl.h
@@ -11,9 +11,6 @@
 #include "../WaitTimer.h"
 #include "ios_WaitTimer_target.h"
 
-namespace OS
-{
-
 class WaitTimerImpl
 {
 public:
@@ -30,9 +27,6 @@ private:
     ios_WaitTimer_target* m_target;
     NSTimer* m_timer;
 };
-
-} // namespace OS
-
 
 
 #endif /* ios_WaitTimerImpl_h */

--- a/Source/Task/iOS/ios_WaitTimerImpl.h
+++ b/Source/Task/iOS/ios_WaitTimerImpl.h
@@ -16,14 +16,14 @@ class WaitTimerImpl
 public:
     WaitTimerImpl();
     ~WaitTimerImpl();
-    HRESULT Initialize(_In_opt_ void* context, _In_ WaitTimerCallback* callback);
+    HRESULT Initialize(_In_opt_ void* context, _In_ OS::WaitTimerCallback* callback);
     void Start(_In_ uint64_t dueTime);
     void Cancel();
     void TimerFired();
     
 private:
     void* m_context;
-    WaitTimerCallback* m_callback;
+    OS::WaitTimerCallback* m_callback;
     ios_WaitTimer_target* m_target;
     NSTimer* m_timer;
 };

--- a/Source/Task/iOS/ios_WaitTimerImpl.h
+++ b/Source/Task/iOS/ios_WaitTimerImpl.h
@@ -11,6 +11,9 @@
 #include "../WaitTimer.h"
 #include "ios_WaitTimer_target.h"
 
+namespace OS
+{
+
 class WaitTimerImpl
 {
 public:
@@ -27,6 +30,9 @@ private:
     ios_WaitTimer_target* m_target;
     NSTimer* m_timer;
 };
+
+} // namespace OS
+
 
 
 #endif /* ios_WaitTimerImpl_h */

--- a/Source/Task/iOS/ios_WaitTimerImpl.h
+++ b/Source/Task/iOS/ios_WaitTimerImpl.h
@@ -11,22 +11,27 @@
 #include "../WaitTimer.h"
 #include "ios_WaitTimer_target.h"
 
+namespace OS
+{
+
 class WaitTimerImpl
 {
 public:
     WaitTimerImpl();
     ~WaitTimerImpl();
-    HRESULT Initialize(_In_opt_ void* context, _In_ OS::WaitTimerCallback* callback);
+    HRESULT Initialize(_In_opt_ void* context, _In_ WaitTimerCallback* callback);
     void Start(_In_ uint64_t dueTime);
     void Cancel();
     void TimerFired();
     
 private:
     void* m_context;
-    OS::WaitTimerCallback* m_callback;
+    WaitTimerCallback* m_callback;
     ios_WaitTimer_target* m_target;
     NSTimer* m_timer;
 };
+
+} // namespace OS
 
 
 

--- a/Source/Task/iOS/ios_WaitTimer_target.mm
+++ b/Source/Task/iOS/ios_WaitTimer_target.mm
@@ -13,7 +13,7 @@
 - (void)timerFireMethod:(NSTimer*)timer
 {
     auto value = (NSValue*)timer.userInfo;
-    auto impl = static_cast<WaitTimerImpl*>(value.pointerValue);
+    auto impl = static_cast<OS::WaitTimerImpl*>(value.pointerValue);
     impl->TimerFired();
 }
 

--- a/Source/Task/iOS/ios_WaitTimer_target.mm
+++ b/Source/Task/iOS/ios_WaitTimer_target.mm
@@ -13,7 +13,7 @@
 - (void)timerFireMethod:(NSTimer*)timer
 {
     auto value = (NSValue*)timer.userInfo;
-    auto impl = static_cast<OS::WaitTimerImpl*>(value.pointerValue);
+    auto impl = static_cast<WaitTimerImpl*>(value.pointerValue);
     impl->TimerFired();
 }
 

--- a/Utilities/Pipelines/Tasks/ios-build.yml
+++ b/Utilities/Pipelines/Tasks/ios-build.yml
@@ -4,8 +4,8 @@ parameters:
 
 steps:
   - template: checkout.yml
-  
-  # Build the CMake version, which is different from libhttpClient.Apple.C
+
+  # Build the CMake static lib
   - script: |
       cmake -B Build/libHttpClient.iOS.CMake/build \
             -S Build/libHttpClient.iOS.CMake \
@@ -15,6 +15,7 @@ steps:
       cmake --build Build/libHttpClient.iOS.CMake/build --config ${{ parameters.configuration }}
     displayName: 'Clean build iOS CMake static lib'
 
+  # Build libHttpClient.Apple.C configurations
   - task: Xcode@5
     displayName: 'Clean build iOS static lib'
     inputs:

--- a/Utilities/Pipelines/Tasks/ios-build.yml
+++ b/Utilities/Pipelines/Tasks/ios-build.yml
@@ -92,3 +92,13 @@ steps:
       scheme: 'libHttpClientFramework_NOWEBSOCKETS_macOS'
       packageApp: false
       useXctool: false
+
+  # Build the CMake version, which is different from libhttpClient.Apple.C
+  - script: |
+      cmake -B Build/libHttpClient.iOS.CMake/build \
+            -S Build/libHttpClient.iOS.CMake \
+            -DCMAKE_SYSTEM_NAME=iOS \
+            -DCMAKE_OSX_ARCHITECTURES=arm64 \
+            -DCMAKE_BUILD_TYPE=${{ parameters.configuration }}
+      cmake --build Build/libHttpClient.iOS.CMake/build --config ${{ parameters.configuration }}
+    displayName: 'Clean build iOS CMake static lib'

--- a/Utilities/Pipelines/Tasks/ios-build.yml
+++ b/Utilities/Pipelines/Tasks/ios-build.yml
@@ -15,7 +15,7 @@ steps:
       cmake --build Build/libHttpClient.iOS.CMake/build --config ${{ parameters.configuration }}
     displayName: 'Clean build iOS CMake static lib'
 
-  - task: Xcode@2
+  - task: Xcode@5
     displayName: 'Clean build iOS static lib'
     inputs:
       actions: 'clean build'
@@ -24,9 +24,8 @@ steps:
       xcWorkspacePath: Build/libHttpClient.Apple.C/libHttpClient.xcworkspace
       scheme: 'libHttpClient_iOS'
       packageApp: false
-      useXctool: false
 
-  - task: Xcode@2
+  - task: Xcode@5
     displayName: 'Clean build iOS framework'
     inputs:
       actions: 'clean build'
@@ -35,9 +34,8 @@ steps:
       xcWorkspacePath: Build/libHttpClient.Apple.C/libHttpClient.xcworkspace
       scheme: 'libHttpClientFramework_iOS'
       packageApp: false
-      useXctool: false
 
-  - task: Xcode@2
+  - task: Xcode@5
     displayName: 'Clean build iOS_NOWEBSOCKETS static lib'
     inputs:
       actions: 'clean build'
@@ -46,9 +44,8 @@ steps:
       xcWorkspacePath: Build/libHttpClient.Apple.C/libHttpClient.xcworkspace
       scheme: 'libHttpClient_NOWEBSOCKETS_iOS'
       packageApp: false
-      useXctool: false
 
-  - task: Xcode@2
+  - task: Xcode@5
     displayName: 'Clean build iOS_NOWEBSOCKETS framework'
     inputs:
       actions: 'clean build'
@@ -57,9 +54,8 @@ steps:
       xcWorkspacePath: Build/libHttpClient.Apple.C/libHttpClient.xcworkspace
       scheme: 'libHttpClientFramework_NOWEBSOCKETS_iOS'
       packageApp: false
-      useXctool: false
 
-  - task: Xcode@2
+  - task: Xcode@5
     displayName: 'Clean build macOS static lib'
     inputs:
       actions: 'clean build'
@@ -68,9 +64,8 @@ steps:
       xcWorkspacePath: Build/libHttpClient.Apple.C/libHttpClient.xcworkspace
       scheme: 'libHttpClient_macOS'
       packageApp: false
-      useXctool: false
 
-  - task: Xcode@2
+  - task: Xcode@5
     displayName: 'Clean build macOS framework'
     inputs:
       actions: 'clean build'
@@ -79,9 +74,8 @@ steps:
       xcWorkspacePath: Build/libHttpClient.Apple.C/libHttpClient.xcworkspace
       scheme: 'libHttpClientFramework_macOS'
       packageApp: false
-      useXctool: false
 
-  - task: Xcode@2
+  - task: Xcode@5
     displayName: 'Clean build macOS_NOWEBSOCKETS static lib'
     inputs:
       actions: 'clean build'
@@ -90,9 +84,8 @@ steps:
       xcWorkspacePath: Build/libHttpClient.Apple.C/libHttpClient.xcworkspace
       scheme: 'libHttpClient_NOWEBSOCKETS_macOS'
       packageApp: false
-      useXctool: false
 
-  - task: Xcode@2
+  - task: Xcode@5
     displayName: 'Clean build macOS_NOWEBSOCKETS framework'
     inputs:
       actions: 'clean build'
@@ -101,5 +94,4 @@ steps:
       xcWorkspacePath: Build/libHttpClient.Apple.C/libHttpClient.xcworkspace
       scheme: 'libHttpClientFramework_NOWEBSOCKETS_macOS'
       packageApp: false
-      useXctool: false
 

--- a/Utilities/Pipelines/Tasks/ios-build.yml
+++ b/Utilities/Pipelines/Tasks/ios-build.yml
@@ -5,6 +5,16 @@ parameters:
 steps:
   - template: checkout.yml
   
+  # Build the CMake version, which is different from libhttpClient.Apple.C
+  - script: |
+      cmake -B Build/libHttpClient.iOS.CMake/build \
+            -S Build/libHttpClient.iOS.CMake \
+            -DCMAKE_SYSTEM_NAME=iOS \
+            -DCMAKE_OSX_ARCHITECTURES=arm64 \
+            -DCMAKE_BUILD_TYPE=${{ parameters.configuration }}
+      cmake --build Build/libHttpClient.iOS.CMake/build --config ${{ parameters.configuration }}
+    displayName: 'Clean build iOS CMake static lib'
+
   - task: Xcode@2
     displayName: 'Clean build iOS static lib'
     inputs:
@@ -93,12 +103,3 @@ steps:
       packageApp: false
       useXctool: false
 
-  # Build the CMake version, which is different from libhttpClient.Apple.C
-  - script: |
-      cmake -B Build/libHttpClient.iOS.CMake/build \
-            -S Build/libHttpClient.iOS.CMake \
-            -DCMAKE_SYSTEM_NAME=iOS \
-            -DCMAKE_OSX_ARCHITECTURES=arm64 \
-            -DCMAKE_BUILD_TYPE=${{ parameters.configuration }}
-      cmake --build Build/libHttpClient.iOS.CMake/build --config ${{ parameters.configuration }}
-    displayName: 'Clean build iOS CMake static lib'


### PR DESCRIPTION
Closes #727 

- Add CMake to build libHttpClient static lib for iOS
- Add said CMake to iOS pipeline and updated out-of-date tooling