### PR TITLE
Fix XTaskQueue shared-timer starvation when a composite terminates with a pending delayed callback

### DIFF
--- a/Build/libHttpClient.Linux/CMakeLists.txt
+++ b/Build/libHttpClient.Linux/CMakeLists.txt
@@ -281,6 +281,7 @@ target_include_directories(
     PRIVATE
     "${COMMON_INCLUDE_DIRS}"
     "${LINUX_INCLUDE_DIRS}"
+    "${PATH_TO_ROOT}/Tests/Shared"
 )
 
 target_link_libraries(

--- a/Build/libHttpClient.Linux/CMakeLists.txt
+++ b/Build/libHttpClient.Linux/CMakeLists.txt
@@ -262,4 +262,55 @@ if (HC_ENABLE_WEBSOCKET_COMPRESSION AND NOT HC_NOWEBSOCKETS)
     )
 endif()
 
+##################################################
+### TaskQueue delayed-callback starvation test ###
+##################################################
+# Standalone regression guard for the composite-queue delayed-callback
+# starvation bug. Exercises the STL WaitTimer backend that the Windows test
+# lanes cannot reach. Uses only the public XTaskQueue API + the standard
+# library, so it just links the libHttpClient.Linux target.
+find_package(Threads REQUIRED)
+
+add_executable(
+    "TaskQueueStarvationTests.Linux"
+    "${PATH_TO_ROOT}/Tests/TaskQueueStarvation/TaskQueueStarvationRepro.cpp"
+)
+
+target_include_directories(
+    "TaskQueueStarvationTests.Linux"
+    PRIVATE
+    "${COMMON_INCLUDE_DIRS}"
+    "${LINUX_INCLUDE_DIRS}"
+)
+
+target_link_libraries(
+    "TaskQueueStarvationTests.Linux"
+    PRIVATE
+    "${PROJECT_NAME}"
+    Threads::Threads
+    ${CMAKE_DL_LIBS}
+)
+
+if (NOT BUILD_SHARED_LIBS)
+    target_link_libraries(
+        "TaskQueueStarvationTests.Linux"
+        PRIVATE
+        "${LIBCURL_BINARY_PATH}"
+        "${LIBSSL_BINARY_PATH}"
+        "${LIBCRYPTO_BINARY_PATH}"
+    )
+endif()
+
+target_set_flags(
+    "TaskQueueStarvationTests.Linux"
+    "${FLAGS}"
+    "${FLAGS_DEBUG}"
+    "${FLAGS_RELEASE}"
+)
+
+add_test(
+    NAME taskqueue-starvation-linux
+    COMMAND "TaskQueueStarvationTests.Linux"
+)
+
 export(TARGETS ${PROJECT_NAME} FILE ${PROJECT_NAME}Config.cmake)

--- a/Build/libHttpClient.UnitTest/libHttpClient.UnitTest.vcxitems
+++ b/Build/libHttpClient.UnitTest/libHttpClient.UnitTest.vcxitems
@@ -8,7 +8,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>HC_UNITTEST_API;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(HCRoot)\Tests\UnitTests\Support;$(HCRoot)\Tests\UnitTests;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(HCRoot)\Tests\UnitTests\Support;$(HCRoot)\Tests\UnitTests;$(HCRoot)\Tests\Shared;</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Source/Task/TaskQueue.cpp
+++ b/Source/Task/TaskQueue.cpp
@@ -990,6 +990,13 @@ void TaskQueuePortImpl::CancelPendingEntries(
     {
         hooks->PendingEntriesRemovedDuringTermination(portContext->GetType());
     }
+
+    // We may have just removed the pending entry that the shared delayed-callback
+    // timer was armed for (a composite that shares this port can terminate while
+    // it still owns the armed-earliest entry). Relying on a "blank fire" of the
+    // now-orphaned deadline to re-arm is fragile under the STL timer backend, so
+    // re-point the timer at the earliest surviving pending entry directly.
+    RearmTimerForEarliestPending();
     
 #ifdef _WIN32
     
@@ -1023,6 +1030,63 @@ void TaskQueuePortImpl::CancelPendingEntries(
     }
 
 #endif
+}
+
+// After cancellation removed pending entries, re-point the shared timer at the
+// earliest surviving pending entry instead of leaving it armed for a deadline
+// whose entry was just removed. Without this, a composite that shares this
+// port's timer can terminate while owning the armed-earliest entry, leaving the
+// timer pointed at an orphaned deadline; if the orphaned fire is lost (STL timer
+// backend), the remaining delayed callbacks never run and the queue starves.
+void TaskQueuePortImpl::RearmTimerForEarliestPending()
+{
+    QueueEntry nextItem = {};
+    bool hasNextItem = false;
+
+    // Read-only scan: keep every entry (return false), tracking the earliest.
+    m_pendingList->remove_if([&](auto& entry, auto /*address*/)
+    {
+        if (!hasNextItem || nextItem.enqueueTime > entry.enqueueTime)
+        {
+            if (hasNextItem)
+            {
+                nextItem.portContext->Release();
+            }
+
+            nextItem = entry;
+            nextItem.portContext->AddRef();
+            hasNextItem = true;
+        }
+
+        return false;
+    });
+
+    uint64_t currentDue = m_timerDue.load();
+
+    if (hasNextItem)
+    {
+        if (nextItem.enqueueTime < currentDue)
+        {
+            // Surviving entry is earlier than the armed deadline: min-wins arm.
+            ArmTimerIfEarlier(nextItem.enqueueTime);
+        }
+        else if (nextItem.enqueueTime > currentDue)
+        {
+            // The armed deadline belonged to a removed entry; advance the timer
+            // to the earliest surviving deadline using the same verified helper
+            // the fire path uses (handles a concurrent earlier publish safely).
+            ArmTimerForNextPendingDueTime(currentDue, nextItem.enqueueTime);
+        }
+
+        nextItem.portContext->Release();
+    }
+    else if (currentDue != UINT64_MAX)
+    {
+        // No pending entries remain on any attached context; let the timer go
+        // idle. Mirrors the no-next-item branch of PromoteReadyPendingCallbacks
+        // (CAS only, never Cancel(), to avoid racing concurrent Start calls).
+        m_timerDue.compare_exchange_strong(currentDue, UINT64_MAX);
+    }
 }
 
 void TaskQueuePortImpl::EraseQueue(

--- a/Source/Task/TaskQueueImpl.h
+++ b/Source/Task/TaskQueueImpl.h
@@ -314,6 +314,11 @@ private:
 
     bool RearmTimerIfDueTimeUnchanged(_In_ uint64_t dueTime);
 
+    // After cancellation removed pending entries, re-point the shared timer at
+    // the earliest surviving pending entry instead of leaving it armed for a
+    // deadline that no longer has an owner.
+    void RearmTimerForEarliestPending();
+
     void PromoteReadyPendingCallbacks(
         _In_ uint64_t dueTime,
         _In_ uint64_t now);

--- a/Tests/Shared/CompositeQueueStarvationScenario.h
+++ b/Tests/Shared/CompositeQueueStarvationScenario.h
@@ -1,0 +1,276 @@
+// Copyright (c) Microsoft Corporation
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// Shared, platform-neutral scenario for the composite-queue delayed-callback
+// starvation regression. Exercised by:
+//   - the Windows unit test VerifyCompositeQueueDelayedCallbackStarvation
+//     (TaskQueueTests.cpp, Win32 WaitTimer backend), and
+//   - the standalone Linux repro binary (CMake target, STL WaitTimer backend).
+//
+// The STL timer backend (Linux/non-Microsoft platforms) is where the regression
+// manifests, so running this on Linux CI guards the platform the Windows lanes
+// cannot reach.
+//
+// Scenario: many concurrent submitter threads each create a composite queue over
+// one shared Work port and drive a self-resubmitting delayed-poll loop with tiny
+// (1-2ms) delays. A canceller thread terminates a subset of the composites while
+// they still have a delayed callback pending, while pump threads dispatch the
+// shared Work port. This races new delayed submits against the timer worker
+// promoting/arming due entries and against terminate removing the armed-earliest
+// entry. If the shared timer fails to re-arm in any of those windows, the
+// remaining delayed callbacks stop firing and the queue starves: some requests
+// never complete and RunCompositeQueueStarvationScenario reports failure.
+//
+// Uses only the public XTaskQueue C API plus the C++ standard library so the
+// same translation unit compiles on every platform.
+
+#pragma once
+
+// async.h pulls in pal.h (HRESULT, STDAPI, CALLBACK, FAILED, ...) and then
+// XTaskQueue.h, so this header is self-contained on every platform.
+#include <httpClient/async.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <thread>
+#include <vector>
+
+namespace hc_test
+{
+
+struct CompositeStarvationConfig
+{
+    int outerIterations = 20;
+    int submitterThreads = 6;
+    int requestsPerSubmitter = 24;
+    int polls = 20;
+    int pumpThreads = 2;
+    // Per-iteration bound; starvation is detected when not every request
+    // completes within this window.
+    int completionTimeoutMs = 15000;
+};
+
+namespace detail
+{
+
+struct PollRequest
+{
+    XTaskQueueHandle composite{ nullptr };
+    int target{ 0 };
+    uint32_t delayMs{ 0 };
+    std::atomic<int> polls{ 0 };
+    std::atomic<int>* completed{ nullptr };
+    std::atomic<int> terminated{ 0 };
+    std::atomic<int> counted{ 0 };
+
+    void MarkDone()
+    {
+        if (counted.exchange(1) == 0)
+        {
+            completed->fetch_add(1);
+        }
+    }
+
+    void TerminateOnce()
+    {
+        if (terminated.exchange(1) == 0)
+        {
+            // Terminate only; the handle is closed in the final cleanup pass
+            // after every worker/canceller/pump thread has joined.
+            XTaskQueueTerminate(composite, false, nullptr, nullptr);
+        }
+    }
+};
+
+inline void CALLBACK PollCallback(void* context, bool cancelled)
+{
+    PollRequest* r = static_cast<PollRequest*>(context);
+
+    if (cancelled)
+    {
+        // Dispatched after the composite was terminated: account for it once.
+        r->MarkDone();
+        return;
+    }
+
+    int n = r->polls.fetch_add(1) + 1;
+    if (n < r->target)
+    {
+        HRESULT hr = XTaskQueueSubmitDelayedCallback(r->composite, XTaskQueuePort::Work, r->delayMs, r, PollCallback);
+        if (FAILED(hr))
+        {
+            // Composite is terminating (E_ABORT); account for it once.
+            r->MarkDone();
+        }
+    }
+    else
+    {
+        r->TerminateOnce();
+        r->MarkDone();
+    }
+}
+
+} // namespace detail
+
+// Runs the scenario. Returns true if every request completed in every iteration
+// (healthy timer arming/teardown). Returns false if any iteration starved.
+// If failedIteration / completedAtFailure are provided, they receive the first
+// failing iteration index and how many of the per-iteration requests completed.
+inline bool RunCompositeQueueStarvationScenario(
+    const CompositeStarvationConfig& cfg = CompositeStarvationConfig{},
+    int* failedIteration = nullptr,
+    int* completedAtFailure = nullptr)
+{
+    using detail::PollRequest;
+    using detail::PollCallback;
+
+    const int total = cfg.submitterThreads * cfg.requestsPerSubmitter;
+
+    for (int iter = 0; iter < cfg.outerIterations; iter++)
+    {
+        XTaskQueueHandle queue{ nullptr };
+        if (FAILED(XTaskQueueCreate(XTaskQueueDispatchMode::Manual, XTaskQueueDispatchMode::Manual, &queue)))
+        {
+            if (failedIteration) { *failedIteration = iter; }
+            if (completedAtFailure) { *completedAtFailure = -1; }
+            return false;
+        }
+
+        XTaskQueuePortHandle workPort{ nullptr };
+        XTaskQueueGetPort(queue, XTaskQueuePort::Work, &workPort);
+
+        // Pump threads for the shared Work port.
+        std::atomic<bool> pumping{ true };
+        std::vector<std::thread> pumps;
+        pumps.reserve(cfg.pumpThreads);
+        for (int p = 0; p < cfg.pumpThreads; p++)
+        {
+            pumps.emplace_back([queue, &pumping]()
+            {
+                while (pumping.load(std::memory_order_acquire))
+                {
+                    XTaskQueueDispatch(queue, XTaskQueuePort::Work, 50);
+                }
+            });
+        }
+
+        std::atomic<int> completed{ 0 };
+
+        // Published request pointers. Composite handles are closed only in the
+        // final cleanup loop after every thread has joined, so no thread can
+        // touch a freed handle.
+        std::vector<std::atomic<PollRequest*>> slots(total);
+        for (auto& s : slots)
+        {
+            s.store(nullptr, std::memory_order_relaxed);
+        }
+
+        // Submitter threads: each creates composites + starts the poll loop.
+        // Requests where (index % 3 == 0) are "long pollers" (effectively
+        // unbounded) kept alive until the canceller terminates them mid-flight;
+        // the rest self-complete after cfg.polls.
+        std::vector<std::thread> submitters;
+        submitters.reserve(cfg.submitterThreads);
+        for (int t = 0; t < cfg.submitterThreads; t++)
+        {
+            int base = t * cfg.requestsPerSubmitter;
+            submitters.emplace_back([base, &cfg, workPort, &completed, &slots]()
+            {
+                for (int i = 0; i < cfg.requestsPerSubmitter; i++)
+                {
+                    int globalIdx = base + i;
+                    PollRequest* r = new PollRequest{};
+                    r->target = (globalIdx % 3 == 0) ? 0x7fffffff : cfg.polls;
+                    r->delayMs = (i & 1) ? 1u : 2u; // tiny delays thrash the "earliest due" pointer
+                    r->completed = &completed;
+
+                    if (FAILED(XTaskQueueCreateComposite(workPort, workPort, &r->composite)))
+                    {
+                        r->MarkDone();
+                        delete r;
+                        continue;
+                    }
+
+                    slots[globalIdx].store(r, std::memory_order_release);
+
+                    if (FAILED(XTaskQueueSubmitCallback(r->composite, XTaskQueuePort::Work, r, PollCallback)))
+                    {
+                        r->MarkDone();
+                    }
+                }
+            });
+        }
+
+        // Canceller thread: terminates the long-poller composites while they
+        // still have a delayed poll pending. It only terminates (never closes);
+        // the request's own canceled dispatch / aborted re-arm accounts for it.
+        std::thread canceller([total, &slots]()
+        {
+            int handled = 0;
+            while (handled < total)
+            {
+                handled = 0;
+                for (int i = 0; i < total; i++)
+                {
+                    if (i % 3 != 0) { handled++; continue; } // only long pollers
+                    PollRequest* r = slots[i].load(std::memory_order_acquire);
+                    if (r == nullptr) { continue; } // not yet published
+                    r->TerminateOnce();
+                    handled++;
+                }
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+        });
+
+        for (auto& s : submitters)
+        {
+            s.join();
+        }
+        canceller.join();
+
+        // Bounded wait for completion. Starvation => timeout.
+        auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(cfg.completionTimeoutMs);
+        while (completed.load() < total && std::chrono::steady_clock::now() < deadline)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+
+        int done = completed.load();
+
+        // Stop pumps and join so nothing touches handles after close.
+        pumping.store(false, std::memory_order_release);
+        for (auto& p : pumps)
+        {
+            p.join();
+        }
+
+        // All threads joined: terminate (idempotent) + close + free.
+        for (auto& slot : slots)
+        {
+            PollRequest* r = slot.load(std::memory_order_acquire);
+            if (r != nullptr)
+            {
+                if (r->composite != nullptr)
+                {
+                    r->TerminateOnce();
+                    XTaskQueueCloseHandle(r->composite);
+                }
+                delete r;
+            }
+        }
+
+        XTaskQueueCloseHandle(queue);
+
+        if (done != total)
+        {
+            if (failedIteration) { *failedIteration = iter; }
+            if (completedAtFailure) { *completedAtFailure = done; }
+            return false;
+        }
+    }
+
+    return true;
+}
+
+} // namespace hc_test

--- a/Tests/TaskQueueStarvation/TaskQueueStarvationRepro.cpp
+++ b/Tests/TaskQueueStarvation/TaskQueueStarvationRepro.cpp
@@ -13,7 +13,7 @@
 // Built as the CTest target "taskqueue-starvation-linux" in
 // Build/libHttpClient.Linux/CMakeLists.txt and run by the Linux CI lane.
 
-#include "../Shared/CompositeQueueStarvationScenario.h"
+#include "CompositeQueueStarvationScenario.h"
 
 #include <cstdio>
 

--- a/Tests/TaskQueueStarvation/TaskQueueStarvationRepro.cpp
+++ b/Tests/TaskQueueStarvation/TaskQueueStarvationRepro.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// Standalone Linux repro / regression guard for the composite-queue delayed-
+// callback starvation bug. Runs the shared scenario against the STL WaitTimer
+// backend (the platform where the regression manifests; the Windows unit-test
+// lanes only exercise the Win32 timer backend and cannot catch it).
+//
+// Exit codes:
+//   0  - scenario healthy (every request completed in every iteration)
+//   1  - starvation detected (a request never completed within the timeout)
+//
+// Built as the CTest target "taskqueue-starvation-linux" in
+// Build/libHttpClient.Linux/CMakeLists.txt and run by the Linux CI lane.
+
+#include "../Shared/CompositeQueueStarvationScenario.h"
+
+#include <cstdio>
+
+int main()
+{
+    hc_test::CompositeStarvationConfig cfg{};
+
+    int failedIteration = -1;
+    int completedAtFailure = -1;
+
+    std::printf(
+        "[taskqueue-starvation] running %d iterations, %d submitters x %d requests, %d pumps...\n",
+        cfg.outerIterations,
+        cfg.submitterThreads,
+        cfg.requestsPerSubmitter,
+        cfg.pumpThreads);
+    std::fflush(stdout);
+
+    bool ok = hc_test::RunCompositeQueueStarvationScenario(cfg, &failedIteration, &completedAtFailure);
+
+    if (!ok)
+    {
+        const int total = cfg.submitterThreads * cfg.requestsPerSubmitter;
+        std::printf(
+            "[taskqueue-starvation] FAILED: starvation at iteration %d (%d / %d requests completed)\n",
+            failedIteration,
+            completedAtFailure,
+            total);
+        std::fflush(stdout);
+        return 1;
+    }
+
+    std::printf("[taskqueue-starvation] PASSED: no starvation detected\n");
+    std::fflush(stdout);
+    return 0;
+}

--- a/Tests/UnitTests/Tests/TaskQueueTests.cpp
+++ b/Tests/UnitTests/Tests/TaskQueueTests.cpp
@@ -6,7 +6,7 @@
 #include "CallbackThunk.h"
 #include "PumpedTaskQueue.h"
 #include "XTaskQueuePriv.h"
-#include "../../Shared/CompositeQueueStarvationScenario.h"
+#include "CompositeQueueStarvationScenario.h"
 
 #define TEST_CLASS_OWNER L"brianpe"
 

--- a/Tests/UnitTests/Tests/TaskQueueTests.cpp
+++ b/Tests/UnitTests/Tests/TaskQueueTests.cpp
@@ -6,6 +6,7 @@
 #include "CallbackThunk.h"
 #include "PumpedTaskQueue.h"
 #include "XTaskQueuePriv.h"
+#include "../../Shared/CompositeQueueStarvationScenario.h"
 
 #define TEST_CLASS_OWNER L"brianpe"
 
@@ -98,6 +99,11 @@ struct HandleCloser
 };
 
 typedef AutoHandleWrapper<HANDLE, HandleCloser> AutoHandle;
+
+// The composite-queue delayed-callback starvation scenario lives in
+// Tests/Shared/CompositeQueueStarvationScenario.h so the exact same scenario is
+// exercised here (Win32 WaitTimer backend) and by the standalone Linux repro
+// binary (STL WaitTimer backend, where the regression manifests).
 
 DEFINE_TEST_CLASS(TaskQueueTests)
 {
@@ -195,6 +201,38 @@ public:
             VERIFY_IS_LESS_THAN(GetTickCount64() - ticks, (UINT64)1000);
             Sleep(100);
         }      
+    }
+
+    DEFINE_TEST_CASE(VerifyCompositeQueueDelayedCallbackStarvation)
+    {
+        // Regression guard for delayed-callback timer arming under composite
+        // teardown. Many concurrent submitter threads each create a composite
+        // over one shared Work port and drive a self-resubmitting delayed-poll
+        // loop (tiny 1-2ms delays). A canceller thread terminates a subset of
+        // the composites WHILE they still have a delayed callback pending, while
+        // pump threads dispatch the shared Work port. This races new delayed
+        // submits against the timer worker promoting/arming due entries and
+        // against terminate removing the armed-earliest entry. If the shared
+        // timer fails to re-arm in any of those windows, the remaining delayed
+        // callbacks stop firing and the queue starves; every request must still
+        // complete.
+        //
+        // The scenario itself lives in the shared header so the exact same code
+        // runs here on the Win32 WaitTimer backend and in the standalone Linux
+        // repro binary on the STL WaitTimer backend (where the bug manifests).
+
+        int failedIteration = -1;
+        int completedAtFailure = -1;
+        bool ok = hc_test::RunCompositeQueueStarvationScenario(
+            hc_test::CompositeStarvationConfig{},
+            &failedIteration,
+            &completedAtFailure);
+
+        if (!ok)
+        {
+            LOG_COMMENT(L"STARVATION at iteration %d: completed %d", failedIteration, completedAtFailure);
+        }
+        VERIFY_IS_TRUE(ok);
     }
 
     DEFINE_TEST_CASE(VerifyDuplicateQueueHandle)

--- a/Utilities/Pipelines/Tasks/linux-build.yml
+++ b/Utilities/Pipelines/Tasks/linux-build.yml
@@ -29,6 +29,15 @@ steps:
       arguments: '-c ${{ parameters.configuration }} -nc -ns -st'
 
   - task: Bash@3
+    displayName: 'Run libHttpClient Linux tests (ctest)'
+    inputs:
+      targetType: 'inline'
+      script: |
+        set -e
+        cd "$(Build.SourcesDirectory)/Int/CMake/libHttpClient.Linux"
+        ctest --output-on-failure -R taskqueue-starvation-linux
+
+  - task: Bash@3
     displayName: 'Build libHttpClient Shared'
     inputs:
       filePath: './Build/libHttpClient.Linux/libHttpClient_Linux.bash'


### PR DESCRIPTION
## Summary
Fixes a delayed-callback starvation in `XTaskQueue` that can occur when a composite queue sharing a port's Work stream is terminated while it still owns the earliest-due pending delayed callback. After such a terminate, the shared delayed-callback timer can be left armed for a deadline whose entry was just removed. On the STL `WaitTimer` backend (non-Microsoft platforms — Linux, Android, iOS, etc.) that orphaned fire can be lost, after which the remaining pending delayed callbacks never run and the queue effectively stops dispatching delayed work.

## Root cause
`TaskQueuePortImpl::CancelPendingEntries` intentionally leaves `m_timer` / `m_timerDue` untouched on terminate (sibling delegates share the port's timer state), relying on a "blank fire" of the now-orphaned deadline to re-arm for the next real item. That assumption holds on the Win32 threadpool timer backend but is fragile on the STL timer backend, where the orphaned notification can be dropped — stranding every remaining pending entry.

## Fix
Add `TaskQueuePortImpl::RearmTimerForEarliestPending()` and call it at the end of `CancelPendingEntries`. After pending entries are removed, it scans for the earliest surviving pending entry and re-points the shared timer at it:

- earlier than the armed deadline → `ArmTimerIfEarlier` (min-wins);
- later (the armed deadline belonged to a removed entry) → `ArmTimerForNextPendingDueTime` (the same verified helper the fire path uses, so a concurrent earlier publish is handled safely);
- none remain → CAS `m_timerDue` to `UINT64_MAX` (CAS only, never `Cancel()`, to avoid racing concurrent `Start` calls — matching the existing no-next-item branch).

## Test coverage
The regression only reproduces on the STL timer backend, which the existing Windows unit-test lanes don't exercise — that's why it wasn't caught. This PR adds a regression guard that runs on **both** backends from a single shared scenario:

- `Tests/Shared/CompositeQueueStarvationScenario.h` — a platform-neutral scenario (public `XTaskQueue` API + the standard library only): many concurrent submitters create composites over one shared Work port and drive self-resubmitting delayed-poll loops with tiny (1–2 ms) delays, while a canceller terminates a subset of composites that still have a delayed callback pending and pump threads dispatch the Work port. It returns failure if any request fails to complete (starvation).
- `Tests/UnitTests/Tests/TaskQueueTests.cpp` — `VerifyCompositeQueueDelayedCallbackStarvation` now calls the shared scenario (Win32 backend).
- `Tests/TaskQueueStarvation/TaskQueueStarvationRepro.cpp` + a CTest target in `Build/libHttpClient.Linux/CMakeLists.txt` — runs the same scenario on the STL backend, wired into the Linux CI lane in `Utilities/Pipelines/Tasks/linux-build.yml`.

Before the fix the scenario starves (times out) on the STL backend; after the fix it passes on both backends, and the full `TaskQueueTests` suite (30 tests, incl. the existing delayed-callback/termination regression tests) passes on both backends.

## Validation
- STL backend: scenario fails (~15 s timeout) without the fix; passes (~3–4 s) with it, consistently across repeated runs.
- Win32 backend + STL backend: full `TaskQueueTests` 30/30.
- Shared scenario header compiles standalone as an isolated C++17 translation unit.