### PR TITLE
Linux: gate WSC source files and zlib system deps on HC_NOWEBSOCKETS/HC_NOZLIB

### DIFF
--- a/Build/libHttpClient.Linux/CMakeLists.txt
+++ b/Build/libHttpClient.Linux/CMakeLists.txt
@@ -83,7 +83,7 @@ set(LINUX_SOURCE_FILES
     "${PATH_TO_ROOT}/Source/Task/WaitTimer_stl.cpp"
     )
 
-if (NOT DEFINED HC_NOWEBSOCKETS)
+if (NOT HC_NOWEBSOCKETS)
     list(APPEND LINUX_SOURCE_FILES
         "${PATH_TO_ROOT}/Source/WebSocket/Websocketpp/websocketpp_websocket.cpp"
         "${PATH_TO_ROOT}/Source/WebSocket/Websocketpp/websocketpp_websocket.h"

--- a/Build/libHttpClient.Linux/CMakeLists.txt
+++ b/Build/libHttpClient.Linux/CMakeLists.txt
@@ -81,10 +81,15 @@ set(LINUX_SOURCE_FILES
     "${PATH_TO_ROOT}/Source/Platform/Linux/PlatformComponents_Linux.cpp"
     "${PATH_TO_ROOT}/Source/Task/ThreadPool_stl.cpp"
     "${PATH_TO_ROOT}/Source/Task/WaitTimer_stl.cpp"
-    "${PATH_TO_ROOT}/Source/WebSocket/Websocketpp/websocketpp_websocket.cpp"
-    "${PATH_TO_ROOT}/Source/WebSocket/Websocketpp/websocketpp_websocket.h"
-    "${PATH_TO_ROOT}/Source/WebSocket/Websocketpp/x509_cert_utilities.hpp"
     )
+
+if (NOT DEFINED HC_NOWEBSOCKETS)
+    list(APPEND LINUX_SOURCE_FILES
+        "${PATH_TO_ROOT}/Source/WebSocket/Websocketpp/websocketpp_websocket.cpp"
+        "${PATH_TO_ROOT}/Source/WebSocket/Websocketpp/websocketpp_websocket.h"
+        "${PATH_TO_ROOT}/Source/WebSocket/Websocketpp/x509_cert_utilities.hpp"
+    )
+endif()
 
 if (NOT DEFINED HC_NOZLIB)
     set(ZLIB_SOURCE_FILES

--- a/Build/libHttpClient.Linux/install_dependencies.bash
+++ b/Build/libHttpClient.Linux/install_dependencies.bash
@@ -26,7 +26,14 @@ done
 set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 
 build_dependencies=(clang make autoconf automake libtool)
-library_dependencies=(zlib1g zlib1g-dev)
+library_dependencies=()
+
+# zlib is only needed when zlib support is enabled (default on) AND websockets are enabled,
+# since WebSocket Compression (HC_ENABLE_WEBSOCKET_COMPRESSION, default ON) depends on zlib.
+# Consumers that opt out via HC_NOZLIB=true or HC_NOWEBSOCKETS=true do not need zlib system packages.
+if [ "${HC_NOZLIB}" != "true" ] && [ "${HC_NOWEBSOCKETS}" != "true" ]; then
+  library_dependencies+=(zlib1g zlib1g-dev)
+fi
 
 if [ "$DO_INSTALL" = false ]; then
 


### PR DESCRIPTION
Addresses the first two checklist items in #989.

After #965, Linux consumers opting out of WebSockets (`HC_NOWEBSOCKETS`) or zlib (`HC_NOZLIB`) still paid the cost of building `websocketpp_websocket.cpp` and installing `zlib1g`/`zlib1g-dev` system packages.

### Changes

1. **`Build/libHttpClient.Linux/CMakeLists.txt`** — wrap `websocketpp_websocket.{cpp,h}` + `x509_cert_utilities.hpp` addition to `LINUX_SOURCE_FILES` in `if (NOT DEFINED HC_NOWEBSOCKETS)`. Matches the existing pattern at line 89 (`if (NOT DEFINED HC_NOZLIB)` guards the zlib source list).

2. **`Build/libHttpClient.Linux/install_dependencies.bash`** — skip `zlib1g` / `zlib1g-dev` when `HC_NOZLIB=true` or `HC_NOWEBSOCKETS=true`. WSC is the only consumer of zlib on Linux, so both opt-outs make zlib unnecessary. Build toolchain deps (clang/make/autoconf/automake/libtool) are unchanged.

### Validation

- No CMakeLists.txt logic change for the default path (HC_NOWEBSOCKETS undefined → same source list as before).
- `install_dependencies.bash` default behavior unchanged when neither env var is set.
- `--check` mode adapts automatically (loops over the same `library_dependencies` array, which is empty in the opt-out case).

### Not in this PR (tracked in #989)

- Apple `HC_ENABLE_WEBSOCKET_COMPRESSION` toggle (hard-coded `=1` in pbxproj).
- MSBuild error/warning when `HCEnableWebSocketCompression=true` and `boost-wintls` submodule is missing.
- `%(PreprocessorDefinitions)` per-file-override audit (one instance fixed in #988).

Resolves first two boxes of #989.

---
_Re-opened on upstream repo (was: #990 from fork; closed per @rgomez391's request to enable ADO CI auto-trigger)._