### PR TITLE
Change Submodule OpenSSL to more secure version

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -37,7 +37,7 @@
         "Type": "git",
         "git": {
           "RepositoryUrl": "https://github.com/openssl/openssl",
-          "CommitHash": "fd78df59b0f656aefe96e39533130454aa957c00"
+          "CommitHash": "8aaca20cf9996257d1ce2e6f4d3059b3698dde3d"
         }
       },
       "DevelopmentDependency": false


### PR DESCRIPTION
Updating OpenSSL from 1.1.1k to 1.1.1p that meets the requirements of componence governance. Settling on 1.1.1p as that is the version that fixes the security bug.