### PR TITLE
TaskQueue: use unnamed condition variables as an option on NDA platform

### DIFF
--- a/Include/httpClient/pal.h
+++ b/Include/httpClient/pal.h
@@ -13,6 +13,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <condition_variable>
 #include <mutex>
 
 #include <httpClient/config.h>
@@ -514,6 +515,26 @@ public:
     void unlock() { std::mutex::unlock(); }
     native_handle_type native_handle() { return std::mutex::native_handle(); }
 };
+
+class DefaultUnnamedConditionVariable : public std::condition_variable
+{
+public:
+    DefaultUnnamedConditionVariable() noexcept : std::condition_variable(nullptr) {}
+    ~DefaultUnnamedConditionVariable() noexcept = default;
+    DefaultUnnamedConditionVariable(DefaultUnnamedConditionVariable const&) = delete;
+    DefaultUnnamedConditionVariable& operator=(DefaultUnnamedConditionVariable const&) = delete;
+};
+
+class DefaultUnnamedConditionVariableAny : public std::condition_variable_any
+{
+public:
+    DefaultUnnamedConditionVariableAny() noexcept : std::condition_variable_any(nullptr) {}
+    ~DefaultUnnamedConditionVariableAny() noexcept = default;
+    DefaultUnnamedConditionVariableAny(DefaultUnnamedConditionVariableAny const&) = delete;
+    DefaultUnnamedConditionVariableAny& operator=(DefaultUnnamedConditionVariableAny const&) = delete;
+};
 #else
 using DefaultUnnamedMutex = std::mutex;
+using DefaultUnnamedConditionVariable = std::condition_variable;
+using DefaultUnnamedConditionVariableAny = std::condition_variable_any;
 #endif

--- a/Source/Task/AsyncLib.cpp
+++ b/Source/Task/AsyncLib.cpp
@@ -46,7 +46,7 @@ struct AsyncState
     XAsyncBlock* userAsyncBlock = nullptr;
     XTaskQueueHandle queue = nullptr;
     DefaultUnnamedMutex waitMutex;
-    std::condition_variable waitCondition;
+    DefaultUnnamedConditionVariable waitCondition;
     bool waitSatisfied = false;
 
 #if _WIN32

--- a/Source/Task/TaskQueue.cpp
+++ b/Source/Task/TaskQueue.cpp
@@ -15,7 +15,7 @@ namespace ApiRefs
 {
     std::atomic<uint32_t> g_globalApiRefs{ 0 };
     std::mutex g_waitMutex;
-    std::condition_variable g_waitCv;
+    DefaultUnnamedConditionVariable g_waitCv;
     
     void GlobalAddRef()
     {

--- a/Source/Task/TaskQueueImpl.h
+++ b/Source/Task/TaskQueueImpl.h
@@ -258,7 +258,7 @@ private:
     AtomicVector<ITaskQueuePortContext*> m_attachedContexts;
     std::atomic<uint32_t> m_processingSerializedTbCallback{ 0 };
     std::atomic<uint32_t> m_processingCallback{ 0 };
-    std::condition_variable m_processingCallbackCv;
+    DefaultUnnamedConditionVariable m_processingCallbackCv;
     DefaultUnnamedMutex m_lock;
     std::unique_ptr<LocklessQueue<QueueEntry>> m_queueList;
     std::unique_ptr<LocklessQueue<QueueEntry>> m_pendingList;
@@ -277,7 +277,7 @@ private:
     uint64_t m_nextWaitToken = 0;
 #else
     bool m_signaled = false;
-    std::condition_variable_any m_event;
+    DefaultUnnamedConditionVariableAny m_event;
 #endif
 
     HRESULT VerifyNotTerminated(_In_ ITaskQueuePortContext* portContext);
@@ -473,7 +473,7 @@ private:
     {
         bool terminated;
         DefaultUnnamedMutex lock;
-        std::condition_variable cv;
+        DefaultUnnamedConditionVariable cv;
     };
 
     XTaskQueueObject m_header = { };

--- a/Source/Task/ThreadPool_stl.cpp
+++ b/Source/Task/ThreadPool_stl.cpp
@@ -223,12 +223,12 @@ namespace OS
         std::atomic<uint32_t> m_refs{ 1 };
 
         DefaultUnnamedMutex m_wakeLock;
-        std::condition_variable m_wake;
+        DefaultUnnamedConditionVariable m_wake;
         uint32_t m_calls{ 0 };
         bool m_terminate{ false };
 
         DefaultUnnamedMutex m_activeLock;
-        std::condition_variable m_active;
+        DefaultUnnamedConditionVariable m_active;
         uint32_t m_activeCalls{ 0 };
 
         std::vector<std::thread> m_pool;

--- a/Source/Task/WaitTimer_stl.cpp
+++ b/Source/Task/WaitTimer_stl.cpp
@@ -102,7 +102,7 @@ namespace OS
         std::atomic<uint64_t> m_generation{ 0 };
         std::atomic<bool> m_terminating{ false };
         DefaultUnnamedMutex m_lock;
-        std::condition_variable m_quiesced;
+        DefaultUnnamedConditionVariable m_quiesced;
         uint32_t m_inFlightDispatch = 0;
     };
 
@@ -161,7 +161,7 @@ namespace OS
         TimerEntry Pop() noexcept;
 
         DefaultUnnamedMutex m_mutex;
-        std::condition_variable m_cv;
+        DefaultUnnamedConditionVariable m_cv;
         std::vector<TimerEntry> m_queue; // used as a heap
         std::thread m_t;
         std::atomic<uint32_t> m_timerCount{ 0 };


### PR DESCRIPTION
Add DefaultUnnamedConditionVariable wrappers and switch task queue, async, wait timer, and thread pool synchronization objects to unnamed condition-variable variants under HC_USE_UNNAMED_MUTEX.