### PR TITLE
Fix infinite WaitTimer spin when the delayed-callback timer is disarmed (UINT64_MAX)

### DIFF
--- a/Source/Task/TaskQueue.cpp
+++ b/Source/Task/TaskQueue.cpp
@@ -1212,6 +1212,14 @@ bool TaskQueuePortImpl::ArmTimerForNextPendingDueTime(
 // must re-evaluate instead of resurrecting it.
 bool TaskQueuePortImpl::RearmTimerIfDueTimeUnchanged(uint64_t dueTime)
 {
+    // UINT64_MAX is the "nothing armed" sentinel and must never be programmed
+    // as a real deadline (see SubmitPendingCallbacks). Mirrors the guard in
+    // ArmTimerIfEarlier.
+    if (dueTime == UINT64_MAX)
+    {
+        return true;
+    }
+
     while (true)
     {
         uint64_t currentDue = m_timerDue.load();
@@ -1401,6 +1409,17 @@ void TaskQueuePortImpl::SubmitPendingCallbacks()
     while (true)
     {
         uint64_t dueTime = m_timerDue.load();
+
+        // UINT64_MAX is the "nothing armed" sentinel. It must never be programmed
+        // as a real deadline: WaitTimer::Start(UINT64_MAX) converts to a duration
+        // of -1 (before the steady_clock epoch), a perpetually-past deadline that
+        // fires immediately and re-arms the sentinel in an infinite loop, starving
+        // every real pending callback. If the timer is disarmed there is nothing
+        // to sweep, so return.
+        if (dueTime == UINT64_MAX)
+        {
+            return;
+        }
 
         // Timer callbacks are advisory: a threadpool fire can arrive after
         // retargeting, or slightly before the steady-clock deadline due to


### PR DESCRIPTION
## Problem
An intermittent hang caused by an infinite spin in the `XTaskQueue` delayed-callback timer.

## Root cause
`#983` ("Centralize timer-arming into three helpers", `385cc9a`) removed the `if (dueTime == UINT64_MAX) return;` guard from the top of `TaskQueuePortImpl::SubmitPendingCallbacks` and routed the `now < dueTime` path through the new `RearmTimerIfDueTimeUnchanged()` helper, which calls `m_timer.Start(dueTime)` unconditionally. Only `ArmTimerIfEarlier()` retained a `UINT64_MAX` guard.

`UINT64_MAX` is the "nothing armed" sentinel for `m_timerDue`. When a timer callback fires while the timer is disarmed:

1. `SubmitPendingCallbacks` reads `dueTime = UINT64_MAX`, sees `now < UINT64_MAX` (always true), and calls `RearmTimerIfDueTimeUnchanged(UINT64_MAX)` → `m_timer.Start(UINT64_MAX)`.
2. `WaitTimerImpl::Start` builds `Deadline(Deadline::duration(UINT64_MAX))`. With the STL backend's signed-`int64` duration rep, `UINT64_MAX` → `-1` → a deadline 1 ns before the `steady_clock` epoch (perpetually in the past).
3. The timer thread fires immediately, re-enters `SubmitPendingCallbacks`, re-arms the sentinel, and fires again — an infinite fire/re-arm spin.

Because every iteration takes the `now < dueTime` re-arm branch, `PromoteReadyPendingCallbacks` is never reached, so all real pending delayed callbacks are starved (stranded in `m_pendingList`). On PS5 this manifested as an intermittent hang: a delayed websocket send-completion poll was never promoted, so the send never completed.

## Fix
- Restore the pre-`#983` `UINT64_MAX` guard at the top of `SubmitPendingCallbacks`.
- Add the same guard to `RearmTimerIfDueTimeUnchanged` (mirrors the existing guard in `ArmTimerIfEarlier`).

The disarm sentinel can no longer be programmed as a real deadline.

## Validation
Reproduced on PS5 (STL wait-timer backend) with tracing that showed the timer firing ~307k times on the `UINT64_MAX` sentinel while real callbacks sat unpromoted. With the guard, the spin is gone: the timer-fire count returns to normal, the guard hits exactly at the sentinel, and promotions resume. A 29‑scenario GameSave PSX device suite passed with **0 failures**, including every previously-hanging teardown scenario.
