### PR TITLE
Use unnamed synchronization objects on PS5

### DIFF
--- a/Build/libHttpClient.UnitTest/libHttpClient.UnitTest.vcxitems
+++ b/Build/libHttpClient.UnitTest/libHttpClient.UnitTest.vcxitems
@@ -8,6 +8,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>HC_UNITTEST_API;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(HCEnableUnnamedObjectDiagnostics)'=='true'">HC_ENABLE_UNNAMED_OBJECT_DIAGNOSTICS=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(HCRoot)\Tests\UnitTests\Support;$(HCRoot)\Tests\UnitTests;$(HCRoot)\Tests\Shared;</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>

--- a/Build/libHttpClient.XAsync/libHttpClient.XAsync.vcxitems
+++ b/Build/libHttpClient.XAsync/libHttpClient.XAsync.vcxitems
@@ -27,6 +27,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\ThreadPool.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\WaitTimer.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XAsyncProviderPriv.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueueDiagnostics.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Task\XTaskQueuePriv.h" />
   </ItemGroup>
   <ItemGroup>

--- a/Include/httpClient/pal.h
+++ b/Include/httpClient/pal.h
@@ -502,25 +502,97 @@ enum class HCWebSocketCloseStatus : uint32_t
 // On some platforms, std::mutex default construction creates named mutexes which have a low
 // system-wide limit. DefaultUnnamedMutex forces unnamed mutex construction on affected platforms.
 // Define HC_USE_UNNAMED_MUTEX in your platform build props to enable the workaround.
-#if defined(HC_USE_UNNAMED_MUTEX)
+#if defined(HC_ENABLE_UNNAMED_OBJECT_DIAGNOSTICS)
+namespace UnnamedObjectDiagnostics
+{
+enum class Type : uint32_t
+{
+    Mutex,
+    RecursiveMutex,
+    ConditionVariable,
+    ConditionVariableAny
+};
+
+void RecordConstruction(Type type) noexcept;
+void RecordDestruction(Type type) noexcept;
+}
+#endif
+
+#if defined(HC_USE_UNNAMED_MUTEX) || defined(HC_ENABLE_UNNAMED_OBJECT_DIAGNOSTICS)
 class DefaultUnnamedMutex : public std::mutex
 {
 public:
-    DefaultUnnamedMutex() noexcept : std::mutex(nullptr) {}
-    ~DefaultUnnamedMutex() noexcept = default;
+    DefaultUnnamedMutex() noexcept
+#if defined(HC_USE_UNNAMED_MUTEX)
+        : std::mutex(nullptr)
+#endif
+    {
+#if defined(HC_ENABLE_UNNAMED_OBJECT_DIAGNOSTICS)
+        UnnamedObjectDiagnostics::RecordConstruction(UnnamedObjectDiagnostics::Type::Mutex);
+#endif
+    }
+    ~DefaultUnnamedMutex() noexcept
+    {
+#if defined(HC_ENABLE_UNNAMED_OBJECT_DIAGNOSTICS)
+        UnnamedObjectDiagnostics::RecordDestruction(UnnamedObjectDiagnostics::Type::Mutex);
+#endif
+    }
     DefaultUnnamedMutex(DefaultUnnamedMutex const&) = delete;
     DefaultUnnamedMutex& operator=(DefaultUnnamedMutex const&) = delete;
     void lock() { std::mutex::lock(); }
     bool try_lock() { return std::mutex::try_lock(); }
     void unlock() { std::mutex::unlock(); }
+#if defined(HC_USE_UNNAMED_MUTEX)
     native_handle_type native_handle() { return std::mutex::native_handle(); }
+#endif
+};
+
+class DefaultUnnamedRecursiveMutex : public std::recursive_mutex
+{
+public:
+    DefaultUnnamedRecursiveMutex() noexcept
+#if defined(HC_USE_UNNAMED_MUTEX)
+        : std::recursive_mutex(nullptr)
+#endif
+    {
+#if defined(HC_ENABLE_UNNAMED_OBJECT_DIAGNOSTICS)
+        UnnamedObjectDiagnostics::RecordConstruction(UnnamedObjectDiagnostics::Type::RecursiveMutex);
+#endif
+    }
+    ~DefaultUnnamedRecursiveMutex() noexcept
+    {
+#if defined(HC_ENABLE_UNNAMED_OBJECT_DIAGNOSTICS)
+        UnnamedObjectDiagnostics::RecordDestruction(UnnamedObjectDiagnostics::Type::RecursiveMutex);
+#endif
+    }
+    DefaultUnnamedRecursiveMutex(DefaultUnnamedRecursiveMutex const&) = delete;
+    DefaultUnnamedRecursiveMutex& operator=(DefaultUnnamedRecursiveMutex const&) = delete;
+    void lock() { std::recursive_mutex::lock(); }
+    bool try_lock() { return std::recursive_mutex::try_lock(); }
+    void unlock() { std::recursive_mutex::unlock(); }
+#if defined(HC_USE_UNNAMED_MUTEX)
+    native_handle_type native_handle() { return std::recursive_mutex::native_handle(); }
+#endif
 };
 
 class DefaultUnnamedConditionVariable : public std::condition_variable
 {
 public:
-    DefaultUnnamedConditionVariable() noexcept : std::condition_variable(nullptr) {}
-    ~DefaultUnnamedConditionVariable() noexcept = default;
+    DefaultUnnamedConditionVariable() noexcept
+#if defined(HC_USE_UNNAMED_MUTEX)
+        : std::condition_variable(nullptr)
+#endif
+    {
+#if defined(HC_ENABLE_UNNAMED_OBJECT_DIAGNOSTICS)
+        UnnamedObjectDiagnostics::RecordConstruction(UnnamedObjectDiagnostics::Type::ConditionVariable);
+#endif
+    }
+    ~DefaultUnnamedConditionVariable() noexcept
+    {
+#if defined(HC_ENABLE_UNNAMED_OBJECT_DIAGNOSTICS)
+        UnnamedObjectDiagnostics::RecordDestruction(UnnamedObjectDiagnostics::Type::ConditionVariable);
+#endif
+    }
     DefaultUnnamedConditionVariable(DefaultUnnamedConditionVariable const&) = delete;
     DefaultUnnamedConditionVariable& operator=(DefaultUnnamedConditionVariable const&) = delete;
 };
@@ -528,13 +600,27 @@ public:
 class DefaultUnnamedConditionVariableAny : public std::condition_variable_any
 {
 public:
-    DefaultUnnamedConditionVariableAny() noexcept : std::condition_variable_any(nullptr) {}
-    ~DefaultUnnamedConditionVariableAny() noexcept = default;
+    DefaultUnnamedConditionVariableAny() noexcept
+#if defined(HC_USE_UNNAMED_MUTEX)
+        : std::condition_variable_any(nullptr)
+#endif
+    {
+#if defined(HC_ENABLE_UNNAMED_OBJECT_DIAGNOSTICS)
+        UnnamedObjectDiagnostics::RecordConstruction(UnnamedObjectDiagnostics::Type::ConditionVariableAny);
+#endif
+    }
+    ~DefaultUnnamedConditionVariableAny() noexcept
+    {
+#if defined(HC_ENABLE_UNNAMED_OBJECT_DIAGNOSTICS)
+        UnnamedObjectDiagnostics::RecordDestruction(UnnamedObjectDiagnostics::Type::ConditionVariableAny);
+#endif
+    }
     DefaultUnnamedConditionVariableAny(DefaultUnnamedConditionVariableAny const&) = delete;
     DefaultUnnamedConditionVariableAny& operator=(DefaultUnnamedConditionVariableAny const&) = delete;
 };
 #else
 using DefaultUnnamedMutex = std::mutex;
+using DefaultUnnamedRecursiveMutex = std::recursive_mutex;
 using DefaultUnnamedConditionVariable = std::condition_variable;
 using DefaultUnnamedConditionVariableAny = std::condition_variable_any;
 #endif

--- a/Source/Global/global.h
+++ b/Source/Global/global.h
@@ -47,15 +47,15 @@ public:
     http_singleton& operator=(http_singleton) = delete;
     ~http_singleton();
 
-    std::recursive_mutex m_singletonLock;
+    DefaultUnnamedRecursiveMutex m_singletonLock;
 
-    std::recursive_mutex m_retryAfterCacheLock;
+    DefaultUnnamedRecursiveMutex m_retryAfterCacheLock;
     http_internal_unordered_map<uint32_t, http_retry_after_api_state> m_retryAfterCache;
     void set_retry_state(_In_ uint32_t retryAfterCacheId, _In_ const http_retry_after_api_state& state);
     http_retry_after_api_state get_retry_state(_In_ uint32_t retryAfterCacheId);
     void clear_retry_state(_In_ uint32_t retryAfterCacheId);
 
-    std::recursive_mutex m_callRoutedHandlersLock;
+    DefaultUnnamedRecursiveMutex m_callRoutedHandlersLock;
     std::atomic<int32_t> m_callRoutedHandlersContext{ 0 };
     http_internal_unordered_map<int32_t, std::pair<HCCallRoutedHandler, void*>> m_callRoutedHandlers;
 #ifndef HC_NOWEBSOCKETS
@@ -76,11 +76,11 @@ public:
 #endif
 
     // Mock state
-    std::recursive_mutex m_mocksLock;
+    DefaultUnnamedRecursiveMutex m_mocksLock;
     http_internal_vector<HC_MOCK_CALL*> m_mocks;
     http_internal_map<http_internal_string, size_t> m_mockCycleIndex;
 
-    std::recursive_mutex m_sharedPtrsLock;
+    DefaultUnnamedRecursiveMutex m_sharedPtrsLock;
     http_internal_unordered_map<void*, std::shared_ptr<void>> m_sharedPtrs;
 
     http_singleton(UniquePtr<NetworkState> networkManager);

--- a/Source/Task/TaskQueue.cpp
+++ b/Source/Task/TaskQueue.cpp
@@ -7,6 +7,97 @@
 #include "TaskQueueP.h"
 #include "TaskQueueImpl.h"
 
+#if defined(HC_ENABLE_UNNAMED_OBJECT_DIAGNOSTICS)
+namespace
+{
+struct UnnamedObjectDiagnosticCounters
+{
+    std::atomic<uint64_t> constructed[4]{};
+    std::atomic<uint64_t> destroyed[4]{};
+};
+
+UnnamedObjectDiagnosticCounters& DiagnosticCounters() noexcept
+{
+    static UnnamedObjectDiagnosticCounters counters;
+    return counters;
+}
+
+size_t DiagnosticTypeIndex(UnnamedObjectDiagnostics::Type type) noexcept
+{
+    return static_cast<size_t>(type);
+}
+}
+
+namespace UnnamedObjectDiagnostics
+{
+void RecordConstruction(Type type) noexcept
+{
+    ++DiagnosticCounters().constructed[DiagnosticTypeIndex(type)];
+}
+
+void RecordDestruction(Type type) noexcept
+{
+    ++DiagnosticCounters().destroyed[DiagnosticTypeIndex(type)];
+}
+}
+
+STDAPI XTaskQueueGetSyncObjectDiagnosticSnapshot(
+    _Out_ XTaskQueueSyncObjectSnapshot* snapshot
+    ) noexcept
+{
+    RETURN_HR_IF(E_POINTER, snapshot == nullptr);
+
+    auto loadCounts = [](UnnamedObjectDiagnostics::Type type)
+    {
+        const size_t index = DiagnosticTypeIndex(type);
+        auto& counters = DiagnosticCounters();
+        const uint64_t destroyed = counters.destroyed[index].load();
+        const uint64_t constructed = counters.constructed[index].load();
+        return XTaskQueueSyncObjectCounts
+        {
+            constructed,
+            destroyed,
+            constructed - destroyed
+        };
+    };
+
+    snapshot->mutex = loadCounts(UnnamedObjectDiagnostics::Type::Mutex);
+    snapshot->recursiveMutex = loadCounts(UnnamedObjectDiagnostics::Type::RecursiveMutex);
+    snapshot->conditionVariable = loadCounts(UnnamedObjectDiagnostics::Type::ConditionVariable);
+    snapshot->conditionVariableAny = loadCounts(UnnamedObjectDiagnostics::Type::ConditionVariableAny);
+#if defined(HC_USE_UNNAMED_MUTEX)
+    snapshot->usesUnnamedConstructors = true;
+#else
+    snapshot->usesUnnamedConstructors = false;
+#endif
+    return S_OK;
+}
+
+STDAPI XTaskQueueRunSyncObjectDiagnosticProbe(
+    _Out_ XTaskQueueSyncObjectSnapshot* before,
+    _Out_ XTaskQueueSyncObjectSnapshot* during,
+    _Out_ XTaskQueueSyncObjectSnapshot* after
+    ) noexcept
+{
+    RETURN_HR_IF(E_POINTER, before == nullptr || during == nullptr || after == nullptr);
+    RETURN_IF_FAILED(XTaskQueueGetSyncObjectDiagnosticSnapshot(before));
+
+    {
+        DefaultUnnamedMutex mutex;
+        DefaultUnnamedRecursiveMutex recursiveMutex;
+        DefaultUnnamedConditionVariable conditionVariable;
+        DefaultUnnamedConditionVariableAny conditionVariableAny;
+
+        std::lock_guard<DefaultUnnamedMutex> mutexLock{ mutex };
+        std::lock_guard<DefaultUnnamedRecursiveMutex> outerRecursiveLock{ recursiveMutex };
+        std::lock_guard<DefaultUnnamedRecursiveMutex> innerRecursiveLock{ recursiveMutex };
+        RETURN_IF_FAILED(XTaskQueueGetSyncObjectDiagnosticSnapshot(during));
+    }
+
+    return XTaskQueueGetSyncObjectDiagnosticSnapshot(after);
+}
+#endif
+
 //
 // ApiRefs tracks global refcounts for all APIs. It is used to identify memory leaks
 // in tests and can be called to wait for all refs to be released.
@@ -14,7 +105,7 @@
 namespace ApiRefs
 {
     std::atomic<uint32_t> g_globalApiRefs{ 0 };
-    std::mutex g_waitMutex;
+    DefaultUnnamedMutex g_waitMutex;
     DefaultUnnamedConditionVariable g_waitCv;
     
     void GlobalAddRef()
@@ -774,7 +865,7 @@ bool __stdcall TaskQueuePortImpl::IsEmpty()
 
 void __stdcall TaskQueuePortImpl::WaitForUnwind()
 {
-    std::mutex mutex;
+    DefaultUnnamedMutex mutex;
     std::unique_lock<std::mutex> lock(mutex);
 
     while(m_processingCallback.load() != 0)

--- a/Source/Task/XTaskQueueDiagnostics.h
+++ b/Source/Task/XTaskQueueDiagnostics.h
@@ -1,0 +1,50 @@
+// Copyright(c) Microsoft Corporation. All rights reserved.
+//
+
+#pragma once
+
+#include "XTaskQueue.h"
+
+#if defined(HC_ENABLE_UNNAMED_OBJECT_DIAGNOSTICS)
+struct XTaskQueueSyncObjectCounts
+{
+    uint64_t constructed;
+    uint64_t destroyed;
+    uint64_t live;
+};
+
+struct XTaskQueueSyncObjectSnapshot
+{
+    XTaskQueueSyncObjectCounts mutex;
+    XTaskQueueSyncObjectCounts recursiveMutex;
+    XTaskQueueSyncObjectCounts conditionVariable;
+    XTaskQueueSyncObjectCounts conditionVariableAny;
+    bool usesUnnamedConstructors;
+};
+
+/// <summary>
+/// Gets aggregate construction and destruction counts for the synchronization
+/// wrappers used by this module. Available only in diagnostic test builds.
+/// </summary>
+STDAPI XTaskQueueGetSyncObjectDiagnosticSnapshot(
+    _Out_ XTaskQueueSyncObjectSnapshot* snapshot
+    ) noexcept;
+
+/// <summary>
+/// Constructs and destroys one of each synchronization wrapper, including a
+/// recursive re-entry, and returns snapshots at each test boundary.
+/// </summary>
+STDAPI XTaskQueueRunSyncObjectDiagnosticProbe(
+    _Out_ XTaskQueueSyncObjectSnapshot* before,
+    _Out_ XTaskQueueSyncObjectSnapshot* during,
+    _Out_ XTaskQueueSyncObjectSnapshot* after
+    ) noexcept;
+
+/// <summary>
+/// Closes per-process queue handles and waits for outstanding TaskQueue
+/// lifecycle references to drain. This is an existing private test API.
+/// </summary>
+STDAPI_(bool) XTaskQueueUninitialize(
+    _In_ uint32_t timeoutMilliseconds
+    ) noexcept;
+#endif

--- a/Source/Task/XTaskQueuePriv.h
+++ b/Source/Task/XTaskQueuePriv.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "XTaskQueue.h"
+#include "XTaskQueueDiagnostics.h"
 
 //----------------------------------------------------------------//
 //

--- a/Source/WebSocket/hcwebsocket.h
+++ b/Source/WebSocket/hcwebsocket.h
@@ -212,7 +212,7 @@ private:
         Disconnected
     } m_state{ State::Initial };
 
-    mutable std::recursive_mutex m_eventCallbacksMutex;
+    mutable DefaultUnnamedRecursiveMutex m_eventCallbacksMutex;
     http_internal_map<uint32_t, EventCallbacks> m_eventCallbacks{};
     uint32_t m_nextToken{ 1 };
 

--- a/Tests/UnitTests/Tests/TaskQueueTests.cpp
+++ b/Tests/UnitTests/Tests/TaskQueueTests.cpp
@@ -162,6 +162,45 @@ public:
         VERIFY_IS_TRUE(completeCalled);
     }
 
+#if defined(HC_ENABLE_UNNAMED_OBJECT_DIAGNOSTICS)
+    DEFINE_TEST_CASE(VerifySyncObjectDiagnosticCounters)
+    {
+        XTaskQueueSyncObjectSnapshot before{};
+        XTaskQueueSyncObjectSnapshot during{};
+        XTaskQueueSyncObjectSnapshot after{};
+        VERIFY_SUCCEEDED(XTaskQueueRunSyncObjectDiagnosticProbe(&before, &during, &after));
+
+        VERIFY_ARE_EQUAL_UINT(before.mutex.constructed + 1, during.mutex.constructed);
+        VERIFY_ARE_EQUAL_UINT(before.recursiveMutex.constructed + 1, during.recursiveMutex.constructed);
+        VERIFY_ARE_EQUAL_UINT(before.conditionVariable.constructed + 1, during.conditionVariable.constructed);
+        VERIFY_ARE_EQUAL_UINT(before.conditionVariableAny.constructed + 1, during.conditionVariableAny.constructed);
+        VERIFY_ARE_EQUAL_UINT(before.mutex.live + 1, during.mutex.live);
+        VERIFY_ARE_EQUAL_UINT(before.recursiveMutex.live + 1, during.recursiveMutex.live);
+        VERIFY_ARE_EQUAL_UINT(before.conditionVariable.live + 1, during.conditionVariable.live);
+        VERIFY_ARE_EQUAL_UINT(before.conditionVariableAny.live + 1, during.conditionVariableAny.live);
+
+        VERIFY_ARE_EQUAL_UINT(before.mutex.destroyed + 1, after.mutex.destroyed);
+        VERIFY_ARE_EQUAL_UINT(before.recursiveMutex.destroyed + 1, after.recursiveMutex.destroyed);
+        VERIFY_ARE_EQUAL_UINT(before.conditionVariable.destroyed + 1, after.conditionVariable.destroyed);
+        VERIFY_ARE_EQUAL_UINT(before.conditionVariableAny.destroyed + 1, after.conditionVariableAny.destroyed);
+
+        VERIFY_ARE_EQUAL_UINT(during.mutex.constructed, after.mutex.constructed);
+        VERIFY_ARE_EQUAL_UINT(during.recursiveMutex.constructed, after.recursiveMutex.constructed);
+        VERIFY_ARE_EQUAL_UINT(during.conditionVariable.constructed, after.conditionVariable.constructed);
+        VERIFY_ARE_EQUAL_UINT(during.conditionVariableAny.constructed, after.conditionVariableAny.constructed);
+        VERIFY_ARE_EQUAL_UINT(before.mutex.live, after.mutex.live);
+        VERIFY_ARE_EQUAL_UINT(before.recursiveMutex.live, after.recursiveMutex.live);
+        VERIFY_ARE_EQUAL_UINT(before.conditionVariable.live, after.conditionVariable.live);
+        VERIFY_ARE_EQUAL_UINT(before.conditionVariableAny.live, after.conditionVariableAny.live);
+
+    #if defined(HC_USE_UNNAMED_MUTEX)
+        VERIFY_IS_TRUE(after.usesUnnamedConstructors);
+    #else
+        VERIFY_IS_FALSE(after.usesUnnamedConstructors);
+    #endif
+    }
+#endif
+
     DEFINE_TEST_CASE(VerifyCompositeQueue)
     {
         AutoQueueHandle queue;


### PR DESCRIPTION
## Summary
- add canonical unnamed mutex, recursive mutex, condition variable, and condition-variable-any wrappers
- convert PS5-reachable common synchronization owners while preserving STL-compatible lock interfaces
- add opt-in construction/destruction diagnostics for validation

## Validation
- Win32 diagnostic-off suite previously passed 101/101
- focused wrapper diagnostics passed
- focused Flair TaskQueue regression tests pass after integration
- PS5 primitive, TaskQueue, global, and websocket stress passed

No NDA source, paths, or raw target logs are included.