### PR TITLE
build: fix iOS/macOS C-linkage on HCWebSocketOptions; Android compileSdk 34; Linux WSC dl/pthread; UWP ARM64; GDK asio

### DIFF
--- a/Build/libHttpClient.Android/build.gradle
+++ b/Build/libHttpClient.Android/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: "com.android.library"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 34
     ndkVersion "27.2.12479018"
 
     defaultConfig {

--- a/Build/libHttpClient.GDK.props
+++ b/Build/libHttpClient.GDK.props
@@ -106,7 +106,12 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <SupportJustMyCode>false</SupportJustMyCode>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <PreprocessorDefinitions>__WRL_NO_DEFAULT_LIB__;_LIB;$(libHttpClientDefine);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!--
+        ASIO_DISABLE_SERIAL_PORT: GDK builds compile with NOSERIALCOMM (no DCB),
+        which breaks asio's win_iocp_serial_port_service. asio is pulled in via
+        websocketpp; we don't use its serial-port transport, so disable it.
+      -->
+      <PreprocessorDefinitions>__WRL_NO_DEFAULT_LIB__;_LIB;ASIO_DISABLE_SERIAL_PORT;$(libHttpClientDefine);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories Condition="'$(Platform)'!='x64' AND '$(Platform)'!='ARM64'">%(AdditionalIncludeDirectories);$(GDKCrossPlatformPath)GRDK\ExtensionLibraries\Xbox.XCurl.API\Include</AdditionalIncludeDirectories>
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <AdditionalOptions>/Zc:__cplusplus /ZH:SHA_256 /bigobj /Zi %(AdditionalOptions)</AdditionalOptions>

--- a/Build/libHttpClient.Linux/CMakeLists.txt
+++ b/Build/libHttpClient.Linux/CMakeLists.txt
@@ -226,6 +226,7 @@ if (HC_ENABLE_WEBSOCKET_COMPRESSION AND NOT HC_NOWEBSOCKETS)
         PRIVATE
         "${PROJECT_NAME}"
         Threads::Threads
+        ${CMAKE_DL_LIBS} # Required for dlopen/dlsym referenced by linked libcrypto in some configurations
     )
 
     if (NOT BUILD_SHARED_LIBS)

--- a/Include/httpClient/httpClient.h
+++ b/Include/httpClient/httpClient.h
@@ -1043,7 +1043,13 @@ enum class HCWebSocketOptions : uint32_t
     CompressionClientNoContextTakeover = 0x00000004
 };
 
+// DEFINE_ENUM_FLAG_OPERATORS expands to C++ inline operators returning
+// HCWebSocketOptions&, which is not legal inside the surrounding extern "C"
+// block. Re-enter C++ linkage just for the macro expansion so callers can
+// still combine flags with |, &, ^, etc.
+extern "C++" {
 DEFINE_ENUM_FLAG_OPERATORS(HCWebSocketOptions)
+} // extern "C++"
 
 /// <summary>
 /// Creates an WebSocket handle.

--- a/Samples/UWP-Http/Http.vcxproj
+++ b/Samples/UWP-Http/Http.vcxproj
@@ -9,6 +9,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">false</TreatWarningAsError>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary

Fixes 4 build regressions and 1 latent GDK build hazard surfaced by **PlayFab.SDKs.All TestDrop build [148660743](https://dev.azure.com/microsoft/Xbox/_build/results?buildId=148660743&view=results)**. TestDrop runs with `checkoutSubmodulesAsLatestCommit: true`, so it builds libHttpClient main HEAD against PlayFab.SDKs.All's iOS/macOS/Linux/GDK toolchains — exposing platform regressions that this repo's MSVC-only PR CI does not catch.

## Why these weren't caught upstream
libHttpClient `libHttpClient.CI.yml` builds primarily on MSVC/Windows. clang `-Wreturn-type-c-linkage` (Xcode iOS/macOS) and the Linux `WebSocketCompressionTests` link (`-ldl -lpthread`) never gated PR #965. Captured as follow-up: **AB#62563305**.

## Commits

### `8c4efc0` — Android compileSdk 34 + UWP ARM64 warning + Linux WSC dl libs
- `Build/libHttpClient.Android/build.gradle` — compileSdk → 34 — **AB#62563300**
- `Build/libHttpClient.Linux/CMakeLists.txt` — add `dl pthread` to WSC test link — **AB#61359145**
- `Samples/UWP-Http/Http.vcxproj` — ARM64 -W4/-Werror suppression — **AB#62563301**

### `2817f2e` — iOS/macOS extern C++ wrap; GDK asio serial-port disable
- `Include/httpClient/httpClient.h` (line 1046) — wrap `DEFINE_ENUM_FLAG_OPERATORS(HCWebSocketOptions)` in `extern "C++" { }` so the C++ operator overloads aren't inside the file-wide `extern "C"` block (clang `-Wreturn-type-c-linkage -Werror` reject) — **AB#62563298**
- `Build/libHttpClient.GDK.props` — add `ASIO_DISABLE_SERIAL_PORT` to PreprocessorDefinitions; GDK `NOSERIALCOMM` removes `DCB` which breaks asio's `win_iocp_serial_port_service` (pulled in via websocketpp) — **AB#62563299**

## Repro (iOS/macOS)
```
httpClient.h:1046:1: error: 'operator|=' has C-linkage specified, but
  returns user-defined type 'HCWebSocketOptions &' which is incompatible
  with C [-Werror,-Wreturn-type-c-linkage]
```
Introduced by #965 (`b19d186`) placing the macro inside the file-wide `extern "C" {` (opened L24, closed L1496). MSVC and gcc tolerate it; clang `-Werror` does not. Minimal fix preserves C linkage for the entire public API surface and only flips to `C++` for the 1-line macro expansion.

## Risk
- `extern "C++"` around a macro is standard C++; supported by MSVC/clang/gcc. No ABI impact — operator overloads were never callable from C.
- `ASIO_DISABLE_SERIAL_PORT` only removes a transport we never use. No runtime behavior change. asio config knob at `External/asio/asio/include/asio/detail/config.hpp:1066-1080`.

## Validation plan
After merge: re-queue PlayFab.SDKs.All TestDrop (def 137186) against main with `checkoutSubmodulesAsLatestCommit: true`. Expect iOS/macOS/Linux green; GDK still red on NuGet feed gap (not patchable here); Android Copy APKs still red pending separate super-repo PR.

## Related ADO work items
- **AB#62563298** — iOS/macOS HCWebSocketOptions C-linkage
- **AB#62563299** — GDK asio NOSERIALCOMM/DCB
- **AB#62563300** — Android compileSdk 34
- **AB#62563301** — UWP ARM64 warning
- **AB#61359145** — Linux WSC `dl/pthread` (Raul)
- **AB#62563305** — Follow-up: libHttpClient CI gate-job gap