### PR TITLE
Fix NetworkState submit/cleanup TOCTOU races

### DIFF
--- a/Source/Global/NetworkState.cpp
+++ b/Source/Global/NetworkState.cpp
@@ -197,6 +197,10 @@ HRESULT CALLBACK NetworkState::HttpCallPerformAsyncProvider(XAsyncOp op, const X
     case XAsyncOp::Cleanup:
     {
         std::unique_lock<std::mutex> lock{ state.m_mutex };
+        // Only a perform that was actually admitted (present in m_activeHttpRequests) may drive the
+        // cleanup wakeup. A perform rejected by the m_cleanupStarted guard was never inserted, so
+        // erase() returns 0 and we must not call ScheduleCleanup()/XAsyncSchedule for it -- doing so
+        // would spuriously (re)schedule cleanup's async block for a request that was never tracked.
         bool scheduleCleanup = state.m_activeHttpRequests.erase(performContext) != 0 && state.ScheduleCleanup();
         lock.unlock();
 

--- a/Source/Global/NetworkState.cpp
+++ b/Source/Global/NetworkState.cpp
@@ -151,6 +151,12 @@ bool NetworkState::CanCleanupCancelHttpRequest(XAsyncBlock* async) noexcept
     }
     return false;
 }
+
+void NetworkState::TestSetCleanupStarted(bool started) noexcept
+{
+    std::unique_lock<std::mutex> lock{ m_mutex };
+    m_cleanupStarted = started;
+}
 #endif
 
 HRESULT CALLBACK NetworkState::HttpCallPerformAsyncProvider(XAsyncOp op, const XAsyncProviderData* data)

--- a/Source/Global/NetworkState.cpp
+++ b/Source/Global/NetworkState.cpp
@@ -174,6 +174,15 @@ HRESULT CALLBACK NetworkState::HttpCallPerformAsyncProvider(XAsyncOp op, const X
         RETURN_IF_FAILED(XTaskQueueCreateComposite(workPort, workPort, &performContext->internalAsyncBlock.queue));
 
         std::unique_lock<std::mutex> lock{ state.m_mutex };
+        if (state.m_cleanupStarted)
+        {
+            // Cleanup has already begun and taken (or is taking) its snapshot of
+            // m_activeHttpRequests under this same mutex. Refuse the request instead of inserting
+            // it after the snapshot, which would orphan it (never canceled or awaited) and could
+            // run it against a torn-down provider.
+            lock.unlock();
+            return E_HC_NOT_INITIALISED;
+        }
         state.m_activeHttpRequests.insert(performContext);
         lock.unlock();
 
@@ -376,6 +385,13 @@ HRESULT CALLBACK NetworkState::WebSocketConnectAsyncProvider(XAsyncOp op, const 
         RETURN_IF_FAILED(XTaskQueueCreateComposite(workPort, workPort, &context->internalAsyncBlock.queue));
 
         std::unique_lock<std::mutex> lock{ state.m_mutex };
+        if (state.m_cleanupStarted)
+        {
+            // See the equivalent guard in HttpCallPerformAsyncProvider: reject connects that arrive
+            // after cleanup has begun rather than orphaning them past the cleanup snapshot.
+            lock.unlock();
+            return E_HC_NOT_INITIALISED;
+        }
         state.m_connectingWebSockets.insert(context->clientAsyncBlock);
         lock.unlock();
 
@@ -501,17 +517,19 @@ HRESULT CALLBACK NetworkState::CleanupAsyncProvider(XAsyncOp op, const XAsyncPro
         {
             std::unique_lock<std::mutex> lock{ state->m_mutex };
             state->m_cleanupAsyncBlock = data->async;
+            state->m_cleanupStarted = true;
             scheduleCleanup = state->ScheduleCleanup();
 
 #ifndef HC_NOWEBSOCKETS 
             HC_TRACE_VERBOSE(HTTPCLIENT, "NetworkState::CleanupAsyncProvider::Begin: HTTP active=%llu, WebSocket Connecting=%llu, WebSocket Connected=%llu", state->m_activeHttpRequests.size(), state->m_connectingWebSockets.size(), state->m_connectedWebSockets.size());
 #endif
-            // No new HTTP performs can enter m_activeHttpRequests after cleanup begins because
-            // http_singleton::singleton_access(cleanup) detaches the singleton before
-            // NetworkState::CleanupAsync runs. Snapshot requests here, then cancel them after
-            // releasing m_mutex. This prevents a race between holding the global cleanup mutex
-            // across XAsyncCancel and allowing completion to advance a request that cleanup has
-            // already decided to cancel.
+            // Setting m_cleanupStarted above (under m_mutex) closes the admission window: any HTTP
+            // perform or WebSocket connect whose Begin op acquires m_mutex after this point is
+            // refused, so nothing can be inserted into the tracking sets after the snapshot below.
+            // Requests that acquired m_mutex before us are already in m_activeHttpRequests and are
+            // captured by the snapshot here. Snapshot them under the lock and cancel them after
+            // releasing m_mutex; this prevents holding the lock across XAsyncCancel while still
+            // ensuring completion cannot advance a request cleanup has already decided to cancel.
             for (auto activeRequest : state->m_activeHttpRequests)
             {
                 auto expectedState = HttpPerformClientBlockState::CleanupMayCancel;

--- a/Source/Global/NetworkState.cpp
+++ b/Source/Global/NetworkState.cpp
@@ -152,10 +152,11 @@ bool NetworkState::CanCleanupCancelHttpRequest(XAsyncBlock* async) noexcept
     return false;
 }
 
-void NetworkState::TestSetCleanupStarted(bool started) noexcept
+void NetworkState::TestSetCleanupStarted(bool started, XAsyncBlock* cleanupAsyncBlock) noexcept
 {
     std::unique_lock<std::mutex> lock{ m_mutex };
     m_cleanupStarted = started;
+    m_cleanupAsyncBlock = cleanupAsyncBlock;
 }
 #endif
 

--- a/Source/Global/NetworkState.cpp
+++ b/Source/Global/NetworkState.cpp
@@ -197,8 +197,7 @@ HRESULT CALLBACK NetworkState::HttpCallPerformAsyncProvider(XAsyncOp op, const X
     case XAsyncOp::Cleanup:
     {
         std::unique_lock<std::mutex> lock{ state.m_mutex };
-        state.m_activeHttpRequests.erase(performContext);
-        bool scheduleCleanup = state.ScheduleCleanup();
+        bool scheduleCleanup = state.m_activeHttpRequests.erase(performContext) != 0 && state.ScheduleCleanup();
         lock.unlock();
 
         // Free performContext before scheduling cleanup to ensure it happens before returing to client

--- a/Source/Global/NetworkState.cpp
+++ b/Source/Global/NetworkState.cpp
@@ -493,11 +493,14 @@ void CALLBACK NetworkState::WebSocketClosed(HCWebsocketHandle /*websocket*/, HCW
 }
 #endif // !HC_NOWEBSOCKETS
 
-HRESULT NetworkState::CleanupAsync(UniquePtr<NetworkState> state, XAsyncBlock* async) noexcept
+HRESULT NetworkState::CleanupAsync(NetworkState* state, XAsyncBlock* async) noexcept
 {
-    RETURN_IF_FAILED(XAsyncBegin(async, state.get(), __FUNCTION__, __FUNCTION__, CleanupAsyncProvider));
-    state.release();
-    return S_OK;
+    // NetworkState is not taken by owning pointer here: it remains owned by the http_singleton for
+    // its whole lifetime. Cleanup runs against the still-owned instance and never destroys it, so an
+    // in-flight API caller holding a singleton reference can never observe a moved-from or destroyed
+    // NetworkState (Race B). The instance is destroyed together with the singleton, once the
+    // singleton's use_count gate confirms no other references remain.
+    return XAsyncBegin(async, state, __FUNCTION__, __FUNCTION__, CleanupAsyncProvider);
 }
 
 HRESULT CALLBACK NetworkState::CleanupAsyncProvider(XAsyncOp op, const XAsyncProviderData* data)
@@ -590,8 +593,7 @@ HRESULT CALLBACK NetworkState::CleanupAsyncProvider(XAsyncOp op, const XAsyncPro
         {
             XAsyncBlock* cleanupAsyncBlock{ state->m_cleanupAsyncBlock };
 
-            UniquePtr<NetworkState> reclaim{ state };
-            reclaim.reset();
+            // NetworkState stays owned by the http_singleton; do not destroy it here.
             providerCleanupAsyncBlock.reset();
 
             XAsyncComplete(cleanupAsyncBlock, hr, 0);
@@ -613,14 +615,15 @@ HRESULT CALLBACK NetworkState::CleanupAsyncProvider(XAsyncOp op, const XAsyncPro
 void CALLBACK NetworkState::HttpProviderCleanupComplete(XAsyncBlock* async)
 {
     UniquePtr<XAsyncBlock> providerCleanupAsyncBlock{ async };
-    UniquePtr<NetworkState> state{ static_cast<NetworkState*>(providerCleanupAsyncBlock->context) };
+    NetworkState* state{ static_cast<NetworkState*>(providerCleanupAsyncBlock->context) };
     XAsyncBlock* stateCleanupAsyncBlock = state->m_cleanupAsyncBlock;
 
     HRESULT cleanupResult = XAsyncGetStatus(providerCleanupAsyncBlock.get(), false);
     providerCleanupAsyncBlock.reset();
-    state.reset();
 
-    // NetworkState fully cleaned up at this point
+    // NetworkState's providers are cleaned up at this point. The NetworkState instance itself stays
+    // owned by the http_singleton and is destroyed when the singleton is (after its use_count gate),
+    // so an in-flight caller holding a singleton reference never observes it freed.
     XAsyncComplete(stateCleanupAsyncBlock, cleanupResult, 0);
 }
 

--- a/Source/Global/NetworkState.h
+++ b/Source/Global/NetworkState.h
@@ -34,7 +34,7 @@ public:
 #endif
 
     static HRESULT CleanupAsync(
-        UniquePtr<NetworkState> networkManager,
+        NetworkState* networkState,
         XAsyncBlock* async
     ) noexcept;
 

--- a/Source/Global/NetworkState.h
+++ b/Source/Global/NetworkState.h
@@ -52,7 +52,7 @@ public: // Http
     bool CanCleanupCancelHttpRequest(XAsyncBlock* async) noexcept;
     // Test seam: simulate that cleanup has begun on this NetworkState without running the
     // real cleanup flow, so admission-control behavior can be exercised deterministically.
-    void TestSetCleanupStarted(bool started) noexcept;
+    void TestSetCleanupStarted(bool started, XAsyncBlock* cleanupAsyncBlock = nullptr) noexcept;
 #endif
 
 #ifndef HC_NOWEBSOCKETS

--- a/Source/Global/NetworkState.h
+++ b/Source/Global/NetworkState.h
@@ -50,6 +50,9 @@ public: // Http
 
 #ifdef HC_UNITTEST_API
     bool CanCleanupCancelHttpRequest(XAsyncBlock* async) noexcept;
+    // Test seam: simulate that cleanup has begun on this NetworkState without running the
+    // real cleanup flow, so admission-control behavior can be exercised deterministically.
+    void TestSetCleanupStarted(bool started) noexcept;
 #endif
 
 #ifndef HC_NOWEBSOCKETS
@@ -93,6 +96,11 @@ private:
 
     Set<HttpPerformContext*> m_activeHttpRequests;
     XAsyncBlock* m_cleanupAsyncBlock{ nullptr }; // non-owning
+
+    // Admission-control gate for new network operations. Set (under m_mutex) once cleanup has
+    // begun; while set, new HTTP performs and WebSocket connects are refused so they cannot land
+    // in the tracking sets after the cleanup snapshot has been taken.
+    bool m_cleanupStarted{ false };
 
 #ifndef HC_NOWEBSOCKETS
     static HRESULT CALLBACK WebSocketConnectAsyncProvider(XAsyncOp op, const XAsyncProviderData* data);

--- a/Source/Global/NetworkState.h
+++ b/Source/Global/NetworkState.h
@@ -100,6 +100,9 @@ private:
     // Admission-control gate for new network operations. Set (under m_mutex) once cleanup has
     // begun; while set, new HTTP performs and WebSocket connects are refused so they cannot land
     // in the tracking sets after the cleanup snapshot has been taken.
+    // All reads and writes must occur under m_mutex; that is what makes a plain bool sufficient
+    // (no atomic needed) and what makes the guard atomic with the tracking-set insert/snapshot. Do
+    // not read this outside m_mutex.
     bool m_cleanupStarted{ false };
 
 #ifndef HC_NOWEBSOCKETS

--- a/Source/Global/global.cpp
+++ b/Source/Global/global.cpp
@@ -156,7 +156,7 @@ HRESULT CALLBACK http_singleton::CleanupAsyncProvider(XAsyncOp op, const XAsyncP
             XAsyncSchedule(singletonCleanupAsyncBlock, 0);
         };
 
-        RETURN_IF_FAILED(NetworkState::CleanupAsync(std::move(singleton->m_networkState), performEnvCleanupAsyncBlock.get()));
+        RETURN_IF_FAILED(NetworkState::CleanupAsync(singleton->m_networkState.get(), performEnvCleanupAsyncBlock.get()));
         performEnvCleanupAsyncBlock.release();
 
         return S_OK;
@@ -169,6 +169,19 @@ HRESULT CALLBACK http_singleton::CleanupAsyncProvider(XAsyncOp op, const XAsyncP
         // Note that the use count check here is only valid because we never create
         // a weak_ptr to the singleton. If we did that could cause the use count
         // to increase even though we are the only strong reference
+        //
+        // This gate is also what keeps NetworkState safe to own from the singleton for its whole
+        // lifetime (rather than moving it out during cleanup Begin). An in-flight API caller that
+        // obtained a strong reference via get_http_singleton() before cleanup detached the singleton
+        // keeps use_count above 1 here, so neither the singleton nor the NetworkState it owns is
+        // destroyed until that caller releases its reference. That is what prevents an in-flight
+        // HCHttpCallPerformAsync / HCWebSocketConnectAsync from observing a moved-from or destroyed
+        // m_networkState.
+        //
+        // INVARIANT: no code may hold a get_http_singleton() reference across an async wait or other
+        // blocking operation. Doing so would keep use_count above 1 indefinitely and stall cleanup
+        // here. Every caller today takes the reference as a short-lived local scoped to a single
+        // synchronous operation.
         if (self.use_count() > 1)
         {
             RETURN_IF_FAILED(XAsyncSchedule(data->async, 10));

--- a/Tests/UnitTests/Tests/GlobalTests.cpp
+++ b/Tests/UnitTests/Tests/GlobalTests.cpp
@@ -196,6 +196,74 @@ public:
         VERIFY_SUCCEEDED(HCHttpCallCloseHandle(call));
         HCCleanup();
     }
+
+    // Race B reproduction: an in-flight API caller (e.g. HCHttpCallPerformAsync) takes a strong
+    // singleton reference via get_http_singleton() and has not yet dereferenced m_networkState.
+    // Cleanup running concurrently must not detach/destroy NetworkState out from under that
+    // reference, otherwise the caller null-derefs the moved-from m_networkState.
+    DEFINE_TEST_CASE(TestCleanupKeepsNetworkStateForInFlightSingletonRef)
+    {
+        VERIFY_SUCCEEDED(HCInitialize(nullptr));
+        PumpedTaskQueue pumpedQueue;
+
+        auto inFlightSingletonRef = get_http_singleton();
+        VERIFY_IS_NOT_NULL(inFlightSingletonRef.get());
+
+        XAsyncBlock cleanupAsyncBlock{ pumpedQueue.queue };
+        VERIFY_SUCCEEDED(HCCleanupAsync(&cleanupAsyncBlock));
+        // XAsyncBegin dispatches the cleanup Begin op synchronously on this thread, so by the time
+        // HCCleanupAsync returns the singleton has been detached. A pre-fix build has already
+        // std::move'd m_networkState out from under our still-live reference at this point.
+        bool networkStateStillValid = (inFlightSingletonRef->m_networkState.get() != nullptr);
+
+        // Release our reference and drain cleanup to completion BEFORE asserting, so a failing
+        // assertion never unwinds the test with an in-flight cleanup still referencing the stack
+        // async block.
+        inFlightSingletonRef.reset();
+        VERIFY_SUCCEEDED(XAsyncGetStatus(&cleanupAsyncBlock, true));
+
+        VERIFY_IS_TRUE(networkStateStillValid);
+    }
+
+    // Race A reproduction: once cleanup has begun on NetworkState, a perform whose Begin op runs
+    // afterwards must be rejected rather than inserted into m_activeHttpRequests. Otherwise it is
+    // orphaned past the cleanup snapshot (never canceled/awaited) and can run against a torn-down
+    // provider.
+    DEFINE_TEST_CASE(TestHttpPerformRejectedAfterCleanupStarted)
+    {
+        VERIFY_SUCCEEDED(HCInitialize(nullptr));
+        PumpedTaskQueue pumpedQueue;
+
+        constexpr char mockUrl[]{ "www.bing.com" };
+        HCMockCallHandle mock{ nullptr };
+        VERIFY_SUCCEEDED(HCMockCallCreate(&mock));
+        VERIFY_SUCCEEDED(HCMockResponseSetStatusCode(mock, 200));
+        VERIFY_SUCCEEDED(HCMockAddMock(mock, "GET", mockUrl, nullptr, 0));
+
+        HCCallHandle call{ nullptr };
+        VERIFY_SUCCEEDED(HCHttpCallCreate(&call));
+        VERIFY_SUCCEEDED(HCHttpCallRequestSetUrl(call, "GET", mockUrl));
+
+        auto httpSingleton = get_http_singleton();
+        VERIFY_IS_NOT_NULL(httpSingleton.get());
+
+        // Simulate cleanup having begun on NetworkState (without running the real teardown, so
+        // NetworkState stays alive and observable for the assertions below).
+        httpSingleton->m_networkState->TestSetCleanupStarted(true);
+
+        XAsyncBlock performAsyncBlock{ pumpedQueue.queue };
+        VERIFY_SUCCEEDED(httpSingleton->m_networkState->HttpCallPerformAsync(call, &performAsyncBlock));
+
+        HRESULT performStatus = XAsyncGetStatus(&performAsyncBlock, true);
+        VERIFY_ARE_EQUAL(E_HC_NOT_INITIALISED, performStatus);
+        VERIFY_IS_FALSE(httpSingleton->m_networkState->CanCleanupCancelHttpRequest(&performAsyncBlock));
+
+        httpSingleton->m_networkState->TestSetCleanupStarted(false);
+        httpSingleton.reset();
+
+        VERIFY_SUCCEEDED(HCHttpCallCloseHandle(call));
+        HCCleanup();
+    }
 };
 
 NAMESPACE_XBOX_HTTP_CLIENT_TEST_END

--- a/Tests/UnitTests/Tests/GlobalTests.cpp
+++ b/Tests/UnitTests/Tests/GlobalTests.cpp
@@ -232,7 +232,32 @@ public:
     DEFINE_TEST_CASE(TestHttpPerformRejectedAfterCleanupStarted)
     {
         VERIFY_SUCCEEDED(HCInitialize(nullptr));
-        PumpedTaskQueue pumpedQueue;
+
+        XTaskQueueHandle queue{ nullptr };
+        VERIFY_SUCCEEDED(XTaskQueueCreate(XTaskQueueDispatchMode::Manual, XTaskQueueDispatchMode::Manual, &queue));
+
+        auto cleanupProvider = [](XAsyncOp op, const XAsyncProviderData* data)
+        {
+            switch (op)
+            {
+            case XAsyncOp::Begin:
+            {
+                return S_OK;
+            }
+            case XAsyncOp::DoWork:
+            {
+                XAsyncComplete(data->async, S_OK, 0);
+                return E_PENDING;
+            }
+            default:
+            {
+                return S_OK;
+            }
+            }
+        };
+
+        XAsyncBlock cleanupAsyncBlock{ queue };
+        VERIFY_SUCCEEDED(XAsyncBegin(&cleanupAsyncBlock, nullptr, nullptr, nullptr, cleanupProvider));
 
         constexpr char mockUrl[]{ "www.bing.com" };
         HCMockCallHandle mock{ nullptr };
@@ -247,22 +272,29 @@ public:
         auto httpSingleton = get_http_singleton();
         VERIFY_IS_NOT_NULL(httpSingleton.get());
 
-        // Simulate cleanup having begun on NetworkState (without running the real teardown, so
-        // NetworkState stays alive and observable for the assertions below).
-        httpSingleton->m_networkState->TestSetCleanupStarted(true);
+        // Simulate cleanup having begun on NetworkState after its tracking-set snapshot. The
+        // cleanup async block is intentionally real and unscheduled so a rejected perform must not
+        // consume cleanup's one allowed schedule.
+        httpSingleton->m_networkState->TestSetCleanupStarted(true, &cleanupAsyncBlock);
 
-        XAsyncBlock performAsyncBlock{ pumpedQueue.queue };
+        XAsyncBlock performAsyncBlock{ queue };
         VERIFY_SUCCEEDED(httpSingleton->m_networkState->HttpCallPerformAsync(call, &performAsyncBlock));
 
         HRESULT performStatus = XAsyncGetStatus(&performAsyncBlock, true);
         VERIFY_ARE_EQUAL(E_HC_NOT_INITIALISED, performStatus);
         VERIFY_IS_FALSE(httpSingleton->m_networkState->CanCleanupCancelHttpRequest(&performAsyncBlock));
 
+        HRESULT cleanupScheduleHr = XAsyncSchedule(&cleanupAsyncBlock, 0);
+        VERIFY_IS_TRUE(XTaskQueueDispatch(queue, XTaskQueuePort::Work, 0));
+        VERIFY_SUCCEEDED(XAsyncGetStatus(&cleanupAsyncBlock, true));
+        VERIFY_SUCCEEDED(cleanupScheduleHr);
+
         httpSingleton->m_networkState->TestSetCleanupStarted(false);
         httpSingleton.reset();
 
         VERIFY_SUCCEEDED(HCHttpCallCloseHandle(call));
         HCCleanup();
+        XTaskQueueCloseHandle(queue);
     }
 };
 


### PR DESCRIPTION
Fixes #999

## Summary

`NetworkState` did not serialize network-operation *submission* against the *start of cleanup*.
Calling `HCHttpCallPerformAsync` / `HCWebSocketConnectAsync` on one thread while another thread
runs `HCCleanup` / `HCCleanupAsync` could crash on a moved-from `m_networkState`, or orphan a
request that lands in the cleanup tracking sets after they were snapshotted. See the linked issue
for the full analysis.

This PR closes both facets. The public API surface is unchanged, and there is no new `shared_ptr`
or per-call allocation on the submission path.

Code review also found a cleanup wake-up edge case in the admission-gate implementation: a
rejected HTTP perform still runs its `XAsyncOp::Cleanup` provider path, and if that rejected
context is treated like a tracked request it can consume cleanup's one schedule slot or double-run
provider cleanup. The final fix only lets contexts that were actually present in
`m_activeHttpRequests` wake cleanup.

## Bug addressed

Two facets of one root cause — submission is not serialized against cleanup-begin:

- **Race A (late insert).** A perform/connect whose `Begin` op acquires `m_mutex` *after*
  `CleanupAsyncProvider::Begin` took its snapshot was inserted into `m_activeHttpRequests` /
  `m_connectingWebSockets` anyway, orphaning it past cleanup: never canceled or awaited, and able
  to run against a torn-down provider.
- **Race B (moved-from `m_networkState`).** `HCHttpCallPerformAsync` dereferences
  `httpSingleton->m_networkState` while `http_singleton::CleanupAsyncProvider::Begin`
  `std::move`s it out. `get_http_singleton()` does not increment the singleton use count, so an
  in-flight caller holding a strong reference is unsynchronized against the move — a null
  dereference / data race.

The PR also includes a code-review hardening fix for the rejection path itself: an HTTP perform
that is refused after cleanup begins is never inserted into `m_activeHttpRequests`, so its later
provider cleanup must reclaim only its local context and must not wake or reschedule cleanup.

## What changed

### Race A — admission gate (`NetworkState`)

- Added `m_cleanupStarted`, set under `m_mutex` in `CleanupAsyncProvider::Begin` alongside the
  existing snapshot.
- `HttpCallPerformAsyncProvider::Begin` and `WebSocketConnectAsyncProvider::Begin` now check
  `m_cleanupStarted` inside the same `m_mutex` critical section as the tracking-set insert. If
  cleanup has begun, the submission is refused with `E_HC_NOT_INITIALISED` instead of being
  inserted. Because insert and snapshot share `m_mutex` and the flag is set under that lock, a
  submission either lands before the snapshot (and is captured/canceled) or is cleanly refused —
  no gap.
- `HttpCallPerformAsyncProvider::Cleanup` now wakes cleanup only when
  `m_activeHttpRequests.erase(performContext)` actually removed a tracked request. Rejected
  performs still reclaim their async context, but cannot consume cleanup's schedule slot or cause
  provider cleanup to run twice because they were never admitted to the active set.

### Race B — keep `NetworkState` owned by the singleton

- `NetworkState::CleanupAsync` now takes a non-owning `NetworkState*` and no longer transfers
  ownership; `global.cpp` passes `singleton->m_networkState.get()` instead of `std::move`.
- Cleanup no longer destroys `NetworkState` (`HttpProviderCleanupComplete` and the `DoWork`
  failure path no longer reclaim it). The instance stays owned by the `http_singleton` and is
  destroyed with the singleton, after the singleton's existing `use_count` gate confirms no other
  references remain. An in-flight caller holding a strong singleton reference keeps `use_count`
  above 1, so it can never observe a moved-from or destroyed `m_networkState`.
- Documented that gate in `global.cpp`, including the supporting invariant that no code may hold a
  `get_http_singleton()` reference across an async wait.

### Tests

- `TestCleanupKeepsNetworkStateForInFlightSingletonRef` (Race B) — a caller holding a live
  `get_http_singleton()` reference asserts `m_networkState` stays non-null across cleanup; fails
  pre-fix when it is moved out from under that reference.
- `TestHttpPerformRejectedAfterCleanupStarted` (Race A) — a perform whose `Begin` runs after
  cleanup has begun must be refused rather than inserted into `m_activeHttpRequests`; fails pre-fix
  when it is orphaned past the snapshot. The test was strengthened during code review with a real
  unscheduled cleanup async block, so it also fails if a rejected perform consumes cleanup's one
  allowed schedule.
- The original reproductions are deterministic (they rely on `XAsyncBegin` dispatching `Begin`
  synchronously) and were committed first as failing tests, then made to pass by the fixes. The
  code-review cleanup wake-up regression was also committed red, then fixed green.
- Adds a `TestSetCleanupStarted` `HC_UNITTEST_API` seam used by the Race A test; the seam can also
  attach a cleanup async block so the rejection path is tested against realistic cleanup state.

## Design rationale

- **Why the admission gate under `m_mutex`?** The insert and the cleanup snapshot already
  serialize on `m_mutex`. Setting/reading the flag in that same critical section makes the
  admission decision atomic with the insert/snapshot, closing the window without a new lock.
- **`m_cleanupStarted` is a plain `bool`, not atomic.** Every read and write occurs under
  `m_mutex`, which provides the required mutual exclusion and ordering; an atomic would be
  redundant and would misleadingly imply lockless access. The correctness of the guard depends on
  the read and the insert being in the *same* critical section as cleanup's write+snapshot, which
  the mutex — not an atomic — provides.
- **Why gate cleanup wake-up on `erase`?** A rejected HTTP perform still owns an async context and
  still receives `XAsyncOp::Cleanup`, but it was never part of the cleanup tracking set. Only an
  admitted request can be work that cleanup is waiting for, so the cleanup wake-up is tied to the
  active-set erase actually removing an entry. This prevents a refused submit from stealing the
  cleanup async block's schedule slot or invoking provider cleanup a second time.
- **Why keep `NetworkState` owned by the singleton instead of a `shared_ptr`?** The singleton
  already has a `use_count` gate that waits for all outstanding references before destruction.
  Reusing it (by not moving `NetworkState` out early) fixes Race B with no new `shared_ptr`, no
  new atomics, and no per-call cost — versus adding an in-flight submitter counter that would
  re-implement `use_count`, touch every public entry point, and add hot-path overhead. The
  trade-off is that `NetworkState` (and its already-cleaned providers) lives until the singleton is
  destroyed — a few milliseconds longer under the gate — and a documented invariant that callers
  must not hold a singleton reference across an async wait.

## Public API surface

- No public `HC*` signatures added, removed, or changed.
- `HCHttpCallPerformAsync` / `HCWebSocketConnectAsync` behavior is unchanged in the normal case;
  when they race a concurrent cleanup they now fail deterministically with `E_HC_NOT_INITIALISED`
  rather than crashing or orphaning the request.

## Validation

- Windows x64 Debug, `libHttpClient.UnitTest.TE`:
  - The two race reproductions: red on their reproduction commits → green after the fix commits.
  - Code-review regression: `TestHttpPerformRejectedAfterCleanupStarted` red with `E_UNEXPECTED`
    when the rejected perform consumed cleanup's schedule slot → green after
    `Skip cleanup wakeup for rejected HTTP performs`.
  - The full `GlobalTests` class passes 7/7, including the cleanup-focused cases
    (`TestAsyncCleanup`, `TestAsyncCleanupWithHttpCall`, `TestAsyncCleanupWithHttpCallPendingRetry`,
    `TestHttpCallCompletionCallbackIsNotCleanupCancelable`,
    `TestCleanupKeepsNetworkStateForInFlightSingletonRef`,
    `TestHttpPerformRejectedAfterCleanupStarted`).
  - Full TE suite passes on a clean rebuild (102–103/103 across runs). The only stragglers are
    load-induced global XTaskQueue teardown flakes (`VerifyGlobalQueueTermination`, and
    `TaskQueueTests::TestCleanup` `XTaskQueueUninitialize(250)`) that are unrelated to this change,
    pass in isolation on both `main` and this branch, and clear on re-run.

## Scope

- No public API additions or removals.
- Change is scoped to `NetworkState` admission control and singleton↔`NetworkState` ownership; the
  cancel/await handshake for already-tracked requests is unchanged.
- No backend/provider-specific changes; all platforms pick up the fix through shared code.

## Review focus

- The `m_cleanupStarted` guard sharing the `m_mutex` critical section with the tracking-set
  insert/snapshot (the core Race A fix), and the `E_HC_NOT_INITIALISED` rejection semantics.
- The rejected HTTP perform cleanup path: only requests actually erased from
  `m_activeHttpRequests` may wake cleanup.
- The ownership change: `NetworkState` is no longer moved out or destroyed by cleanup, and is now
  destroyed with the singleton after the `use_count` gate (the core Race B fix).
- The documented invariant that no code may hold a `get_http_singleton()` reference across an async
  wait, and whether it holds for all current callers.
