### PR TITLE
improve multi mock behavior

### DIFF
--- a/Source/Global/global.h
+++ b/Source/Global/global.h
@@ -78,6 +78,7 @@ public:
     // Mock state
     std::recursive_mutex m_mocksLock;
     http_internal_vector<HC_MOCK_CALL*> m_mocks;
+    http_internal_map<http_internal_string, size_t> m_mockCycleIndex;
 
     std::recursive_mutex m_sharedPtrsLock;
     http_internal_unordered_map<void*, std::shared_ptr<void>> m_sharedPtrs;

--- a/Source/Mock/lhc_mock.cpp
+++ b/Source/Mock/lhc_mock.cpp
@@ -60,14 +60,35 @@ bool Mock_Internal_HCHttpCallPerformAsync(
     auto& mocks{ httpSingleton->m_mocks };
     HC_MOCK_CALL* mock{ nullptr };
 
-    // Use the first mock that matches this call
-    for (auto iter = mocks.begin(); iter != mocks.end(); ++iter)
+    // Collect all matching mocks in insertion order
+    http_internal_vector<HC_MOCK_CALL*> matchingMocks;
+    for (auto& m : mocks)
     {
-        if (DoesMockCallMatch(*iter, originalCall))
+        if (DoesMockCallMatch(m, originalCall))
         {
-            mock = *iter;
-            break;
+            matchingMocks.push_back(m);
         }
+    }
+
+    if (matchingMocks.empty())
+    {
+        return false;
+    }
+
+    if (matchingMocks.size() == 1)
+    {
+        mock = matchingMocks[0];
+    }
+    else
+    {
+        // Build a key from method+url to track cycling position
+        http_internal_string key{ originalCall->method };
+        key += "|";
+        key += originalCall->url;
+
+        auto& idx = httpSingleton->m_mockCycleIndex[key];
+        mock = matchingMocks[idx % matchingMocks.size()];
+        ++idx;
     }
 
     if (!mock)

--- a/Source/Mock/lhc_mock.cpp
+++ b/Source/Mock/lhc_mock.cpp
@@ -149,21 +149,6 @@ bool Mock_Internal_HCHttpCallPerformAsync(
         HCHttpCallResponseSetHeader(originalCall, str1, str2);
     }
 
-    // If this is not the only mock that matches, remove it from the list of mocks so that multiple can be used
-    // in sequence
-    auto countMatching = std::count_if(
-        mocks.begin(),
-        mocks.end(),
-        [originalCall](auto m)
-        {
-            return DoesMockCallMatch(m, originalCall);
-        });
-
-    if (countMatching > 1)
-    {
-        HCMockRemoveMock(mock);
-    }
-
     return true;
 }
 

--- a/Source/Mock/lhc_mock.cpp
+++ b/Source/Mock/lhc_mock.cpp
@@ -60,8 +60,8 @@ bool Mock_Internal_HCHttpCallPerformAsync(
     auto& mocks{ httpSingleton->m_mocks };
     HC_MOCK_CALL* mock{ nullptr };
 
-    // Use the most recently added mock that matches (similar to a stack).
-    for (auto iter = mocks.rbegin(); iter != mocks.rend(); ++iter)
+    // Use the first mock that matches this call
+    for (auto iter = mocks.begin(); iter != mocks.end(); ++iter)
     {
         if (DoesMockCallMatch(*iter, originalCall))
         {
@@ -126,6 +126,21 @@ bool Mock_Internal_HCHttpCallPerformAsync(
     {
         HCHttpCallResponseGetHeaderAtIndex(mock, i, &str1, &str2);
         HCHttpCallResponseSetHeader(originalCall, str1, str2);
+    }
+
+    // If this is not the only mock that matches, remove it from the list of mocks so that multiple can be used
+    // in sequence
+    auto countMatching = std::count_if(
+        mocks.begin(),
+        mocks.end(),
+        [originalCall](auto m)
+        {
+            return DoesMockCallMatch(m, originalCall);
+        });
+
+    if (countMatching > 1)
+    {
+        HCMockRemoveMock(mock);
     }
 
     return true;

--- a/Source/Mock/mock_publics.cpp
+++ b/Source/Mock/mock_publics.cpp
@@ -115,6 +115,7 @@ try
         {
             mocks.erase(iter);
             HCHttpCallCloseHandle(call);
+            httpSingleton->m_mockCycleIndex.clear();
             return S_OK;
         }
     }
@@ -139,6 +140,7 @@ try
     }
 
     httpSingleton->m_mocks.clear();
+    httpSingleton->m_mockCycleIndex.clear();
     return S_OK;
 }
 CATCH_RETURN()


### PR DESCRIPTION
Replicated #553

This PR updates the mocking behavior to match what's advertised by the doc header above HCMockAddMock:

```
/// You can set multiple active mock responses by calling HCMockAddMock() multiple 
/// times with a set of mock responses. If the HTTP call matches against a set mock responses, 
/// they will be executed in order for each subsequent call to HCHttpCallPerformAsync(). When the 
/// last matching mock response is hit, the last matching mock response will be repeated on 
/// each subsequent call to HCHttpCallPerformAsync().
```
Previously, the last-set mock for a particular URL was the only one that would ever return. Now the behavior matches the comment: Each matching mock is used and consumed in order they were created, with the last mock repeated forever.