### PR TITLE
Linux: add ${CMAKE_DL_LIBS} to libHttpClient.Linux and WebSocketCompressionTests target_link_libraries

### DIFF
--- a/Build/libHttpClient.Linux/CMakeLists.txt
+++ b/Build/libHttpClient.Linux/CMakeLists.txt
@@ -146,6 +146,7 @@ if (BUILD_SHARED_LIBS)
         PRIVATE ${LIBCURL_BINARY_PATH}
         PRIVATE ${LIBSSL_BINARY_PATH}
         PRIVATE ${LIBCRYPTO_BINARY_PATH}
+        PRIVATE ${CMAKE_DL_LIBS}
     )
 else()
     #########################
@@ -226,6 +227,7 @@ if (HC_ENABLE_WEBSOCKET_COMPRESSION AND NOT HC_NOWEBSOCKETS)
         PRIVATE
         "${PROJECT_NAME}"
         Threads::Threads
+        ${CMAKE_DL_LIBS}
     )
 
     if (NOT BUILD_SHARED_LIBS)


### PR DESCRIPTION
Both targets transitively call `dlfcn` functions (via OpenSSL's `dso_dlfcn.c`) but don't link against `libdl`. On linkers that don't auto-resolve, the link fails:

```
/usr/bin/ld: dso_dlfcn.c:(.text+0xda): undefined reference to `dlerror'
```

Adds `${CMAKE_DL_LIBS}` to:

- `libHttpClient.Linux` (shared lib) `target_link_libraries`
- `WebSocketCompressionTests.Linux` `target_link_libraries`

`${CMAKE_DL_LIBS}` is the idiomatic CMake variable for this — it expands to `dl` on platforms that need it and is empty elsewhere. Safe no-op on Windows/macOS.

Surfaced via the `PlayFab.SDKs.All.TestDrop` Linux pipeline.