### PR TITLE
Apple: Fix _platform_strlen crashes inside getSystemProxyForUri

### DIFF
--- a/Source/Common/Apple/utils_apple.mm
+++ b/Source/Common/Apple/utils_apple.mm
@@ -33,21 +33,24 @@ bool getSystemProxyForUri(const Uri& uri, Uri* outUri, String* outUsername, Stri
     NSString* proxyPassword = nil;
     if ([resolver getProxy:&proxyUrl withUsername:&proxyUsername andPassword:&proxyPassword])
     {
-        if (!outUri)
+        const char* proxyUrlUtf8 = [proxyUrl.absoluteString UTF8String];
+        if (!outUri || !proxyUrlUtf8)
         {
             return false;
         }
 
-        *outUri = Uri(String([proxyUrl.absoluteString UTF8String]));
-
-        if (outUsername && proxyUsername)
+        *outUri = Uri(String(proxyUrlUtf8));
+        
+        const char* proxyUsernameUtf8 = [proxyUsername UTF8String];
+        if (outUsername && proxyUsernameUtf8)
         {
-            *outUsername = String{ [proxyUsername UTF8String] };
+            *outUsername = String{ proxyUsernameUtf8 };
         }
-
-        if (outPassword && proxyPassword)
+        
+        const char* proxyPasswordUtf8 = [proxyPassword UTF8String];
+        if (outPassword && proxyPasswordUtf8)
         {
-            *outPassword = String{ [proxyPassword UTF8String] };
+            *outPassword = String{ proxyPasswordUtf8 };
         }
         return true;
     }


### PR DESCRIPTION
I've seen some crashes on iOS where a _platform_strlen error is thrown in the basic_string constructor during getSystemProxyForUri. In general, since UTF8String returns a char pointer, the three locations where it's used should check that the pointer is valid before using it to create a string.