### PR TITLE
GDK: add ASIO_DISABLE_SERIAL_PORT to per-file websocketpp_websocket.cpp defines (follow-up to #987)

### DIFF
--- a/Build/libHttpClient.GDK.Shared/libHttpClient.GDK.Shared.vcxitems
+++ b/Build/libHttpClient.GDK.Shared/libHttpClient.GDK.Shared.vcxitems
@@ -36,7 +36,13 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Platform\Windows\PlatformTrace_Windows.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\Websocketpp\websocketpp_websocket.cpp" Condition="Exists('$(HCRoot)\External\boost-wintls\include\wintls.hpp') and '$(HCEnableWebSocketCompression)' == 'true'">
       <AdditionalIncludeDirectories>$(HCRoot)\External\asio\asio\include;$(HCRoot)\External\websocketpp;$(HCRoot)\External\boost-wintls\include;$(HCRoot)\External\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;_WEBSOCKETPP_CPP11_STL_;_WEBSOCKETPP_CPP11_RANDOM_DEVICE_;HC_ENABLE_WEBSOCKET_COMPRESSION=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!--
+        ASIO_DISABLE_SERIAL_PORT must be set per-file here: %(PreprocessorDefinitions)
+        does not inherit ItemDefinitionGroup defaults across shared-items imports, so
+        the GDK.props-level define is dropped for this TU.
+        Safe to define unconditionally - asio serial-port transport is unused by websocketpp.
+      -->
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;_WEBSOCKETPP_CPP11_STL_;_WEBSOCKETPP_CPP11_RANDOM_DEVICE_;HC_ENABLE_WEBSOCKET_COMPRESSION=1;ASIO_DISABLE_SERIAL_PORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/std:c++17 %(AdditionalOptions)</AdditionalOptions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>

--- a/Build/libHttpClient.Win32.Shared/libHttpClient.Win32.Shared.vcxitems
+++ b/Build/libHttpClient.Win32.Shared/libHttpClient.Win32.Shared.vcxitems
@@ -29,7 +29,13 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer_win32.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\WebSocket\Websocketpp\websocketpp_websocket.cpp" Condition="Exists('$(HCRoot)\External\boost-wintls\include\wintls.hpp') and '$(HCEnableWebSocketCompression)' == 'true'">
       <AdditionalIncludeDirectories>$(HCRoot)\External\asio\asio\include;$(HCRoot)\External\websocketpp;$(HCRoot)\External\boost-wintls\include;$(HCRoot)\External\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;_WEBSOCKETPP_CPP11_STL_;_WEBSOCKETPP_CPP11_RANDOM_DEVICE_;HC_ENABLE_WEBSOCKET_COMPRESSION=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!--
+        ASIO_DISABLE_SERIAL_PORT must be set per-file here: %(PreprocessorDefinitions)
+        does not inherit ItemDefinitionGroup defaults across shared-items imports, so
+        the GDK.props-level define is dropped for this TU on GDK builds.
+        Safe to define unconditionally - asio serial-port transport is unused by websocketpp.
+      -->
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;_WEBSOCKETPP_CPP11_STL_;_WEBSOCKETPP_CPP11_RANDOM_DEVICE_;HC_ENABLE_WEBSOCKET_COMPRESSION=1;ASIO_DISABLE_SERIAL_PORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/std:c++17 %(AdditionalOptions)</AdditionalOptions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>


### PR DESCRIPTION
## What

Add `ASIO_DISABLE_SERIAL_PORT` to the per-file `PreprocessorDefinitions` override on `websocketpp_websocket.cpp` in both `Build/libHttpClient.Win32.Shared/libHttpClient.Win32.Shared.vcxitems` and `Build/libHttpClient.GDK.Shared/libHttpClient.GDK.Shared.vcxitems`.

## Why

PR #987 set `ASIO_DISABLE_SERIAL_PORT` in `Build/libHttpClient.GDK.props:114` (ItemDefinitionGroup ClCompile PreprocessorDefinitions). That should have suppressed the body of `asio/serial_port_base.hpp` on GDK (where `WINAPI_FAMILY=WINAPI_FAMILY_GAMES` strips `DCB` and friends).

But it didn't. The per-file `<ClCompile Include="...websocketpp_websocket.cpp">` overrides set their own `PreprocessorDefinitions` list using `%(PreprocessorDefinitions)`. That `%(...)` does **not** inherit the project's `ItemDefinitionGroup` defaults when the override is sourced from an `<Import Label="Shared">` shared-items file. The actual `CL.exe` invocation for this TU on GDK was missing `/D ASIO_DISABLE_SERIAL_PORT`:

```
... /D _CRT_SECURE_NO_WARNINGS /D _CRT_NONSTDC_NO_WARNINGS /D _WEBSOCKETPP_CPP11_STL_
    /D _WEBSOCKETPP_CPP11_RANDOM_DEVICE_ /D HC_ENABLE_WEBSOCKET_COMPRESSION=1
    /D HC_DATAMODEL=HC_DATAMODEL_LLP64 /D HC_PLATFORM=HC_PLATFORM_WIN32 ...
    websocketpp_websocket.cpp
```

So `serial_port_base.hpp(58,9)` still compiled and failed with:

```
error C2061: syntax error: identifier 'DCB'
error C4430: missing type specifier - int assumed
error C2143: syntax error: missing ',' before '&'
error C2065: 'storage': undeclared identifier (serial_port_base.ipp:507)
error C2065: 'ec': undeclared identifier (serial_port_base.ipp:507)
```

## How

Add `ASIO_DISABLE_SERIAL_PORT` to both per-file overrides, with a comment explaining why the inheritance gap forces this duplication. Defined unconditionally - asio's serial-port transport is unused by the websocketpp provider on every platform we ship, so the Win32 entry getting the same define is harmless.

## Repro / validation

Surfaced by PlayFab.SDKs.All TestDrop 148864603 (microsoft/Xbox ADO def 137186) against libHttpClient `e79302c` (PR #987 squash). All four GDK jobs (x64/ARM64 x Debug/Release) failed at this exact point. Once this fix is in and the consumer bumps the submodule, GDK is expected to go green.

## Notes

- Follow-up to #987.
- Linked ADO bug: AB#62596841 (microsoft Xbox project).
